### PR TITLE
Update macOS `npx react-native init` command `--version` syntax

### DIFF
--- a/docs/rnm-getting-started.md
+++ b/docs/rnm-getting-started.md
@@ -16,7 +16,7 @@ Make sure you have installed all the [development dependencies](https://microsof
 Remember to call `react-native init` from the place you want your project directory to live.
 
 ```
-npx react-native init <projectName> --version 0.61.5
+npx react-native init <projectName> --version react-native@0.61.5
 ```
 
 ### Navigate into this newly created directory


### PR DESCRIPTION
I've tried to run the command and it failed with the error: 

```
[1/4] 🔍  Resolving packages...
error An unexpected error occurred: "https://registry.yarnpkg.com/0.61: Not found".
info If you think this is a bug, please open a bug report with the information provided in 
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
[...]
Error: Command failed: yarn add 0.61 --exact
[...]
```

I've also read that the syntax provided in the [documentation](https://microsoft.github.io/react-native-windows/docs/rnm-getting-started#install-react-native-for-macos) works only for certain versions...
After updating the command `--version` syntax, everything seems to work just fine.

## Change diff
```diff
- npx react-native init <projectName> --version 0.61
+ npx react-native init <projectName> --version 0.61.0
```