### PR TITLE
Add 63 to win10-compat

### DIFF
--- a/docs/win10-compat.md
+++ b/docs/win10-compat.md
@@ -21,6 +21,7 @@ The following table captures the versions of Windows 10 that a React Native for 
 
 | React Native Windows | Target OS Version | Minimum OS Version |
 | :--: | :-: | :-: |
+| 0.63 | **May 2019 update**<br> Version-1903 ; Build-10.0.18362.1 | **Fall Creators Update**<br> Version-1709 ; Build-10.0.16299.91 |
 | 0.62 | **May 2019 update**<br> Version-1903 ; Build-10.0.18362.1 | **Fall Creators Update**<br> Version-1709 ; Build-10.0.16299.91 |
 | 0.61 | **May 2019 update**<br> Version-1903 ; Build-10.0.18362.1 | **Creators Update**<br> Version-1703 ; Build-10.0.15063.468 |
 | 0.60 | **May 2019 update**<br> Version-1903 ; Build-10.0.18362.1 | **Creators Update**<br> Version-1703 ; Build-10.0.15063.468 |

--- a/website/versioned_docs/version-0.63/win10-compat.md
+++ b/website/versioned_docs/version-0.63/win10-compat.md
@@ -22,6 +22,7 @@ The following table captures the versions of Windows 10 that a React Native for 
 
 | React Native Windows | Target OS Version | Minimum OS Version |
 | :--: | :-: | :-: |
+| 0.63 | **May 2019 update**<br> Version-1903 ; Build-10.0.18362.1 | **Fall Creators Update**<br> Version-1709 ; Build-10.0.16299.91 |
 | 0.62 | **May 2019 update**<br> Version-1903 ; Build-10.0.18362.1 | **Fall Creators Update**<br> Version-1709 ; Build-10.0.16299.91 |
 | 0.61 | **May 2019 update**<br> Version-1903 ; Build-10.0.18362.1 | **Creators Update**<br> Version-1703 ; Build-10.0.15063.468 |
 | 0.60 | **May 2019 update**<br> Version-1903 ; Build-10.0.18362.1 | **Creators Update**<br> Version-1703 ; Build-10.0.15063.468 |


### PR DESCRIPTION
Adds 63 to the windows compat table (same as 62, but causing some confusion).

Closes #259 