### PR TITLE
added command to overwrite metro without user confirmation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,8 +35,11 @@ cd <project name>
 Lastly, install the React Native for Windows packages.
 
 ```
-npx react-native-windows-init
+npx react-native-windows-init --overwrite
 ```
+
+#### Confirming Metro JS reinstallation
+
 
 ## Running a React Native Windows App
 


### PR DESCRIPTION
added `--overwrite` at end of second npx command - to ensure metro is overwritten without the user needing to confirm.

This addresses #[4504](https://github.com/microsoft/react-native-windows/issues/4504)