### PR TITLE
Fix Link the basics system requirements

### DIFF
--- a/website/versioned_docs/version-0.60/rnw-dependencies.md
+++ b/website/versioned_docs/version-0.60/rnw-dependencies.md
@@ -38,7 +38,7 @@ To develop React-Native for Windows apps, you will need the following:
 
 ## E2E Test
 
-Please refer to [Author and Run E2E Test for React Native Windows](e2e-test.md)
+Please refer to [Author and Run E2E Test for React Native Windows](https://microsoft.github.io/react-native-windows/docs/e2e-test)
 
 # Troubleshooting
 

--- a/website/versioned_docs/version-0.61/rnw-dependencies.md
+++ b/website/versioned_docs/version-0.61/rnw-dependencies.md
@@ -40,7 +40,7 @@ To develop React-Native for Windows apps, you will need the following:
 
 ## E2E Test
 
-Please refer to [Author and Run E2E Test for React Native Windows](e2e-test.md)
+Please refer to [Author and Run E2E Test for React Native Windows](https://microsoft.github.io/react-native-windows/docs/e2e-test)
 
 ## Troubleshooting
 


### PR DESCRIPTION
This PR fix link in The Basics System Requirements in both versions 0.60 and 0.61, when you click in this link appears 404 error.
![image](https://user-images.githubusercontent.com/36824170/82168202-d468d800-9883-11ea-9f8b-def7981dc17c.png)
