### PR TITLE
remove manual Pods installation from macOS guide

### DIFF
--- a/docs/rnm-getting-started.md
+++ b/docs/rnm-getting-started.md
@@ -35,12 +35,6 @@ Install the React Native for macOS packages.
 npx react-native-macos-init
 ```
 
-Update the CocoaPods versions
-
-```
-cd macos && pod install && cd ..
-```
-
 ## Running a React Native macOS App
 
 - **Without using Xcode**:


### PR DESCRIPTION
This small PR removes the manual Pods installation step from the latest Getting Started guide for the macOS. 

Refs: microsoft/react-native-macos#366