### PR TITLE
Update links to new location of readme.md in react-native-windows repo

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -5,7 +5,7 @@ title: Release Strategy (vnext)
 
 > This page is hanging, see [Issue #59](https://github.com/microsoft/react-native-windows-samples/issues/59).
 
-This document describes the release strategy for the [`vnext`](https://github.com/microsoft/react-native-windows/blob/master/vnext/README.md) effort for React Native for Windows.
+This document describes the release strategy for the [`vnext`](https://github.com/microsoft/react-native-windows/blob/master/README.md) effort for React Native for Windows.
 
 The `vnext` versioning will generally follow the same strategy as outlined in current [Releases](https://github.com/microsoft/react-native-windows/blob/0.60-stable/current/docs/Releases.md).
 

--- a/website/versioned_docs/version-0.60/releases.md
+++ b/website/versioned_docs/version-0.60/releases.md
@@ -4,7 +4,7 @@ title: Release Strategy (vnext)
 original_id: releases
 ---
 
-This document describes the release strategy for the [`vnext`](https://github.com/microsoft/react-native-windows/blob/master/vnext/README.md) effort for React Native for Windows.
+This document describes the release strategy for the [`vnext`](https://github.com/microsoft/react-native-windows/blob/master/README.md) effort for React Native for Windows.
 
 The `vnext` versioning will generally follow the same strategy as outlined in current [Releases](https://github.com/microsoft/react-native-windows/blob/0.60-stable/current/docs/Releases.md).
 


### PR DESCRIPTION
[PR #4731](https://github.com/microsoft/react-native-windows/pull/4731) in [react-native-windows](https://github.com/microsoft/react-native-windows) repo moved readme.md from the vnext folder to unify them.