### PR TITLE
Fixing links for 63 versioned docs

### DIFF
--- a/website/versioned_docs/version-0.63/rnm-getting-started.md
+++ b/website/versioned_docs/version-0.63/rnm-getting-started.md
@@ -7,7 +7,7 @@ original_id: rnm-getting-started
 This guide will help you get started on setting up your very first React Native for macOS app.
 
 >** Latest stable version available for React Native for macOS is 0.62**
-Please visit the [0.62 version of the Getting Started guide](https://microsoft.github.io/react-native-windows/docs/rnm-getting-started) to build React Native for macOS apps.
+Please visit the [0.62 version of the Getting Started guide](https://microsoft.github.io/react-native-windows/docs/0.62/rnm-getting-started) to build React Native for macOS apps.
 
 For information around how to set up:
 - React Native for iOS and Android: See [React Native Getting Started Guide](https://reactnative.dev/docs/getting-started)

--- a/website/versioned_sidebars/version-0.63-sidebars.json
+++ b/website/versioned_sidebars/version-0.63-sidebars.json
@@ -18,7 +18,8 @@
       "version-0.63-native-modules-async",
       "version-0.63-native-modules-jsvalue",
       "version-0.63-native-modules-advanced",
-      "version-0.63-native-modules-csharp-codegen"
+      "version-0.63-native-modules-csharp-codegen",
+      "version-0.63-supported-community-modules"
     ],
     "The Basics (MacOS)": [
       "version-0.63-rnm-getting-started",


### PR DESCRIPTION
One more fix following #237 to make sure the 63 versioned docs are pointing to the right links. 