### PR TITLE
Enable ARM64 for CameraDemo

### DIFF
--- a/.github/workflows/samples-CameraDemo-ci-upgrade.yml
+++ b/.github/workflows/samples-CameraDemo-ci-upgrade.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         sample: [CameraDemo]
-        architecture: [ARM] # Can't build ARM64 until https://github.com/react-native-community/react-native-camera/issues/2944
+        architecture: [ARM, ARM64]
         configuration: [Debug, Release]
         reactNativeWindowsVersion: ['latest'] # Add 'preview' here when a new preview is available
     steps:

--- a/.github/workflows/samples-CameraDemo-ci.yml
+++ b/.github/workflows/samples-CameraDemo-ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         sample: [CameraDemo]
-        architecture: [ARM] # Can't build ARM64 until https://github.com/react-native-community/react-native-camera/issues/2944
+        architecture: [ARM, ARM64]
         configuration: [Debug, Release]
     steps:
       - uses: actions/checkout@v2

--- a/samples/CameraDemo/App.js
+++ b/samples/CameraDemo/App.js
@@ -151,7 +151,7 @@ class App extends PureComponent {
 
   recordVideo = async () => {
     if (this.camera) {
-      const options = { maxDuration: 3600 };
+      const options = { };
 
       var isRecording = await this.camera.isRecording();
       if (!isRecording) {

--- a/samples/CameraDemo/package.json
+++ b/samples/CameraDemo/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "16.13.1",
     "react-native": "0.63.2",
-    "react-native-camera": "^3.37.0",
+    "react-native-camera": "^3.38.0",
     "react-native-windows": "^0.63.0-0"
   },
   "devDependencies": {

--- a/samples/CameraDemo/yarn.lock
+++ b/samples/CameraDemo/yarn.lock
@@ -5521,10 +5521,10 @@ react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-native-camera@^3.37.0:
-  version "3.37.0"
-  resolved "https://registry.yarnpkg.com/react-native-camera/-/react-native-camera-3.37.0.tgz#fd0df704392735ede5935627b6358be379e97e27"
-  integrity sha512-NlhQurRUgjHEFdu0XPxzTlhBY5p4o7iqCBYD7mJsh+sMLTNqu8STklm/avMd0S/6XMS7zsjKFY3eyKGuZfZR3Q==
+react-native-camera@^3.38.0:
+  version "3.38.0"
+  resolved "https://registry.yarnpkg.com/react-native-camera/-/react-native-camera-3.38.0.tgz#d51bd78306c185d8210cd89c6cf8d8b1b4cc1294"
+  integrity sha512-mczUap9TWHeFuGOY5fCoMnPWv704BiPyGNU5p4filB/XuQL4/M93Teqgw6gWMdd8KfElY9uqH4QNtHruJ67A5A==
   dependencies:
     prop-types "^15.6.2"
 


### PR DESCRIPTION
* Updated react-native-camera to 3.38.0, which supports ARM64 on windows
* Removed record maxDuration
* Updated CI