### PR TITLE
Typo on the getting started page

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,7 +31,7 @@ Alternately, if you're looking to build directly from the repo or you want to ma
 
 **Stable**
 ```
-react-native init <project name> --version ^0.60
+react-native init <project name> --version ^0.60.0
 ```
 
 **Beta**


### PR DESCRIPTION
Changed from 0.60 to 0.60.0 in the instructions.