### PR TITLE
Update rnm-dependencies.md

### DIFF
--- a/docs/rnm-dependencies.md
+++ b/docs/rnm-dependencies.md
@@ -5,17 +5,24 @@ title: System Requirements
 
 You can run React Native for macOS apps on Mac devices with versions [Mojave (10.14.6)](https://support.apple.com/en-us/HT209149#macos10146) or newer.
 
-To develop React Native for macOS apps, you will need the following:
+The development dependencies for React Native for macOS are identical to the development dependencies for React Native for iOS. You can follow the steps at [Setting up the development environment](https://reactnative.dev/docs/environment-setup) in the **"React Native CLI Quickstart"** section, or follow the paraphrased steps below:
 
 ### macOS Development Dependencies
 - A Mac device is required to build projects with native code for macOS.
 - Install [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) version 11.3.1 or newer.
 - Ensure to install Xcode Command Line Tools. Open Xcode, then choose "Preferences..." from the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
 - Install [CocoaPods](https://guides.cocoapods.org/using/getting-started.html)
+   ```bash
+   sudo gem install cocoapods
+   ```
 
 ### React Native Development Dependencies
 - Install the [standard React Native dependencies](https://reactnative.dev/docs/getting-started#node-python2-jdk)
 - Install [Node.js](https://nodejs.org) version 12 LTS or newer via [HomeBrew](https://brew.sh/)
-```
-brew install node
-```
+   ```bash
+   brew install node
+   ```
+- Install [Watchman](https://facebook.github.io/watchman)
+   ``` bash
+   brew install watchman
+   ```

--- a/docs/rnm-dependencies.md
+++ b/docs/rnm-dependencies.md
@@ -3,7 +3,7 @@ id: rnm-dependencies
 title: System Requirements
 ---
 
-You can run React Native for macOS apps on Mac devices with versions [Mojave (10.14.6)](https://apps.apple.com/us/app/macos-mojave/id1398502828?ls=1&mt=12) or newer.
+You can run React Native for macOS apps on Mac devices with versions [Mojave (10.14.6)](https://support.apple.com/en-us/HT209149#macos10146) or newer.
 
 To develop React Native for macOS apps, you will need the following:
 

--- a/docs/rnm-dependencies.md
+++ b/docs/rnm-dependencies.md
@@ -9,13 +9,13 @@ To develop React Native for macOS apps, you will need the following:
 
 ### macOS Development Dependencies
 - A Mac device is required to build projects with native code for macOS.
-- Install [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) version 9.4 or newer.
+- Install [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) version 11.3.1 or newer.
 - Ensure to install Xcode Command Line Tools. Open Xcode, then choose "Preferences..." from the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
 - Install [CocoaPods](https://guides.cocoapods.org/using/getting-started.html)
 
 ### React Native Development Dependencies
 - Install the [standard React Native dependencies](https://reactnative.dev/docs/getting-started#node-python2-jdk)
-- Install [Node.js](https://nodejs.org) version 8.3 or newer via [HomeBrew](https://brew.sh/)
+- Install [Node.js](https://nodejs.org) version 12 LTS or newer via [HomeBrew](https://brew.sh/)
 ```
 brew install node
 ```

--- a/docs/rnm-getting-started.md
+++ b/docs/rnm-getting-started.md
@@ -9,6 +9,8 @@ For information around how to set up:
 - React Native for iOS and Android: See [React Native Getting Started Guide](https://reactnative.dev/docs/getting-started)
 - React Native for Windows: See [React Native for Windows Getting Started Guide](https://microsoft.github.io/react-native-windows/docs/getting-started)
 
+Make sure you have installed all the [development dependencies](https://microsoft.github.io/react-native-windows/docs/rnm-dependencies)
+
 ## Install React Native for macOS
 
 Remember to call `react-native init` from the place you want your project directory to live.

--- a/docs/rnm-getting-started.md
+++ b/docs/rnm-getting-started.md
@@ -16,7 +16,7 @@ Make sure you have installed all the [development dependencies](https://microsof
 Remember to call `react-native init` from the place you want your project directory to live.
 
 ```
-npx react-native init <projectName> --version 0.61
+npx react-native init <projectName> --version 0.61.5
 ```
 
 ### Navigate into this newly created directory
@@ -29,18 +29,28 @@ cd <projectName>
 
 ### Install the macOS extension
 
-Lastly, install the React Native for macOS packages.
+Install the React Native for macOS packages.
 
 ```
 npx react-native-macos-init
 ```
 
+Update the CocoaPods versions
+
+```
+cd macos && pod install && cd..
+```
+
 ## Running a React Native macOS App
 
+- **Without using Xcode**:
   In your React Native macOS project directory, run:
 
   ```
   npx react-native run-macos
   ```
-
-  A new Command Prompt window will open with the React packager as well as a `react-native-macos` app. This step may take a while during first run since it involves building the entire project and all dependencies. You can now start developing! :tada:
+ 
+- **Using Xcode**:
+  Open macos\test.xcworkspace in Xcode or run `xed -b macos`; `yarn start:macos`. Hit the Run button. 
+  
+A new Command Prompt window will open with the React packager as well as a `react-native-macos` app. This step may take a while during first run since it involves building the entire project and all dependencies. You can now start developing! 🎉

--- a/docs/rnw-dependencies.md
+++ b/docs/rnw-dependencies.md
@@ -33,10 +33,6 @@ To develop React-Native for Windows apps, you will need the following:
 - Install [Chrome](https://www.google.com/chrome/) (_optional_, but needed for JS debugging)
 - Install [Yarn](https://yarnpkg.com/en/docs/install) (_optional_ if only consuming react-native-windows, but **required** to contribute to react-native-windows)
 
-## E2E Test
-
-Please refer to [Author and Run E2E Test for React Native Windows](e2e-test.md)
-
 ## Troubleshooting
 
 - If after running the app, the packager does not update (or) app does not show React Native content - close the packager command prompt window and the app, make sure browser is open, run `yarn start` and run the app from Visual Studio again.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,8 +33,3 @@ These tests can run on the local development host.
 # Starts test services and runs tests.
 & Scripts\IntegrationTests.ps1
 ```
-
-### E2E Tests
-
-_Implemented in packages/E2ETest_
-<BR/>Please follow [Author and Run E2E Test for React Native Windows](e2e-test.md) for E2E Tests

--- a/website/versioned_docs/version-0.61/rnm-dependencies.md
+++ b/website/versioned_docs/version-0.61/rnm-dependencies.md
@@ -4,19 +4,19 @@ title: System Requirements
 original_id: rnm-dependencies
 ---
 
-You can run React Native for macOS apps on Mac devices with versions [Mojave (10.14.6)](https://apps.apple.com/us/app/macos-mojave/id1398502828?ls=1&mt=12) or newer.
+You can run React Native for macOS apps on Mac devices with versions [Mojave (10.14.6)](https://support.apple.com/en-us/HT209149#macos10146) or newer.
 
 To develop React Native for macOS apps, you will need the following:
 
 ### macOS Development Dependencies
 - A Mac device is required to build projects with native code for macOS.
-- Install [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) version 9.4 or newer.
+- Install [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) version 11.3.1 or newer.
 - Ensure to install Xcode Command Line Tools. Open Xcode, then choose "Preferences..." from the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
 - Install [CocoaPods](https://guides.cocoapods.org/using/getting-started.html)
 
 ### React Native Development Dependencies
 - Install the [standard React Native dependencies](https://reactnative.dev/docs/getting-started#node-python2-jdk)
-- Install [Node.js](https://nodejs.org) version 8.3 or newer via [HomeBrew](https://brew.sh/)
+- Install [Node.js](https://nodejs.org) version 12 LTS or newer via [HomeBrew](https://brew.sh/)
 ```
 brew install node
 ```

--- a/website/versioned_docs/version-0.61/rnm-dependencies.md
+++ b/website/versioned_docs/version-0.61/rnm-dependencies.md
@@ -6,17 +6,24 @@ original_id: rnm-dependencies
 
 You can run React Native for macOS apps on Mac devices with versions [Mojave (10.14.6)](https://support.apple.com/en-us/HT209149#macos10146) or newer.
 
-To develop React Native for macOS apps, you will need the following:
+The development dependencies for React Native for macOS are identical to the development dependencies for React Native for iOS. You can follow the steps at [Setting up the development environment](https://reactnative.dev/docs/environment-setup) in the **"React Native CLI Quickstart"** section, or follow the paraphrased steps below:
 
 ### macOS Development Dependencies
 - A Mac device is required to build projects with native code for macOS.
 - Install [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) version 11.3.1 or newer.
 - Ensure to install Xcode Command Line Tools. Open Xcode, then choose "Preferences..." from the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
 - Install [CocoaPods](https://guides.cocoapods.org/using/getting-started.html)
+   ```bash
+   sudo gem install cocoapods
+   ```
 
 ### React Native Development Dependencies
 - Install the [standard React Native dependencies](https://reactnative.dev/docs/getting-started#node-python2-jdk)
 - Install [Node.js](https://nodejs.org) version 12 LTS or newer via [HomeBrew](https://brew.sh/)
-```
-brew install node
-```
+   ```bash
+   brew install node
+   ```
+- Install [Watchman](https://facebook.github.io/watchman)
+   ``` bash
+   brew install watchman
+   ```


### PR DESCRIPTION
Updating XCode version and Node version based on @tom-un 's comments. 

Removing links to e2e testing sections under `rnw-dependencies` and `testing` sections so that the CI for broken links is passed.