### PR TITLE
unify the minimum macOS SDK version

### DIFF
--- a/docs/rnm-dependencies.md
+++ b/docs/rnm-dependencies.md
@@ -3,7 +3,7 @@ id: rnm-dependencies
 title: System Requirements
 ---
 
-You can run React Native for macOS apps on Mac devices with versions [Mojave (10.14.6)](https://support.apple.com/en-us/HT209149#macos10146) or newer.
+You can run React Native for macOS apps on Mac devices with versions [High Sierra (10.13)](https://www.apple.com/newsroom/2017/09/macos-high-sierra-now-available-as-a-free-update/) or newer.
 
 The development dependencies for React Native for macOS are identical to the development dependencies for React Native for iOS. You can follow the steps at [Setting up the development environment](https://reactnative.dev/docs/environment-setup) in the **"React Native CLI Quickstart"** section, or follow the paraphrased steps below:
 

--- a/samples/rssreader/macos/Podfile
+++ b/samples/rssreader/macos/Podfile
@@ -35,7 +35,7 @@ abstract_target 'Shared' do
   pod 'Folly', :podspec => '../node_modules/react-native-macos/third-party-podspecs/Folly.podspec'
 
   target 'rssreader-macOS' do
-    platform :macos, '10.14'
+    platform :macos, '10.13'
     use_native_modules!
     # Pods specifically for macOS target
   end

--- a/samples/rssreader/macos/rssreader.xcodeproj/project.pbxproj
+++ b/samples/rssreader/macos/rssreader.xcodeproj/project.pbxproj
@@ -465,7 +465,7 @@
 				DEAD_CODE_STRIPPING = NO;
 				INFOPLIST_FILE = "rssreader-macos/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -485,7 +485,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = "rssreader-macos/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -24,14 +24,14 @@ const textContent = {
   `,
   about: `
 **React Native for Windows + macOS brings React Native support for the
-[Windows 10 SDK] as well as the [macOS 10.12 SDK]**. With this, you can use JavaScript to build native
+[Windows 10 SDK] as well as the [macOS 10.13 SDK]**. With this, you can use JavaScript to build native
 Windows apps for [all devices supported by Windows 10] including PCs,
 tablets, 2-in-1s, Xbox, Mixed reality devices, etc., as well as the macOS desktop and laptop ecosystems.
 
 [React Native]: https://reactnative.dev/
 [React]: https://reactjs.org/
 [Windows 10 SDK]: https://developer.microsoft.com/en-us/windows/downloads
-[macOS 10.12 SDK]: https://developer.apple.com/documentation/macos_release_notes/macos_catalina_10_15_release_notes
+[macOS 10.13 SDK]: https://www.apple.com/newsroom/2017/09/macos-high-sierra-now-available-as-a-free-update/
 [all devices supported by Windows 10]: https://developer.microsoft.com/en-us/windows/get-started-windows-10
   `,
   roadmapwindows: `

--- a/website/versioned_docs/version-0.61/rnm-dependencies.md
+++ b/website/versioned_docs/version-0.61/rnm-dependencies.md
@@ -4,7 +4,7 @@ title: System Requirements
 original_id: rnm-dependencies
 ---
 
-You can run React Native for macOS apps on Mac devices with versions [Mojave (10.14.6)](https://support.apple.com/en-us/HT209149#macos10146) or newer.
+You can run React Native for macOS apps on Mac devices with versions [High Sierra (10.13)](https://www.apple.com/newsroom/2017/09/macos-high-sierra-now-available-as-a-free-update/) or newer.
 
 The development dependencies for React Native for macOS are identical to the development dependencies for React Native for iOS. You can follow the steps at [Setting up the development environment](https://reactnative.dev/docs/environment-setup) in the **"React Native CLI Quickstart"** section, or follow the paraphrased steps below:
 


### PR DESCRIPTION
Currently website mentions 10.12 SDK on the front page and 10.14 in system requirement, when 10.14 was the right version. After the merge of linked PR in the `react-native-macos` repository the correct version will be 10.13.

This PR updates the minimum macOS SDK version across the whole repository. It affects home page, getting started guide, and RRS Reader sample files.

Unfortunately [Apple release notes](https://developer.apple.com/documentation/macos-release-notes) are available from 10.14 onwards, at the beginning I want to use the last [10.13 update page](https://support.apple.com/en-us/HT208864) (like on some instances before, but I was able to find the [High Sierra release post](https://www.apple.com/newsroom/2017/09/macos-high-sierra-now-available-as-a-free-update/) in the Apple Newsroom. 

This page looks more meaningful for me, but I can change the link to any other one.

CC @alloy