### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,7 +47,7 @@ npx react-native-windows-init --overwrite
 
 - Without Using Visual Studio
 
-  In your React Native Windows project directory, run:
+  In your React Native Windows project directory, from an elevated Command Prompt run:
 
   ```
   npx react-native run-windows


### PR DESCRIPTION
If `npx react-native run-windows` is not run from an elevated Command Prompt it will fail.