### PR TITLE
Fix command error in website rnm-getting-started.md

### DIFF
--- a/website/versioned_docs/version-0.61/rnm-getting-started.md
+++ b/website/versioned_docs/version-0.61/rnm-getting-started.md
@@ -15,7 +15,7 @@ For information around how to set up:
 Remember to call `react-native init` from the place you want your project directory to live.
 
 ```
-npx react-native init <projectName> --version 0.61
+npx react-native init <projectName> --version 0.61.5
 ```
 
 ### Navigate into this newly created directory


### PR DESCRIPTION
An error occurred in Install React Native for macOS.

```
% npx react-native init sample --version 0.61
This will walk you through creating a new React Native project in /Users/shoken/git/sample
Using yarn v1.22.4
Installing 0.61...
yarn add v1.22.4
info No lockfile found.
[1/4] 🔍  Resolving packages...
error An unexpected error occurred: "https://registry.yarnpkg.com/0.61: Not found".
info If you think this is a bug, please open a bug report with the information provided in "/Users/shoken/git/sample/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
Error: Command failed: yarn add 0.61 --exact
    at checkExecSyncError (child_process.js:621:11)
    at execSync (child_process.js:657:15)
    at run (/Users/shoken/.nodebrew/node/v12.14.1/lib/node_modules/react-native-cli/index.js:294:5)
    at createProject (/Users/shoken/.nodebrew/node/v12.14.1/lib/node_modules/react-native-cli/index.js:249:3)
    at init (/Users/shoken/.nodebrew/node/v12.14.1/lib/node_modules/react-native-cli/index.js:200:5)
    at Object.<anonymous> (/Users/shoken/.nodebrew/node/v12.14.1/lib/node_modules/react-native-cli/index.js:153:7)
    at Module._compile (internal/modules/cjs/loader.js:955:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:991:10)
    at Module.load (internal/modules/cjs/loader.js:811:32)
    at Function.Module._load (internal/modules/cjs/loader.js:723:14) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 1725,
  stdout: null,
  stderr: null
}
Command `yarn add 0.61 --exact` failed.
```

Add patch version e.g. 0.61.5, and it worked.

```diff
- npx react-native init sample --version 0.61
+ npx react-native init sample --version 0.61.5
```