### PR TITLE
Cross referencing and updating community modules docs

### DIFF
--- a/docs/nuget.md
+++ b/docs/nuget.md
@@ -9,7 +9,7 @@ The default for react-native-windows has been to build all code from source. Thi
 
 Starting with version 0.63 the team offers experimental NuGet packages that can be used as a replacement of compiling the sources.
 
-> Disclaimer: There are known compatibility issues with [community modules](parity-status.md#supported-community-modules), as they still rely on building the shared code from source. So the solution still needs to have all the source projects which puts all the build performance problems back.
+> Disclaimer: There are known compatibility issues with [community modules](supported-community-modules.md), as they still rely on building the shared code from source. So the solution still needs to have all the source projects which puts all the build performance problems back.
 
 > Disclaimer: NuGet packages are not compatible with experimental feature [WinUI3](winui3.md).
 

--- a/docs/parity-status.md
+++ b/docs/parity-status.md
@@ -3,6 +3,8 @@ id: parity-status
 title: API Parity
 ---
 
+## Core APIs and Components
+
 [React Native Components and APIs](https://reactnative.dev/docs/components-and-apis) that are a part of the [React Native Lean Core](https://github.com/facebook/react-native/issues/23313) effort are now all supported in React Native for Windows.
 
 For a more closely monitored look at our work in progress, check out the [API Completion](https://github.com/microsoft/react-native-windows/labels/API%20Completion) label on issues in our repo.
@@ -13,26 +15,10 @@ A few methods or props may be missing on some types and we are actively working 
 
 If you encounter an unsupported API that should be tracked, please [submit an issue](https://github.com/microsoft/react-native-windows/issues/new/choose) to let us know.
 
-## Supported Community Modules
-We are in the process of ejecting the components and modules that are not part of React Native [Lean Core](https://github.com/facebook/react-native/issues/23313) into their respective [community repos](https://github.com/react-native-community).
+## Windows APIs and Components
 
-The following have been migrated out:
+In addition to the React Native core APIs, there are a handful of APIs that are either new in React Native for Windows to support desktop (like keyboarding, mouse, popups, windowing, multi-instance etc.,) scenarios as well as signature Windows 10 scenarios (like Themes, Acrylic brushes etc.,). You can find documentation on these under the [APIs](https://microsoft.github.io/react-native-windows/docs/flyout-component) tab. 
 
-| Name | Version Supported | 
-|:-|:-|
-| <ins>[async-storage](https://github.com/react-native-community/async-storage)</ins> | 0.61 |
-| <ins>[react-native-webview](https://www.github.com/react-native-community/react-native-webview)</ins> | 0.61 |
-| <ins>[react-native-netinfo](https://www.github.com/react-native-community/react-native-netinfo)</ins> | 0.61 |
-| <ins>[react-native-picker](https://github.com/react-native-community/react-native-picker)</ins> | 0.61 |
-| <ins>[datetimepicker](https://github.com/react-native-community/datetimepicker)</ins> | [in progress](https://github.com/react-native-community/datetimepicker/pull/157) |
+## More APIs and Components
 
-In addition, we are working on adding Windows support to popular and highly requested community modules. You can keep track on the progress of both these efforts through the [Community Modules support project board](https://github.com/microsoft/react-native-windows/projects/23). Here are some modules that React Native for Windows currently supports:
-
-| Name | Version Supported | 
-|:-|:-|
-| <ins>[react-native-camera](https://www.github.com/react-native-community/react-native-camera)</ins> | 0.61 |
-| <ins>[react-native-device-info](https://www.github.com/react-native-community/react-native-device-info)</ins> | 0.61 |
-| <ins>[react-native-video](https://www.github.com/react-native-community/react-native-video)</ins> | 0.61 |
-| <ins>[react-native-linear-gradient](https://www.github.com/react-native-community/react-native-linear-gradient)</ins> | 0.61 |
-
-If there is an unsupported community module that you don’t see in our roadmap, please [submit a support request](https://github.com/microsoft/react-native-windows/issues/new/choose) and let us know.
+In addition to the above, there are several community modules that are supported in Windows. Please see [Supported Community Modules](https://microsoft.github.io/react-native-windows/docs/supported-community-modules) for details.

--- a/docs/supported-community-modules.md
+++ b/docs/supported-community-modules.md
@@ -1,0 +1,55 @@
+---
+id: supported-community-modules
+title: Supported Community Modules
+---
+
+## ReactNative.Directory
+
+The [React Native Directory](https://reactnative.directory/) lists libraries and native modules that are available across all of the React Native platforms including iOS, Android, Windows, macOS, and more. 
+
+To view which modules are available for a specific platform, you can use the Filters function on the website, or visit these pre-filtered URLs:
+
+- [Modules that support Windows](https://reactnative.directory/?windows=true)
+- [Modules that support macOS](https://reactnative.directory/?macos=true)
+
+## Modules with Microsoft contributions
+
+The React Native team at Microsoft has worked together with community maintainers to add Windows and macOS implementations to several community modules. These modules are listed below.
+
+### Ejected Modules 
+
+The React Native [Lean Core](https://github.com/facebook/react-native/issues/23313) effort slims down the core functionality of React Native by ejecting specific modules into their own repos. 
+
+The following modules have either been ejected from core, or are on path to be ejected as part of this effort:
+
+| Name | Version Supported (Windows) | Version Supported (macOS) |
+|:-|:-|:-|
+| <ins>[async-storage](https://github.com/react-native-community/async-storage)</ins> | 0.61 | 0.61 |
+| <ins>[datetimepicker](https://github.com/react-native-community/datetimepicker)</ins> | 0.62 | [Not yet ejected](https://github.com/microsoft/react-native-macos/issues/389) |
+| <ins>[react-native-checkbox](https://github.com/react-native-community/react-native-checkbox)</ins> | 0.62 | x |
+| <ins>[react-native-netinfo](https://www.github.com/react-native-community/react-native-netinfo)</ins> | 0.61 | 0.61 |
+| <ins>[react-native-picker](https://github.com/react-native-community/react-native-picker)</ins> | 0.61 | [Not yet ejected](https://github.com/microsoft/react-native-macos/issues/395) |
+| <ins>[react-native-progress-view](https://github.com/react-native-community/progress-view)</ins> | 0.62 | [Not yet ejected](https://github.com/microsoft/react-native-macos/issues/391) |
+| <ins>[react-native-slider](https://github.com/react-native-community/react-native-slider)</ins> | 0.62 | [Not yet ejected](https://github.com/microsoft/react-native-macos/issues/394) |
+| <ins>[react-native-webview](https://www.github.com/react-native-community/react-native-webview)</ins> | 0.61 | 0.61 |
+
+### Community modules
+
+In addition to the ejected modules above, Microsoft has also added implementations for a set of popular and highly requested community modules:
+
+| Name | Version Supported (Windows) | Version Supported (macOS) |
+|:-|:-|:-|
+| <ins>[react-native-camera](https://www.github.com/react-native-community/react-native-camera)</ins> | 0.61 | x |
+| <ins>[react-native-device-info](https://www.github.com/react-native-community/react-native-device-info)</ins> | 0.61 | [In Progress](https://github.com/react-native-community/react-native-device-info/pull/1057) |
+| <ins>[react-navigation](https://github.com/react-navigation/react-navigation)</ins> | 0.62 | [Partial](https://github.com/react-navigation/react-navigation/pull/8570) |
+| <ins>[react-native-reanimated](https://github.com/software-mansion/react-native-reanimated)</ins> | [Partial](https://github.com/microsoft/react-native-windows/issues/4151) | x |
+| <ins>[react-native-video](https://www.github.com/react-native-community/react-native-video)</ins> | 0.61 | x |
+| <ins>[react-native-linear-gradient](https://www.github.com/react-native-community/react-native-linear-gradient)</ins> | 0.61 | x |
+
+The React Native team at Microsoft is continually adding native implementations for community modules. Visit the [Community Module Requests project board](https://github.com/microsoft/react-native-windows/projects/23) to see which modules are on our radar.
+
+## Help! A module I need doesn't work with Windows and/or macOS!
+
+If you need a module that doesn't currently have a native Windows and/or macOS implementation, please [submit an issue on GitHub](https://github.com/microsoft/react-native-windows/issues/new/choose) and let us know.
+
+Additionally, you can also file an issue on the module repository to let them know that you need Windows and/or macOS support. If you file an additional issue in the module repository, please be sure to link it to the issue in the React Native Windows repo to help us track.

--- a/website/versioned_docs/version-0.62/parity-status.md
+++ b/website/versioned_docs/version-0.62/parity-status.md
@@ -4,6 +4,8 @@ title: API Parity
 original_id: parity-status
 ---
 
+## Core APIs and Components
+
 [React Native Components and APIs](https://reactnative.dev/docs/components-and-apis) that are a part of the [React Native Lean Core](https://github.com/facebook/react-native/issues/23313) effort are now all supported in React Native for Windows.
 
 For a more closely monitored look at our work in progress, check out the [API Completion](https://github.com/microsoft/react-native-windows/labels/API%20Completion) label on issues in our repo.
@@ -13,3 +15,11 @@ For a more closely monitored look at our work in progress, check out the [API Co
 A few methods or props may be missing on some types and we are actively working to add support for those in our [upcoming milestones](https://github.com/microsoft/react-native-windows/milestones).
 
 If you encounter an unsupported API that should be tracked, please [submit an issue](https://github.com/microsoft/react-native-windows/issues/new/choose) to let us know.
+
+## Windows APIs and Components
+
+In addition to the React Native core APIs, there are a handful of APIs that are either new in React Native for Windows to support desktop (like keyboarding, mouse, popups, windowing, multi-instance etc.,) scenarios as well as signature Windows 10 scenarios (like Themes, Acrylic brushes etc.,). You can find documentation on these under the [APIs](https://microsoft.github.io/react-native-windows/docs/flyout-component) tab. 
+
+## More APIs and Components
+
+In addition to the above, there are several community modules that are supported in Windows. Please see [Supported Community Modules](https://microsoft.github.io/react-native-windows/docs/supported-community-modules) for details.


### PR DESCRIPTION
Few things were missing from the new community modules doc that this PR attempts to fix:

- Supported community modules doc was not added to /docs/ folder and was only present in the versioned 0.62 folder. This will make it not move forward with the website folder since an original id would be missing. This PR adds this file to the docs/ folder
- Same with API parity doc update. That has also been done on docs/ folder
- API parity doc needed a bit more details and cross reference to the new doc.