### PR TITLE
Exclude all versioned pages by default from text searches in Visual Studio Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "search.exclude": {
+      "**/node_modules": true,
+      "/website/versioned_docs": true,
+      "/website/versioned_sidebars": true
+    }
+}


### PR DESCRIPTION
When searching (especially search & replace!) I find myself frequently excluding the previous versions. 
This change will make it the default in VsCode through a shared settings.json file.