### PR TITLE
Update supported modules table

### DIFF
--- a/website/versioned_docs/version-0.62/parity-status.md
+++ b/website/versioned_docs/version-0.62/parity-status.md
@@ -13,27 +13,3 @@ For a more closely monitored look at our work in progress, check out the [API Co
 A few methods or props may be missing on some types and we are actively working to add support for those in our [upcoming milestones](https://github.com/microsoft/react-native-windows/milestones).
 
 If you encounter an unsupported API that should be tracked, please [submit an issue](https://github.com/microsoft/react-native-windows/issues/new/choose) to let us know.
-
-## Supported Community Modules
-We are in the process of ejecting the components and modules that are not part of React Native [Lean Core](https://github.com/facebook/react-native/issues/23313) into their respective [community repos](https://github.com/react-native-community).
-
-The following have been migrated out:
-
-| Name | Version Supported | 
-|:-|:-|
-| <ins>[async-storage](https://github.com/react-native-community/async-storage)</ins> | 0.61 |
-| <ins>[react-native-webview](https://www.github.com/react-native-community/react-native-webview)</ins> | 0.61 |
-| <ins>[react-native-netinfo](https://www.github.com/react-native-community/react-native-netinfo)</ins> | 0.61 |
-| <ins>[react-native-picker](https://github.com/react-native-community/react-native-picker)</ins> | 0.61 |
-| <ins>[datetimepicker](https://github.com/react-native-community/datetimepicker)</ins> | [in progress](https://github.com/react-native-community/datetimepicker/pull/157) |
-
-In addition, we are working on adding Windows support to popular and highly requested community modules. You can keep track on the progress of both these efforts through the [Community Modules support project board](https://github.com/microsoft/react-native-windows/projects/23). Here are some modules that React Native for Windows currently supports:
-
-| Name | Version Supported | 
-|:-|:-|
-| <ins>[react-native-camera](https://www.github.com/react-native-community/react-native-camera)</ins> | 0.61 |
-| <ins>[react-native-device-info](https://www.github.com/react-native-community/react-native-device-info)</ins> | 0.61 |
-| <ins>[react-native-video](https://www.github.com/react-native-community/react-native-video)</ins> | 0.61 |
-| <ins>[react-native-linear-gradient](https://www.github.com/react-native-community/react-native-linear-gradient)</ins> | 0.61 |
-
-If there is an unsupported community module that you don’t see in our roadmap, please [submit a support request](https://github.com/microsoft/react-native-windows/issues/new/choose) and let us know.

--- a/website/versioned_docs/version-0.62/supported-community-modules.md
+++ b/website/versioned_docs/version-0.62/supported-community-modules.md
@@ -1,0 +1,29 @@
+---
+id: version-0.62-supported-community-modules
+title: Supported Community Modules
+original_id: supported-community-modules
+---
+
+## Supported Community Modules
+We are in the process of ejecting the components and modules that are not part of React Native [Lean Core](https://github.com/facebook/react-native/issues/23313) into their respective [community repos](https://github.com/react-native-community).
+
+The following have been migrated out:
+
+| Name | Version Supported | 
+|:-|:-|
+| <ins>[async-storage](https://github.com/react-native-community/async-storage)</ins> | 0.61 |
+| <ins>[react-native-webview](https://www.github.com/react-native-community/react-native-webview)</ins> | 0.61 |
+| <ins>[react-native-netinfo](https://www.github.com/react-native-community/react-native-netinfo)</ins> | 0.61 |
+| <ins>[react-native-picker](https://github.com/react-native-community/react-native-picker)</ins> | 0.61 |
+| <ins>[datetimepicker](https://github.com/react-native-community/datetimepicker)</ins> | [in progress](https://github.com/react-native-community/datetimepicker/pull/157) |
+
+In addition, we are working on adding Windows support to popular and highly requested community modules. You can keep track on the progress of both these efforts through the [Community Modules support project board](https://github.com/microsoft/react-native-windows/projects/23). Here are some modules that React Native for Windows currently supports:
+
+| Name | Version Supported | 
+|:-|:-|
+| <ins>[react-native-camera](https://www.github.com/react-native-community/react-native-camera)</ins> | 0.61 |
+| <ins>[react-native-device-info](https://www.github.com/react-native-community/react-native-device-info)</ins> | 0.61 |
+| <ins>[react-native-video](https://www.github.com/react-native-community/react-native-video)</ins> | 0.61 |
+| <ins>[react-native-linear-gradient](https://www.github.com/react-native-community/react-native-linear-gradient)</ins> | 0.61 |
+
+If there is an unsupported community module that you don’t see in our roadmap, please [submit a support request](https://github.com/microsoft/react-native-windows/issues/new/choose) and let us know.

--- a/website/versioned_docs/version-0.62/supported-community-modules.md
+++ b/website/versioned_docs/version-0.62/supported-community-modules.md
@@ -25,6 +25,7 @@ The following modules have been ejected as part of the React Native [Lean Core](
 | <ins>[react-native-webview](https://www.github.com/react-native-community/react-native-webview)</ins> | 0.61 | |
 | <ins>[react-native-netinfo](https://www.github.com/react-native-community/react-native-netinfo)</ins> | 0.61 | |
 | <ins>[react-native-picker](https://github.com/react-native-community/react-native-picker)</ins> | 0.61 | |
+| <ins>[react-native-progress-view](https://github.com/react-native-community/progress-view)</ins> | 0.62 | |
 | <ins>[datetimepicker](https://github.com/react-native-community/datetimepicker)</ins> | 0.62 | |
 
 In addition to the ejected modules above, Microsoft has also added support for a set of popular and highly requested community modules:
@@ -33,6 +34,8 @@ In addition to the ejected modules above, Microsoft has also added support for a
 |:-|:-|:-|
 | <ins>[react-native-camera](https://www.github.com/react-native-community/react-native-camera)</ins> | 0.61 | |
 | <ins>[react-native-device-info](https://www.github.com/react-native-community/react-native-device-info)</ins> | 0.61 | |
+| <ins>[react-native-navigation](https://github.com/react-navigation/react-navigation)</ins> | 0.62 | |
+| <ins>[react-native-reanimated](https://github.com/software-mansion/react-native-reanimated)</ins> | 0.62[*](https://github.com/microsoft/react-native-windows/issues/4151) | |
 | <ins>[react-native-video](https://www.github.com/react-native-community/react-native-video)</ins> | 0.61 | |
 | <ins>[react-native-linear-gradient](https://www.github.com/react-native-community/react-native-linear-gradient)</ins> | 0.61 | |
 

--- a/website/versioned_docs/version-0.62/supported-community-modules.md
+++ b/website/versioned_docs/version-0.62/supported-community-modules.md
@@ -22,11 +22,13 @@ The following modules have been ejected as part of the React Native [Lean Core](
 | Name | Version Supported (Windows) | Version Supported (macOS) |
 |:-|:-|:-|
 | <ins>[async-storage](https://github.com/react-native-community/async-storage)</ins> | 0.61 | 0.61 |
-| <ins>[react-native-webview](https://www.github.com/react-native-community/react-native-webview)</ins> | 0.61 | 0.61 |
+| <ins>[datetimepicker](https://github.com/react-native-community/datetimepicker)</ins> | 0.62 | ? |
+| <ins>[react-native-checkbox](https://github.com/react-native-community/react-native-checkbox)</ins> | 0.62 | ? |
 | <ins>[react-native-netinfo](https://www.github.com/react-native-community/react-native-netinfo)</ins> | 0.61 | 0.61 |
 | <ins>[react-native-picker](https://github.com/react-native-community/react-native-picker)</ins> | 0.61 | 0.61 |
 | <ins>[react-native-progress-view](https://github.com/react-native-community/progress-view)</ins> | 0.62 | ? |
-| <ins>[datetimepicker](https://github.com/react-native-community/datetimepicker)</ins> | 0.62 | ? |
+| <ins>[react-native-slider](https://github.com/react-native-community/react-native-slider)</ins> | 0.62 | ? |
+| <ins>[react-native-webview](https://www.github.com/react-native-community/react-native-webview)</ins> | 0.61 | 0.61 |
 
 In addition to the ejected modules above, Microsoft has also added support for a set of popular and highly requested community modules:
 

--- a/website/versioned_docs/version-0.62/supported-community-modules.md
+++ b/website/versioned_docs/version-0.62/supported-community-modules.md
@@ -4,6 +4,15 @@ title: Supported Community Modules
 original_id: supported-community-modules
 ---
 
+## ReactNative.Directory
+
+The [React Native Directory](https://reactnative.directory/) lists libraries and native modules that are available across all of the React Native platforms, including iOS, Android, Windows, macOS, and more. 
+
+To view which modules are available for a specific platform, you can use the Filters function on the website, or visit these pre-filtered URLs:
+
+- [Modules that support Windows](https://reactnative.directory/?windows=true)
+- [Modules that support macOS](https://reactnative.directory/?macos=true)
+
 ## Supported Community Modules
 We are in the process of ejecting the components and modules that are not part of React Native [Lean Core](https://github.com/facebook/react-native/issues/23313) into their respective [community repos](https://github.com/react-native-community).
 

--- a/website/versioned_docs/version-0.62/supported-community-modules.md
+++ b/website/versioned_docs/version-0.62/supported-community-modules.md
@@ -6,7 +6,7 @@ original_id: supported-community-modules
 
 ## ReactNative.Directory
 
-The [React Native Directory](https://reactnative.directory/) lists libraries and native modules that are available across all of the React Native platforms, including iOS, Android, Windows, macOS, and more. 
+The [React Native Directory](https://reactnative.directory/) lists libraries and native modules that are available across all of the React Native platforms including iOS, Android, Windows, macOS, and more. 
 
 To view which modules are available for a specific platform, you can use the Filters function on the website, or visit these pre-filtered URLs:
 
@@ -25,7 +25,7 @@ The following modules have been ejected as part of the React Native [Lean Core](
 | <ins>[react-native-webview](https://www.github.com/react-native-community/react-native-webview)</ins> | 0.61 | |
 | <ins>[react-native-netinfo](https://www.github.com/react-native-community/react-native-netinfo)</ins> | 0.61 | |
 | <ins>[react-native-picker](https://github.com/react-native-community/react-native-picker)</ins> | 0.61 | |
-| <ins>[datetimepicker](https://github.com/react-native-community/datetimepicker)</ins> | [in progress](https://github.com/react-native-community/datetimepicker/pull/157) | |
+| <ins>[datetimepicker](https://github.com/react-native-community/datetimepicker)</ins> | 0.62 | |
 
 In addition to the ejected modules above, Microsoft has also added support for a set of popular and highly requested community modules:
 
@@ -36,4 +36,10 @@ In addition to the ejected modules above, Microsoft has also added support for a
 | <ins>[react-native-video](https://www.github.com/react-native-community/react-native-video)</ins> | 0.61 | |
 | <ins>[react-native-linear-gradient](https://www.github.com/react-native-community/react-native-linear-gradient)</ins> | 0.61 | |
 
-If there is an unsupported community module that you don’t see in our roadmap, please [submit a support request](https://github.com/microsoft/react-native-windows/issues/new/choose) and let us know.
+The React Native team at Microsoft is continually adding support for community modules. Visit the [Community Modules support project board](https://github.com/microsoft/react-native-windows/projects/23) to see which modules will be supported next.
+
+## Help! A module I need doesn't support Windows and/or macOS!
+
+If you need a module that doesn't currently support Windows and/or macOS, please [submit a support request](https://github.com/microsoft/react-native-windows/issues/new/choose) and let us know.
+
+Additionally, you can also file an issue on the module repository to let them know that you need Windows and/or macOS support. If you file an additional issue in the module repository, please be sure to link it to the issue in the React Native Windows repo to help us track.

--- a/website/versioned_docs/version-0.62/supported-community-modules.md
+++ b/website/versioned_docs/version-0.62/supported-community-modules.md
@@ -13,38 +13,44 @@ To view which modules are available for a specific platform, you can use the Fil
 - [Modules that support Windows](https://reactnative.directory/?windows=true)
 - [Modules that support macOS](https://reactnative.directory/?macos=true)
 
-## Microsoft-supported Modules
+## Modules with Microsoft contributions
 
-The React Native team at Microsoft has worked together with the community to add Windows and macOS support to several community modules. The modules that Microsoft has added support for are listed below. 
+The React Native team at Microsoft has worked together with community maintainers to add Windows and macOS implementations to several community modules. These modules are listed below.
 
-The following modules have been ejected as part of the React Native [Lean Core](https://github.com/facebook/react-native/issues/23313) effort:
+### Ejected Modules 
+
+The React Native [Lean Core](https://github.com/facebook/react-native/issues/23313) effort slims down the core functionality of React Native by ejecting specific modules into their own repos. 
+
+The following modules have either been ejected from core, or are on path to be ejected as part of this effort:
 
 | Name | Version Supported (Windows) | Version Supported (macOS) |
 |:-|:-|:-|
 | <ins>[async-storage](https://github.com/react-native-community/async-storage)</ins> | 0.61 | 0.61 |
-| <ins>[datetimepicker](https://github.com/react-native-community/datetimepicker)</ins> | 0.62 | ? |
-| <ins>[react-native-checkbox](https://github.com/react-native-community/react-native-checkbox)</ins> | 0.62 | ? |
+| <ins>[datetimepicker](https://github.com/react-native-community/datetimepicker)</ins> | 0.62 | [Not yet ejected](https://github.com/microsoft/react-native-macos/issues/389) |
+| <ins>[react-native-checkbox](https://github.com/react-native-community/react-native-checkbox)</ins> | 0.62 | x |
 | <ins>[react-native-netinfo](https://www.github.com/react-native-community/react-native-netinfo)</ins> | 0.61 | 0.61 |
-| <ins>[react-native-picker](https://github.com/react-native-community/react-native-picker)</ins> | 0.61 | 0.61 |
-| <ins>[react-native-progress-view](https://github.com/react-native-community/progress-view)</ins> | 0.62 | ? |
-| <ins>[react-native-slider](https://github.com/react-native-community/react-native-slider)</ins> | 0.62 | ? |
+| <ins>[react-native-picker](https://github.com/react-native-community/react-native-picker)</ins> | 0.61 | [Not yet ejected](https://github.com/microsoft/react-native-macos/issues/395) |
+| <ins>[react-native-progress-view](https://github.com/react-native-community/progress-view)</ins> | 0.62 | [Not yet ejected](https://github.com/microsoft/react-native-macos/issues/391) |
+| <ins>[react-native-slider](https://github.com/react-native-community/react-native-slider)</ins> | 0.62 | [Not yet ejected](https://github.com/microsoft/react-native-macos/issues/394) |
 | <ins>[react-native-webview](https://www.github.com/react-native-community/react-native-webview)</ins> | 0.61 | 0.61 |
 
-In addition to the ejected modules above, Microsoft has also added support for a set of popular and highly requested community modules:
+### Community modules
+
+In addition to the ejected modules above, Microsoft has also added implementations for a set of popular and highly requested community modules:
 
 | Name | Version Supported (Windows) | Version Supported (macOS) |
 |:-|:-|:-|
 | <ins>[react-native-camera](https://www.github.com/react-native-community/react-native-camera)</ins> | 0.61 | x |
-| <ins>[react-native-device-info](https://www.github.com/react-native-community/react-native-device-info)</ins> | 0.61 | 0.61 |
-| <ins>[react-native-navigation](https://github.com/react-navigation/react-navigation)</ins> | 0.62 | x |
-| <ins>[react-native-reanimated](https://github.com/software-mansion/react-native-reanimated)</ins> | 0.62[*](https://github.com/microsoft/react-native-windows/issues/4151) | x |
+| <ins>[react-native-device-info](https://www.github.com/react-native-community/react-native-device-info)</ins> | 0.61 | [In Progress](https://github.com/react-native-community/react-native-device-info/pull/1057) |
+| <ins>[react-native-navigation](https://github.com/react-navigation/react-navigation)</ins> | 0.62 | [Partial](https://github.com/react-navigation/react-navigation/pull/8570) |
+| <ins>[react-native-reanimated](https://github.com/software-mansion/react-native-reanimated)</ins> | [Partial](https://github.com/microsoft/react-native-windows/issues/4151) | x |
 | <ins>[react-native-video](https://www.github.com/react-native-community/react-native-video)</ins> | 0.61 | x |
 | <ins>[react-native-linear-gradient](https://www.github.com/react-native-community/react-native-linear-gradient)</ins> | 0.61 | x |
 
-The React Native team at Microsoft is continually adding support for community modules. Visit the [Community Modules support project board](https://github.com/microsoft/react-native-windows/projects/23) to see which modules will be supported next.
+The React Native team at Microsoft is continually adding native implementations for community modules. Visit the [Community Module Requests project board](https://github.com/microsoft/react-native-windows/projects/23) to see which modules are on our radar.
 
 ## Help! A module I need doesn't support Windows and/or macOS!
 
-If you need a module that doesn't currently support Windows and/or macOS, please [submit a support request](https://github.com/microsoft/react-native-windows/issues/new/choose) and let us know.
+If you need a module that doesn't currently have a native Windows and/or macOS implementation, please [submit an issue on GitHub](https://github.com/microsoft/react-native-windows/issues/new/choose) and let us know.
 
 Additionally, you can also file an issue on the module repository to let them know that you need Windows and/or macOS support. If you file an additional issue in the module repository, please be sure to link it to the issue in the React Native Windows repo to help us track.

--- a/website/versioned_docs/version-0.62/supported-community-modules.md
+++ b/website/versioned_docs/version-0.62/supported-community-modules.md
@@ -21,23 +21,23 @@ The following modules have been ejected as part of the React Native [Lean Core](
 
 | Name | Version Supported (Windows) | Version Supported (macOS) |
 |:-|:-|:-|
-| <ins>[async-storage](https://github.com/react-native-community/async-storage)</ins> | 0.61 | |
-| <ins>[react-native-webview](https://www.github.com/react-native-community/react-native-webview)</ins> | 0.61 | |
-| <ins>[react-native-netinfo](https://www.github.com/react-native-community/react-native-netinfo)</ins> | 0.61 | |
-| <ins>[react-native-picker](https://github.com/react-native-community/react-native-picker)</ins> | 0.61 | |
-| <ins>[react-native-progress-view](https://github.com/react-native-community/progress-view)</ins> | 0.62 | |
-| <ins>[datetimepicker](https://github.com/react-native-community/datetimepicker)</ins> | 0.62 | |
+| <ins>[async-storage](https://github.com/react-native-community/async-storage)</ins> | 0.61 | 0.61 |
+| <ins>[react-native-webview](https://www.github.com/react-native-community/react-native-webview)</ins> | 0.61 | 0.61 |
+| <ins>[react-native-netinfo](https://www.github.com/react-native-community/react-native-netinfo)</ins> | 0.61 | 0.61 |
+| <ins>[react-native-picker](https://github.com/react-native-community/react-native-picker)</ins> | 0.61 | 0.61 |
+| <ins>[react-native-progress-view](https://github.com/react-native-community/progress-view)</ins> | 0.62 | ? |
+| <ins>[datetimepicker](https://github.com/react-native-community/datetimepicker)</ins> | 0.62 | ? |
 
 In addition to the ejected modules above, Microsoft has also added support for a set of popular and highly requested community modules:
 
 | Name | Version Supported (Windows) | Version Supported (macOS) |
 |:-|:-|:-|
-| <ins>[react-native-camera](https://www.github.com/react-native-community/react-native-camera)</ins> | 0.61 | |
-| <ins>[react-native-device-info](https://www.github.com/react-native-community/react-native-device-info)</ins> | 0.61 | |
-| <ins>[react-native-navigation](https://github.com/react-navigation/react-navigation)</ins> | 0.62 | |
-| <ins>[react-native-reanimated](https://github.com/software-mansion/react-native-reanimated)</ins> | 0.62[*](https://github.com/microsoft/react-native-windows/issues/4151) | |
-| <ins>[react-native-video](https://www.github.com/react-native-community/react-native-video)</ins> | 0.61 | |
-| <ins>[react-native-linear-gradient](https://www.github.com/react-native-community/react-native-linear-gradient)</ins> | 0.61 | |
+| <ins>[react-native-camera](https://www.github.com/react-native-community/react-native-camera)</ins> | 0.61 | x |
+| <ins>[react-native-device-info](https://www.github.com/react-native-community/react-native-device-info)</ins> | 0.61 | 0.61 |
+| <ins>[react-native-navigation](https://github.com/react-navigation/react-navigation)</ins> | 0.62 | x |
+| <ins>[react-native-reanimated](https://github.com/software-mansion/react-native-reanimated)</ins> | 0.62[*](https://github.com/microsoft/react-native-windows/issues/4151) | x |
+| <ins>[react-native-video](https://www.github.com/react-native-community/react-native-video)</ins> | 0.61 | x |
+| <ins>[react-native-linear-gradient](https://www.github.com/react-native-community/react-native-linear-gradient)</ins> | 0.61 | x |
 
 The React Native team at Microsoft is continually adding support for community modules. Visit the [Community Modules support project board](https://github.com/microsoft/react-native-windows/projects/23) to see which modules will be supported next.
 

--- a/website/versioned_docs/version-0.62/supported-community-modules.md
+++ b/website/versioned_docs/version-0.62/supported-community-modules.md
@@ -13,26 +13,27 @@ To view which modules are available for a specific platform, you can use the Fil
 - [Modules that support Windows](https://reactnative.directory/?windows=true)
 - [Modules that support macOS](https://reactnative.directory/?macos=true)
 
-## Supported Community Modules
-We are in the process of ejecting the components and modules that are not part of React Native [Lean Core](https://github.com/facebook/react-native/issues/23313) into their respective [community repos](https://github.com/react-native-community).
+## Microsoft-supported Modules
 
-The following have been migrated out:
+The React Native team at Microsoft has worked together with the community to add Windows and macOS support to several community modules. The modules that Microsoft has added support for are listed below. 
 
-| Name | Version Supported | 
-|:-|:-|
-| <ins>[async-storage](https://github.com/react-native-community/async-storage)</ins> | 0.61 |
-| <ins>[react-native-webview](https://www.github.com/react-native-community/react-native-webview)</ins> | 0.61 |
-| <ins>[react-native-netinfo](https://www.github.com/react-native-community/react-native-netinfo)</ins> | 0.61 |
-| <ins>[react-native-picker](https://github.com/react-native-community/react-native-picker)</ins> | 0.61 |
-| <ins>[datetimepicker](https://github.com/react-native-community/datetimepicker)</ins> | [in progress](https://github.com/react-native-community/datetimepicker/pull/157) |
+The following modules have been ejected as part of the React Native [Lean Core](https://github.com/facebook/react-native/issues/23313) effort:
 
-In addition, we are working on adding Windows support to popular and highly requested community modules. You can keep track on the progress of both these efforts through the [Community Modules support project board](https://github.com/microsoft/react-native-windows/projects/23). Here are some modules that React Native for Windows currently supports:
+| Name | Version Supported (Windows) | Version Supported (macOS) |
+|:-|:-|:-|
+| <ins>[async-storage](https://github.com/react-native-community/async-storage)</ins> | 0.61 | |
+| <ins>[react-native-webview](https://www.github.com/react-native-community/react-native-webview)</ins> | 0.61 | |
+| <ins>[react-native-netinfo](https://www.github.com/react-native-community/react-native-netinfo)</ins> | 0.61 | |
+| <ins>[react-native-picker](https://github.com/react-native-community/react-native-picker)</ins> | 0.61 | |
+| <ins>[datetimepicker](https://github.com/react-native-community/datetimepicker)</ins> | [in progress](https://github.com/react-native-community/datetimepicker/pull/157) | |
 
-| Name | Version Supported | 
-|:-|:-|
-| <ins>[react-native-camera](https://www.github.com/react-native-community/react-native-camera)</ins> | 0.61 |
-| <ins>[react-native-device-info](https://www.github.com/react-native-community/react-native-device-info)</ins> | 0.61 |
-| <ins>[react-native-video](https://www.github.com/react-native-community/react-native-video)</ins> | 0.61 |
-| <ins>[react-native-linear-gradient](https://www.github.com/react-native-community/react-native-linear-gradient)</ins> | 0.61 |
+In addition to the ejected modules above, Microsoft has also added support for a set of popular and highly requested community modules:
+
+| Name | Version Supported (Windows) | Version Supported (macOS) |
+|:-|:-|:-|
+| <ins>[react-native-camera](https://www.github.com/react-native-community/react-native-camera)</ins> | 0.61 | |
+| <ins>[react-native-device-info](https://www.github.com/react-native-community/react-native-device-info)</ins> | 0.61 | |
+| <ins>[react-native-video](https://www.github.com/react-native-community/react-native-video)</ins> | 0.61 | |
+| <ins>[react-native-linear-gradient](https://www.github.com/react-native-community/react-native-linear-gradient)</ins> | 0.61 | |
 
 If there is an unsupported community module that you don’t see in our roadmap, please [submit a support request](https://github.com/microsoft/react-native-windows/issues/new/choose) and let us know.

--- a/website/versioned_docs/version-0.62/supported-community-modules.md
+++ b/website/versioned_docs/version-0.62/supported-community-modules.md
@@ -49,7 +49,7 @@ In addition to the ejected modules above, Microsoft has also added implementatio
 
 The React Native team at Microsoft is continually adding native implementations for community modules. Visit the [Community Module Requests project board](https://github.com/microsoft/react-native-windows/projects/23) to see which modules are on our radar.
 
-## Help! A module I need doesn't support Windows and/or macOS!
+## Help! A module I need doesn't work with Windows and/or macOS!
 
 If you need a module that doesn't currently have a native Windows and/or macOS implementation, please [submit an issue on GitHub](https://github.com/microsoft/react-native-windows/issues/new/choose) and let us know.
 

--- a/website/versioned_sidebars/version-0.62-sidebars.json
+++ b/website/versioned_sidebars/version-0.62-sidebars.json
@@ -16,7 +16,8 @@
       "version-0.62-native-modules-marshalling-data",
       "version-0.62-native-modules-async",
       "version-0.62-native-modules-jsvalue",
-      "version-0.62-native-modules-advanced"
+      "version-0.62-native-modules-advanced",
+      "version-0.62-supported-community-modules"
     ],
     "The Basics (MacOS)": [
       "version-0.62-rnm-getting-started",


### PR DESCRIPTION
This change updates the docs to include the recently supported modules, and expands the previous table to also discuss macOS support. It also adds a note about reactnative.directory.

Fixes #202 

# Open Questions

- Is it worthwhile to have the specific "Supported Version" columns or could this be collapsed to ✔ vs ❌ ?
- Is the macOS version column correct?
- Are we missing any modules?
- This doc currently lives in the Native Modules (Windows) section of the sidebar; is that correct or should it move?
