### PR TITLE
Remove some guidance referencing internals that have changed

### DIFF
--- a/docs/native-code.md
+++ b/docs/native-code.md
@@ -100,13 +100,6 @@ To work around this problem there are three options:
 
 So you added a new native module or a new method to a module but it isn't working, **now what?!**
 
-If your method isn't being hit in the VS debugger, something is blocking the call due to a mismatch, likely between the expected and actual types that your method takes/returns.
-
-To debug into what is rejecting the call, set a breakpoint in `CxxNativeModule::invoke` (See [`ReactCommon\react-native-patched\ReactCommon\cxxreact\CxxNativeModule.cpp`](https://github.com/facebook/react-native/blob/0b8a82a6eeeb3508b80ee137d313f64fe323db06/ReactCommon/cxxreact/CxxNativeModule.cpp#L97)). This breakpoint is bound to be hit a lot (every time a call to a native method is made), so we want to make sure we only break when *our* method of interest is involved.
-
-Right-click on the breakpoint to add a Condition. Suppose the method you are interested in catching is called `getString`. 
-The conditional breakpoint condition to enter should compare the name of the method to that string: `strcmp(method.name._Mypair._Myval2._Bx._Ptr, "getString")==0`
-
 ### `Compile error 'XamlMetaDataProvider': is not a member of 'winrt::MyModuleName'`
 ```
 Error	C2039	'XamlMetaDataProvider': is not a member of 'winrt::MyModuleName'


### PR DESCRIPTION
The section references a build-time directory that is no longer present, and some upstream implementation details that have been shifting quite frequently. Remove it.