### PR TITLE
Fix parameters order in the async sample.

### DIFF
--- a/docs/native-modules.md
+++ b/docs/native-modules.md
@@ -316,7 +316,7 @@ This can be also tied in with C++/WinRT event handlers or `IAsyncOperation<T>` l
       if (error) {
         result.Reject("Failure");
       } else {
-        something.Completed([result] (const auto& status, const auto& operation) {
+        something.Completed([result] (const auto& operation, const auto& status) {
           // do error checking, e.g. status should be Completed
           std::wstring wtext{operation.GetResults()};
           result.Resolve(React::JSValue{ ConvertWideStringToUtf8String(text) });


### PR DESCRIPTION
Correct the example to callback to `something.Completed([result] (const auto& operation, const auto& status)`