### PR TITLE
Fix to Releases.md on next docs

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -3,22 +3,13 @@ id: releases
 title: Release Strategy
 ---
 
-> This page is hanging, see [Issue #59](https://github.com/microsoft/react-native-windows-samples/issues/59).
+For every major version update of `react-native`, React Native for Windows releases a matching version. In addition, there are three release distributions with corresponding npm package distribution tags:
+1.	Canary (@canary)
+2.	Preview (@preview)
+3.	Latest (@latest)
 
-This document describes the release strategy for the [`vnext`](https://github.com/microsoft/react-native-windows/blob/master/README.md) effort for React Native for Windows.
+`canary` builds are built directly from our master branch. These builds provide no guarantees around upstream React version, breaking changes, or overall stability. These builds should be used for development or to test bleeding edge functionality but should not be relied upon for production use. Master builds are versioned as 0.0.0-canary.x.
 
-The `vnext` versioning will generally follow the same strategy as outlined in current [Releases](https://github.com/microsoft/react-native-windows/blob/0.60-stable/current/docs/Releases.md).
+`preview` builds are the first released by stable branches. These builds aim to become increasingly polished over time and have fewer breaking changes than in canary. react-native-windows-init will work out of the box with preview builds when none else are available, but will warn users before installing them. Preview builds are versioned as 0.x.0-preview.y, where x matches the minor release of React Native.
 
-Specifically,
-
-- We release in lock-step with [facebook/react-native](https://github.com/facebook/react-native). I.e., for every release of `react-native`, we create a release of `react-native-windows` with a matching major version.
-- We will use a pre-release flag: `-vnext` - to differentiate this C++ implementation followed by the current vnext version number.
-
-For example:
-
-```
-...
-react-native@0.57.* -> react-native-windows@0.57.0-vnext.*
-react-native@0.58.* -> react-native-windows@0.58.0-vnext.*
-...
-```
+`latest` builds corresponding to our "released" version. Breaking changes should not be made to stable branches after promotion to latest. Caution must be taken to not compromise the stability of our non-prerelease branches. Only low risk changes critical to customer scenarios should be backported. Released builds are versioned as 0.x.y where x matches the minor release of React Native.


### PR DESCRIPTION
Minor issue/desparity between the releases.md info under the main/next docs folder and the releases.md under the v62 docs.