### PR TITLE
Added instructional link to enable build tools

### DIFF
--- a/docs/rnw-dependencies.md
+++ b/docs/rnw-dependencies.md
@@ -13,7 +13,7 @@ To develop React-Native for Windows apps, you will need the following:
 - Install [Visual Studio 2019](https://www.visualstudio.com/downloads) with the following options:
   - Workloads
     - Universal Windows Platform development
-      - Enable the optional `C++ (v141) Universal Windows Platform tools`
+      - Enable the optional `C++ (v141) Universal Windows Platform tools` ([details here](https://github.com/microsoft/react-native-windows/issues/3263#issuecomment-617797919))
     - Desktop development with C++
   - Individual Components
     - Compilers, build tools and runtimes


### PR DESCRIPTION
Just following the Getting Started guide may cause the user to have an improper dependency setup leading to the error:

> Failed to restore the NuGet packages: Error: MSBuild tools not found. Make sure all required components have been installed (e.g. v141 support)

Adding a link to guide the user to install the correct version of the platform tools should help avoid confusion.