### PR TITLE
Add Web Debugger warning to Release build docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -105,6 +105,9 @@ Follow these steps to build a version of your app that you can install or publis
 - Build the solution. You can now launch without first launching Metro.
 - If you want to build an APPX package to share or publish, use the **Project** > **Publish** > **Create App Packages...** option.
 
+> The Debug configuration uses the Web Debugger by default, which means the application's JavaScript code runs in Chrome.<br>
+> If you're getting different runtime behavior between the Release and Debug configurations, consider setting the `UseWebDebugger` setting off in [App.cpp](https://github.com/microsoft/react-native-windows/blob/6b415659aa017dbc41e3f28e817fb768a8e80435/vnext/template/cpp-app/src/App.cpp#L30) or [App.xaml.cs](https://github.com/microsoft/react-native-windows/blob/6b415659aa017dbc41e3f28e817fb768a8e80435/vnext/template/cs-app/src/App.xaml.cs#L20) to get the same behavior in the Debug configuration.
+
 See also this article for additional details: https://techcommunity.microsoft.com/t5/windows-dev-appconsult/getting-started-with-react-native-for-windows/ba-p/912093#
 </body>
 </html>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -106,7 +106,7 @@ Follow these steps to build a version of your app that you can install or publis
 - If you want to build an APPX package to share or publish, use the **Project** > **Publish** > **Create App Packages...** option.
 
 > The Debug configuration uses the Web Debugger by default, which means the application's JavaScript code runs in Chrome.<br>
-> If you're getting different runtime behavior between the Release and Debug configurations, consider setting the `UseWebDebugger` setting off in [App.cpp](https://github.com/microsoft/react-native-windows/blob/6b415659aa017dbc41e3f28e817fb768a8e80435/vnext/template/cpp-app/src/App.cpp#L30) or [App.xaml.cs](https://github.com/microsoft/react-native-windows/blob/6b415659aa017dbc41e3f28e817fb768a8e80435/vnext/template/cs-app/src/App.xaml.cs#L20) to get the same behavior in the Debug configuration.
+> If you're getting different runtime behavior between the Release and Debug configurations, consider setting the `UseWebDebugger` setting off in [`App.cpp`](https://github.com/microsoft/react-native-windows/blob/6b415659aa017dbc41e3f28e817fb768a8e80435/vnext/template/cpp-app/src/App.cpp#L30) or [`App.xaml.cs`](https://github.com/microsoft/react-native-windows/blob/6b415659aa017dbc41e3f28e817fb768a8e80435/vnext/template/cs-app/src/App.xaml.cs#L20) to get the same behavior in the Debug configuration.
 
 See also this article for additional details: https://techcommunity.microsoft.com/t5/windows-dev-appconsult/getting-started-with-react-native-for-windows/ba-p/912093#
 </body>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -106,7 +106,7 @@ Follow these steps to build a version of your app that you can install or publis
 - If you want to build an APPX package to share or publish, use the **Project** > **Publish** > **Create App Packages...** option.
 
 > The Debug configuration uses the Web Debugger by default, which means the application's JavaScript code runs in Chrome.<br>
-> If you're getting different runtime behavior between the Release and Debug configurations, consider setting the `UseWebDebugger` setting off in [`App.cpp`](https://github.com/microsoft/react-native-windows/blob/6b415659aa017dbc41e3f28e817fb768a8e80435/vnext/template/cpp-app/src/App.cpp#L30) or [`App.xaml.cs`](https://github.com/microsoft/react-native-windows/blob/6b415659aa017dbc41e3f28e817fb768a8e80435/vnext/template/cs-app/src/App.xaml.cs#L20) to get the same behavior in the Debug configuration.
+> If you're getting different runtime behavior between the Release and Debug configurations, consider disabling the `UseWebDebugger` setting in [`App.cpp`](https://github.com/microsoft/react-native-windows/blob/6b415659aa017dbc41e3f28e817fb768a8e80435/vnext/template/cpp-app/src/App.cpp#L30) or [`App.xaml.cs`](https://github.com/microsoft/react-native-windows/blob/6b415659aa017dbc41e3f28e817fb768a8e80435/vnext/template/cs-app/src/App.xaml.cs#L20) to get the same behavior in the Debug configuration.
 
 See also this article for additional details: https://techcommunity.microsoft.com/t5/windows-dev-appconsult/getting-started-with-react-native-for-windows/ba-p/912093#
 </body>


### PR DESCRIPTION
Adds a warning to try disabling UseWebDebugger when building for Release and there are differences in behavior between Release and Debug builds.

This change in documentation is motivated by having run into a situation where the react-native-windows application ran in the Debug configuration but just showed a blank screen in the Release configuration. In this case it was caused by the use of JavaScript's method `Object.fromEntries`, which is implemented in V8 but not supported in the Chakra release. Disabling `UseWebDebugger` in Debug allowed me to see the exception that `Object` doesn't have `fromEntries` bubble up into the popup.

I'd expect this issue to become more common as developers and modules start using more recent ECMAScript features that are not supported by Chakra.
Here's an example of a fix submitted to `react-native-device-info` to bring back support for `react-native-windows` after `Object.fromEntries` had been added to the code: https://github.com/react-native-device-info/react-native-device-info/pull/1110