### PR TITLE
Fix experimental tab

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,15 +1,11 @@
 {
   "docs": {
-    "Experimental" : [
-      "nuget"
-    ],
     "The Basics (Windows)": [
       "getting-started",
       "rnw-dependencies",
       "parity-status",
       "config",
       "windowsbrush-and-theme",
-      "winui3",
       "releases"
     ],
     "Native Modules (Windows)": [
@@ -27,6 +23,10 @@
     "The Basics (MacOS)": [
       "rnm-getting-started",
       "rnm-dependencies"
+    ],
+    "Experimental" : [
+      "native-modules-nuget",
+      "winui3"
     ]
   },
   "apis": {


### PR DESCRIPTION
The PR #213 had the wrong ID for the nuget markdown page so the tab wasn't showing up. I also moved winui into it and moved the experimental tab lower in the list of tabs