### PR TITLE
Fix command error in rnm-getting-started.md

### DIFF
--- a/docs/rnm-getting-started.md
+++ b/docs/rnm-getting-started.md
@@ -38,7 +38,7 @@ npx react-native-macos-init
 Update the CocoaPods versions
 
 ```
-cd macos && pod install && cd..
+cd macos && pod install && cd ..
 ```
 
 ## Running a React Native macOS App


### PR DESCRIPTION
An error occurred in Install React Native for macOS.

```
command not found: cd..
```

"cd" command needs space between args. 

```diff
- cd macos && pod install && cd..
+ cd macos && pod install && cd ..
```