### PR TITLE
Adding ReactInit and ReactFunction

### DIFF
--- a/docs/native-modules.md
+++ b/docs/native-modules.md
@@ -51,10 +51,9 @@ Open the Visual Studio solution in the `windows` folder and add the new files di
 | `ReactConstant`         | Specifies a field or property that represents a constant. |
 | `ReactConstantProvider` | Specifies a method that provides a set of constants.      |
 | `ReactEvent`            | Specifies a field or property that represents an event.   |
-| `ReactStruct`           | Specifies a `struct` that can be used in native methods.    |
-| `ReactInit`             | Specifies a class initialization method.                  |
-| `ReactFunction`         | Specifies a field that helps calling a function.          |
-| `ReactStruct`           | Specifies a `struct` that can be used in native methods.    |
+| `ReactStruct`           | Specifies a `struct` that can be used in native methods.  |
+| `ReactInit`             | Specifies a class initialization module.                  |
+| `ReactFunction`         | Specifies a field that helps calling a JavaScript function. |
 
 ### 1. Authoring your Native Module
 
@@ -176,9 +175,8 @@ The `Microsoft.ReactNative.Managed.ReactPackageProvider` is a convenience that m
 | `REACT_CONSTANTPROVIDER` | Specifies a method that provides a set of constants.      |
 | `REACT_EVENT`            | Specifies a field or property that represents an event.   |
 | `REACT_STRUCT`           | Specifies a `struct` that can be used in native methods (don't nest the definition inside `REACT_MODULE`).    |
-| `REACT_INIT`             | Specifies a class initialization method.                  |
-| `REACT_FUNCTION`         | Specifies a field that helps calling a function.          |
-| `REACT_STRUCT`           | Specifies a `struct` that can be used in native methods (don't nest the definition inside `REACT_MODULE`).    |
+| `REACT_INIT`             | Specifies a class initialization module.                  |
+| `REACT_FUNCTION`         | Specifies a field that helps calling a JavaScript function.          |
 
 ### 1. Authoring your Native Module
 

--- a/docs/native-modules.md
+++ b/docs/native-modules.md
@@ -52,6 +52,8 @@ Open the Visual Studio solution in the `windows` folder and add the new files di
 | `ReactConstantProvider` | Specifies a method that provides a set of constants.      |
 | `ReactEvent`            | Specifies a field or property that represents an event.   |
 | `ReactStruct`           | Specifies a `struct` that can be used in native methods.    |
+| `ReactInit`             | Specifies a class initialization method.                  |
+| `ReactFunction`         | Specifies a field that helps calling a function.          |
 
 ### 1. Authoring your Native Module
 
@@ -173,6 +175,8 @@ The `Microsoft.ReactNative.Managed.ReactPackageProvider` is a convenience that m
 | `REACT_CONSTANTPROVIDER` | Specifies a method that provides a set of constants.      |
 | `REACT_EVENT`            | Specifies a field or property that represents an event.   |
 | `REACT_STRUCT`           | Specifies a `struct` that can be used in native methods (don't nest the definition inside `REACT_MODULE`).    |
+| `REACT_INIT`             | Specifies a class initialization method.                  |
+| `REACT_FUNCTION`         | Specifies a field that helps calling a function.          |
 
 ### 1. Authoring your Native Module
 

--- a/docs/native-modules.md
+++ b/docs/native-modules.md
@@ -53,7 +53,8 @@ Open the Visual Studio solution in the `windows` folder and add the new files di
 | `ReactEvent`            | Specifies a field or property that represents an event.   |
 | `ReactStruct`           | Specifies a `struct` that can be used in native methods.  |
 | `ReactInit`             | Specifies a class initialization module.                  |
-| `ReactFunction`         | Specifies a field that helps calling a JavaScript function. |
+| `ReactFunction`         | Specifies a JavaScript function that you want exposed to your native code. |
+
 
 ### 1. Authoring your Native Module
 
@@ -176,7 +177,7 @@ The `Microsoft.ReactNative.Managed.ReactPackageProvider` is a convenience that m
 | `REACT_EVENT`            | Specifies a field or property that represents an event.   |
 | `REACT_STRUCT`           | Specifies a `struct` that can be used in native methods (don't nest the definition inside `REACT_MODULE`).    |
 | `REACT_INIT`             | Specifies a class initialization module.                  |
-| `REACT_FUNCTION`         | Specifies a field that helps calling a JavaScript function.          |
+| `ReactFunction`         | Specifies a JavaScript function that you want exposed to your native code. |
 
 ### 1. Authoring your Native Module
 

--- a/docs/native-modules.md
+++ b/docs/native-modules.md
@@ -54,6 +54,7 @@ Open the Visual Studio solution in the `windows` folder and add the new files di
 | `ReactStruct`           | Specifies a `struct` that can be used in native methods.    |
 | `ReactInit`             | Specifies a class initialization method.                  |
 | `ReactFunction`         | Specifies a field that helps calling a function.          |
+| `ReactStruct`           | Specifies a `struct` that can be used in native methods.    |
 
 ### 1. Authoring your Native Module
 
@@ -177,6 +178,7 @@ The `Microsoft.ReactNative.Managed.ReactPackageProvider` is a convenience that m
 | `REACT_STRUCT`           | Specifies a `struct` that can be used in native methods (don't nest the definition inside `REACT_MODULE`).    |
 | `REACT_INIT`             | Specifies a class initialization method.                  |
 | `REACT_FUNCTION`         | Specifies a field that helps calling a function.          |
+| `REACT_STRUCT`           | Specifies a `struct` that can be used in native methods (don't nest the definition inside `REACT_MODULE`).    |
 
 ### 1. Authoring your Native Module
 

--- a/website/versioned_docs/version-0.62/native-modules.md
+++ b/website/versioned_docs/version-0.62/native-modules.md
@@ -49,8 +49,8 @@ Open the Visual Studio solution in the `windows` folder and add the new files di
 | `ReactConstant`         | Specifies a field or property that represents a constant. |
 | `ReactConstantProvider` | Specifies a method that provides a set of constants.      |
 | `ReactEvent`            | Specifies a field or property that represents an event.   |
-| `ReactInit`             | Specifies a class initialization method.                  |
-| `ReactFunction`         | Specifies a field that helps calling a function.          |
+| `ReactInit`             | Specifies a class initialization module.                  |
+| `ReactFunction`         | Specifies a field that helps calling a JavaScript function. |
 
 ### 1. Authoring your Native Module
 
@@ -240,8 +240,8 @@ For events, you'll see that we created an instance of `NativeEventEmitter` passi
 | `REACT_CONSTANT`         | Specifies a field or property that represents a constant. |
 | `REACT_CONSTANTPROVIDER` | Specifies a method that provides a set of constants.      |
 | `REACT_EVENT`            | Specifies a field or property that represents an event.   |
-| `REACT_INIT`             | Specifies a class initialization method.                  |
-| `REACT_FUNCTION`         | Specifies a field that helps calling a function.          |
+| `REACT_INIT`             | Specifies a class initialization module.                  |
+| `REACT_FUNCTION`         | Specifies a field that helps calling a JavaScript function.          |
 
 ### 1. Authoring your Native Module
 

--- a/website/versioned_docs/version-0.62/native-modules.md
+++ b/website/versioned_docs/version-0.62/native-modules.md
@@ -49,6 +49,8 @@ Open the Visual Studio solution in the `windows` folder and add the new files di
 | `ReactConstant`         | Specifies a field or property that represents a constant. |
 | `ReactConstantProvider` | Specifies a method that provides a set of constants.      |
 | `ReactEvent`            | Specifies a field or property that represents an event.   |
+| `ReactInit`             | Specifies a class initialization method.                  |
+| `ReactFunction`         | Specifies a field that helps calling a function.          |
 
 ### 1. Authoring your Native Module
 
@@ -238,6 +240,8 @@ For events, you'll see that we created an instance of `NativeEventEmitter` passi
 | `REACT_CONSTANT`         | Specifies a field or property that represents a constant. |
 | `REACT_CONSTANTPROVIDER` | Specifies a method that provides a set of constants.      |
 | `REACT_EVENT`            | Specifies a field or property that represents an event.   |
+| `REACT_INIT`             | Specifies a class initialization method.                  |
+| `REACT_FUNCTION`         | Specifies a field that helps calling a function.          |
 
 ### 1. Authoring your Native Module
 

--- a/website/versioned_docs/version-0.62/native-modules.md
+++ b/website/versioned_docs/version-0.62/native-modules.md
@@ -241,7 +241,7 @@ For events, you'll see that we created an instance of `NativeEventEmitter` passi
 | `REACT_CONSTANTPROVIDER` | Specifies a method that provides a set of constants.      |
 | `REACT_EVENT`            | Specifies a field or property that represents an event.   |
 | `REACT_INIT`             | Specifies a class initialization module.                  |
-| `REACT_FUNCTION`         | Specifies a field that helps calling a JavaScript function.          |
+| `ReactFunction`         | Specifies a JavaScript function that you want exposed to your native code. |
 
 ### 1. Authoring your Native Module
 

--- a/website/versioned_docs/version-0.63/native-modules.md
+++ b/website/versioned_docs/version-0.63/native-modules.md
@@ -49,8 +49,8 @@ Open the Visual Studio solution in the `windows` folder and add the new files di
 | `ReactConstant`         | Specifies a field or property that represents a constant. |
 | `ReactConstantProvider` | Specifies a method that provides a set of constants.      |
 | `ReactEvent`            | Specifies a field or property that represents an event.   |
-| `ReactInit`             | Specifies a class initialization method.                  |
-| `ReactFunction`         | Specifies a field that helps calling a function.          |
+| `ReactInit`             | Specifies a class initialization module.                  |
+| `ReactFunction`         | Specifies a field that helps calling a JavaScript function. |
 
 ### 1. Authoring your Native Module
 
@@ -240,8 +240,8 @@ For events, you'll see that we created an instance of `NativeEventEmitter` passi
 | `REACT_CONSTANT`         | Specifies a field or property that represents a constant. |
 | `REACT_CONSTANTPROVIDER` | Specifies a method that provides a set of constants.      |
 | `REACT_EVENT`            | Specifies a field or property that represents an event.   |
-| `REACT_INIT`             | Specifies a class initialization method.                  |
-| `REACT_FUNCTION`         | Specifies a field that helps calling a function.          |
+| `REACT_INIT`             | Specifies a class initialization module.                  |
+| `REACT_FUNCTION`         | Specifies a field that helps calling a JavaScript function.          |
 
 ### 1. Authoring your Native Module
 

--- a/website/versioned_docs/version-0.63/native-modules.md
+++ b/website/versioned_docs/version-0.63/native-modules.md
@@ -50,7 +50,7 @@ Open the Visual Studio solution in the `windows` folder and add the new files di
 | `ReactConstantProvider` | Specifies a method that provides a set of constants.      |
 | `ReactEvent`            | Specifies a field or property that represents an event.   |
 | `ReactInit`             | Specifies a class initialization module.                  |
-| `ReactFunction`         | Specifies a field that helps calling a JavaScript function. |
+| `ReactFunction`         | Specifies a JavaScript function that you want exposed to your native code. |
 
 ### 1. Authoring your Native Module
 
@@ -241,7 +241,7 @@ For events, you'll see that we created an instance of `NativeEventEmitter` passi
 | `REACT_CONSTANTPROVIDER` | Specifies a method that provides a set of constants.      |
 | `REACT_EVENT`            | Specifies a field or property that represents an event.   |
 | `REACT_INIT`             | Specifies a class initialization module.                  |
-| `REACT_FUNCTION`         | Specifies a field that helps calling a JavaScript function.          |
+| `ReactFunction`         | Specifies a JavaScript function that you want exposed to your native code. |
 
 ### 1. Authoring your Native Module
 

--- a/website/versioned_docs/version-0.63/native-modules.md
+++ b/website/versioned_docs/version-0.63/native-modules.md
@@ -49,6 +49,8 @@ Open the Visual Studio solution in the `windows` folder and add the new files di
 | `ReactConstant`         | Specifies a field or property that represents a constant. |
 | `ReactConstantProvider` | Specifies a method that provides a set of constants.      |
 | `ReactEvent`            | Specifies a field or property that represents an event.   |
+| `ReactInit`             | Specifies a class initialization method.                  |
+| `ReactFunction`         | Specifies a field that helps calling a function.          |
 
 ### 1. Authoring your Native Module
 
@@ -238,6 +240,8 @@ For events, you'll see that we created an instance of `NativeEventEmitter` passi
 | `REACT_CONSTANT`         | Specifies a field or property that represents a constant. |
 | `REACT_CONSTANTPROVIDER` | Specifies a method that provides a set of constants.      |
 | `REACT_EVENT`            | Specifies a field or property that represents an event.   |
+| `REACT_INIT`             | Specifies a class initialization method.                  |
+| `REACT_FUNCTION`         | Specifies a field that helps calling a function.          |
 
 ### 1. Authoring your Native Module
 

--- a/website/versioned_docs/version-0.64/native-modules.md
+++ b/website/versioned_docs/version-0.64/native-modules.md
@@ -52,7 +52,7 @@ Open the Visual Studio solution in the `windows` folder and add the new files di
 | `ReactEvent`            | Specifies a field or property that represents an event.   |
 | `ReactStruct`           | Specifies a `struct` that can be used in native methods.    |
 | `ReactInit`             | Specifies a class initialization module.                  |
-| `ReactFunction`         | Specifies a field that helps calling a JavaScript function. |
+| `ReactFunction`         | Specifies a JavaScript function that you want exposed to your native code. |
 
 ### 1. Authoring your Native Module
 
@@ -244,7 +244,7 @@ For events, you'll see that we created an instance of `NativeEventEmitter` passi
 | `REACT_EVENT`            | Specifies a field or property that represents an event.   |
 | `REACT_STRUCT`           | Specifies a `struct` that can be used in native methods (don't nest the definition inside `REACT_MODULE`).    |
 | `REACT_INIT`             | Specifies a class initialization module.                  |
-| `REACT_FUNCTION`         | Specifies a field that helps calling a JavaScript function.          |
+| `ReactFunction`         | Specifies a JavaScript function that you want exposed to your native code. |
 
 ### 1. Authoring your Native Module
 

--- a/website/versioned_docs/version-0.64/native-modules.md
+++ b/website/versioned_docs/version-0.64/native-modules.md
@@ -51,6 +51,8 @@ Open the Visual Studio solution in the `windows` folder and add the new files di
 | `ReactConstantProvider` | Specifies a method that provides a set of constants.      |
 | `ReactEvent`            | Specifies a field or property that represents an event.   |
 | `ReactStruct`           | Specifies a `struct` that can be used in native methods.    |
+| `ReactInit`             | Specifies a class initialization module.                  |
+| `ReactFunction`         | Specifies a field that helps calling a JavaScript function. |
 
 ### 1. Authoring your Native Module
 
@@ -241,6 +243,8 @@ For events, you'll see that we created an instance of `NativeEventEmitter` passi
 | `REACT_CONSTANTPROVIDER` | Specifies a method that provides a set of constants.      |
 | `REACT_EVENT`            | Specifies a field or property that represents an event.   |
 | `REACT_STRUCT`           | Specifies a `struct` that can be used in native methods (don't nest the definition inside `REACT_MODULE`).    |
+| `REACT_INIT`             | Specifies a class initialization module.                  |
+| `REACT_FUNCTION`         | Specifies a field that helps calling a JavaScript function.          |
 
 ### 1. Authoring your Native Module
 

--- a/website/versioned_docs/version-0.65/native-modules.md
+++ b/website/versioned_docs/version-0.65/native-modules.md
@@ -54,7 +54,7 @@ Open the Visual Studio solution in the `windows` folder and add the new files di
 | `ReactEvent`            | Specifies a field or property that represents an event.   |
 | `ReactStruct`           | Specifies a `struct` that can be used in native methods.    |
 | `ReactInit`             | Specifies a class initialization module.                  |
-| `ReactFunction`         | Specifies a field that helps calling a JavaScript function. |
+| `ReactFunction`         | Specifies a JavaScript function that you want exposed to your native code. |
 
 ### 1. Authoring your Native Module
 
@@ -177,7 +177,7 @@ The `Microsoft.ReactNative.Managed.ReactPackageProvider` is a convenience that m
 | `REACT_EVENT`            | Specifies a field or property that represents an event.   |
 | `REACT_STRUCT`           | Specifies a `struct` that can be used in native methods (don't nest the definition inside `REACT_MODULE`).    |
 | `REACT_INIT`             | Specifies a class initialization module.                  |
-| `REACT_FUNCTION`         | Specifies a field that helps calling a JavaScript function.          |
+| `ReactFunction`         | Specifies a JavaScript function that you want exposed to your native code. |
 
 ### 1. Authoring your Native Module
 

--- a/website/versioned_docs/version-0.65/native-modules.md
+++ b/website/versioned_docs/version-0.65/native-modules.md
@@ -53,6 +53,8 @@ Open the Visual Studio solution in the `windows` folder and add the new files di
 | `ReactConstantProvider` | Specifies a method that provides a set of constants.      |
 | `ReactEvent`            | Specifies a field or property that represents an event.   |
 | `ReactStruct`           | Specifies a `struct` that can be used in native methods.    |
+| `ReactInit`             | Specifies a class initialization module.                  |
+| `ReactFunction`         | Specifies a field that helps calling a JavaScript function. |
 
 ### 1. Authoring your Native Module
 
@@ -174,6 +176,8 @@ The `Microsoft.ReactNative.Managed.ReactPackageProvider` is a convenience that m
 | `REACT_CONSTANTPROVIDER` | Specifies a method that provides a set of constants.      |
 | `REACT_EVENT`            | Specifies a field or property that represents an event.   |
 | `REACT_STRUCT`           | Specifies a `struct` that can be used in native methods (don't nest the definition inside `REACT_MODULE`).    |
+| `REACT_INIT`             | Specifies a class initialization module.                  |
+| `REACT_FUNCTION`         | Specifies a field that helps calling a JavaScript function.          |
 
 ### 1. Authoring your Native Module
 


### PR DESCRIPTION
Could be more documentation based on the content of [NativeModules.h](https://github.com/microsoft/react-native-windows/blob/0dfe9decb4390c4b77e0837e69c4a25878034960/vnext/Microsoft.ReactNative.Cxx/NativeModules.h), but followed the pattern of others to just put a quick sentence. 

Added on all versions back to 0.62, which is when these were added.