### PR TITLE
Removed unnecessary table formatting

### DIFF
--- a/website/static/css/docs.css
+++ b/website/static/css/docs.css
@@ -113,7 +113,7 @@ table {
   border-collapse: collapse;
   display: table;
   margin: 20px 0;
-  width: 80%;
+  width: 100%;
 }
 table thead tr {
   /* display: table-header-group; */


### PR DESCRIPTION
The css forces all docs tables to have the first column at 60% and the 4th column at 80%. It makes every table on the site look weird, especially as the first item is usually the shortest.