### PR TITLE
Remove out of date "implemented" column

### DIFF
--- a/docs/parity-status.md
+++ b/docs/parity-status.md
@@ -14,19 +14,25 @@ A few methods or props may be missing on some types and we are actively working 
 If you encounter an unsupported API that should be tracked, please [submit an issue](https://github.com/microsoft/react-native-windows/issues/new/choose) to let us know.
 
 ## Supported Community Modules
-We are in the process of ejecting the components and modules that are not part of React Native Lean Core into their respective [community repos](https://github.com/react-native-community).
+We are in the process of ejecting the components and modules that are not part of React Native [Lean Core](https://github.com/facebook/react-native/issues/23313) into their respective [community repos](https://github.com/react-native-community).
 
-The following were completed recently:
+The following have been migrated out:
 
-| Name | Status | Implemented |
-|:-|:-|-:|
-| <ins>[react-native-webview](https://www.github.com/react-native-community/react-native-webview)</ins> | **Completed** |Mar 17, 2020 |
-| <ins>[react-native-camera](https://www.github.com/react-native-community/react-native-camera)</ins> | **Completed** |Mar 10, 2020 |
-| <ins>[react-native-netinfo](https://www.github.com/react-native-community/react-native-netinfo)</ins> | **Completed** |Dec 29, 2019 |
-| <ins>[react-native-device-info](https://www.github.com/react-native-community/react-native-device-info)</ins> | **Completed** |Nov 1, 2019 |
-| <ins>[react-native-video](https://www.github.com/react-native-community/react-native-video)</ins> | **Completed** |Feb 25, 2020 |
-| <ins>[react-native-linear-gradient](https://www.github.com/react-native-community/react-native-linear-gradient)</ins> | **Completed** |Sep 18, 2019 |
+| Name | Version Supported | 
+|:-|:-|
+| <ins>[async-storage](https://github.com/react-native-community/async-storage)</ins> | 0.61 |
+| <ins>[react-native-webview](https://www.github.com/react-native-community/react-native-webview)</ins> | 0.61 |
+| <ins>[react-native-netinfo](https://www.github.com/react-native-community/react-native-netinfo)</ins> | 0.61 |
+| <ins>[react-native-picker](https://github.com/react-native-community/react-native-picker)</ins> | 0.61 |
+| <ins>[datetimepicker](https://github.com/react-native-community/datetimepicker)</ins> | [in progress](https://github.com/react-native-community/datetimepicker/pull/157) |
 
-In addition, we are working on adding Windows support to popular and highly requested community modules. You can keep track on the progress of both these efforts through the [Community Modules support project board](https://github.com/microsoft/react-native-windows/projects/23).
+In addition, we are working on adding Windows support to popular and highly requested community modules. You can keep track on the progress of both these efforts through the [Community Modules support project board](https://github.com/microsoft/react-native-windows/projects/23). Here are some modules that React Native for Windows currently supports:
+
+| Name | Version Supported | 
+|:-|:-|
+| <ins>[react-native-camera](https://www.github.com/react-native-community/react-native-camera)</ins> | 0.61 |
+| <ins>[react-native-device-info](https://www.github.com/react-native-community/react-native-device-info)</ins> | 0.61 |
+| <ins>[react-native-video](https://www.github.com/react-native-community/react-native-video)</ins> | 0.61 |
+| <ins>[react-native-linear-gradient](https://www.github.com/react-native-community/react-native-linear-gradient)</ins> | 0.61 |
 
 If there is an unsupported community module that you don’t see in our roadmap, please [submit a support request](https://github.com/microsoft/react-native-windows/issues/new/choose) and let us know.


### PR DESCRIPTION
The dates were wrong on the column of implemented modules. Also, it's not terrible helpful, so I removed it.
These modules were also all described as being migrated out, which isn't correct for all of them. Broke into two tables, one for lean core migrations, the other for community modules.
Long term those should be tracked with a [directory](https://github.com/microsoft/react-native-windows/issues/3718), but for now while the list is short this is still helpful.

Fixes #86 86