### PR TITLE
Add @react-native to the version parameters fixes #28

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,7 +81,7 @@ npm install -g react-native-cli
 Remember to call this ``react-native init`` in the directory you want your project to live.
 
 ```
-react-native init <project name> --version ^0.60.0
+react-native init <project name> --version ^react-native@0.60.0
 ```
 
 ### Navigate into this newly created directory


### PR DESCRIPTION
When following the getting started guide I was getting an error because of the version parameter:

```
❯ react-native init hello --version ^0.60.0
This will walk you through creating a new React Native project in C:\Users\jealles\source\repos\react-native-sandbox\hello
Using yarn v1.22.0
Installing ^0.60.0...
yarn add v1.22.0
info No lockfile found.
[1/4] Resolving packages...
error An unexpected error occurred: "https://registry.yarnpkg.com/0.60.0: Not found".
```

This PR is an attempt at fixing it.

cc @stmoy 