### PR TITLE
Mention VS 16.5 Requirements

### DIFF
--- a/docs/rnw-dependencies.md
+++ b/docs/rnw-dependencies.md
@@ -27,7 +27,7 @@ Start an **elevated** PowerShell window and run:
 
 Alternatively, you can setup your environment manually:
 - Ensure Developer Mode is turned ON in Windows Settings App.
-- Install [Visual Studio 2019](https://www.visualstudio.com/downloads) **with the following options checked**:
+- Install [Visual Studio 2019 (version 16.5 or greater)](https://www.visualstudio.com/downloads) **with the following options checked**:
   - Workloads
     - Universal Windows Platform development
     - Desktop development with C++


### PR DESCRIPTION
https://github.com/microsoft/react-native-windows/pull/6548 means we will start requiring VS 16.5 or later. Add that as information to the docs.