### PR TITLE
Update VS instructions with autolink step

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,12 +72,11 @@ This sends telemetry to Microsoft by default. You can prevent the telemetry from
 
 - Using Visual Studio
 
-  - Open the `windows` folder in the project directory (e.g., `AwesomeProject/windows` if you used `AwesomeProject` as `<projectName>`)
-  - In the `windows` folder, run:
-  ```bat
-  npx react-native autolink-windows
-  ```
-  - From the `windows` folder, open the solution file in Visual Studio (e.g., `AwesomeProject/windows/AwesomeProject.sln`)
+  - From the root of the project directory, run the following script which will automatically link your app's dependencies:
+    ```bat
+    npx react-native autolink-windows
+    ```
+  - Open the solution file in the application folder in Visual Studio (e.g., `AwesomeProject/windows/AwesomeProject.sln` if you used `AwesomeProject` as `<projectName>`)
   - Select the `Debug` configuration and the `x64` platform from the combo box controls to the left of the `Run` button and underneath the `Team` and `Tools` menu item.
   - Run `yarn start` from your project directory, and wait for the React Native packager to report success.
   - Click the `Run` button to the right of the platform combo box control in VS, or select the `Debug`->`Start without Debugging` menu item. You now see your new app and Chrome should have loaded `http://localhost:8081/debugger-ui/` in a new tab. Press `F12` or `Ctrl+Shift+I` in Chrome to open its Developer Tools. :tada:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,7 +72,12 @@ This sends telemetry to Microsoft by default. You can prevent the telemetry from
 
 - Using Visual Studio
 
-  - Open the solution file in the application folder in Visual Studio (e.g., `AwesomeProject/windows/AwesomeProject.sln` if you used `AwesomeProject` as `<projectName>`)
+  - Open the `windows` folder in the project directory (e.g., `AwesomeProject/windows` if you used `AwesomeProject` as `<projectName>`)
+  - In the `windows` folder, run:
+  ```bat
+  npx react-native autolink-windows
+  ```
+  - From the `windows` folder, open the solution file in Visual Studio (e.g., `AwesomeProject/windows/AwesomeProject.sln`)
   - Select the `Debug` configuration and the `x64` platform from the combo box controls to the left of the `Run` button and underneath the `Team` and `Tools` menu item.
   - Run `yarn start` from your project directory, and wait for the React Native packager to report success.
   - Click the `Run` button to the right of the platform combo box control in VS, or select the `Debug`->`Start without Debugging` menu item. You now see your new app and Chrome should have loaded `http://localhost:8081/debugger-ui/` in a new tab. Press `F12` or `Ctrl+Shift+I` in Chrome to open its Developer Tools. :tada:

--- a/website/versioned_docs/version-0.63/getting-started.md
+++ b/website/versioned_docs/version-0.63/getting-started.md
@@ -72,12 +72,11 @@ This sends telemetry to Microsoft by default. You can prevent the telemetry from
 
 - Using Visual Studio
 
-  - Open the `windows` folder in the project directory (e.g., `AwesomeProject/windows` if you used `AwesomeProject` as `<projectName>`)
-  - In the `windows` folder, run:
-  ```bat
-  npx react-native autolink-windows
-  ```
-  - From the `windows` folder, open the solution file in Visual Studio (e.g., `AwesomeProject/windows/AwesomeProject.sln`)
+  - From the root of the project directory, run the following script which will automatically link your app's dependencies:
+    ```bat
+    npx react-native autolink-windows
+    ```
+  - Open the solution file in the application folder in Visual Studio (e.g., `AwesomeProject/windows/AwesomeProject.sln` if you used `AwesomeProject` as `<projectName>`)
   - Select the `Debug` configuration and the `x64` platform from the combo box controls to the left of the `Run` button and underneath the `Team` and `Tools` menu item.
   - Run `yarn start` from your project directory, and wait for the React Native packager to report success.
   - Click the `Run` button to the right of the platform combo box control in VS, or select the `Debug`->`Start without Debugging` menu item. You now see your new app and Chrome should have loaded `http://localhost:8081/debugger-ui/` in a new tab. Press `F12` or `Ctrl+Shift+I` in Chrome to open its Developer Tools. :tada:

--- a/website/versioned_docs/version-0.63/getting-started.md
+++ b/website/versioned_docs/version-0.63/getting-started.md
@@ -72,7 +72,12 @@ This sends telemetry to Microsoft by default. You can prevent the telemetry from
 
 - Using Visual Studio
 
-  - Open the solution file in the application folder in Visual Studio (e.g., `AwesomeProject/windows/AwesomeProject.sln` if you used `AwesomeProject` as `<projectName>`)
+  - Open the `windows` folder in the project directory (e.g., `AwesomeProject/windows` if you used `AwesomeProject` as `<projectName>`)
+  - In the `windows` folder, run:
+  ```bat
+  npx react-native autolink-windows
+  ```
+  - From the `windows` folder, open the solution file in Visual Studio (e.g., `AwesomeProject/windows/AwesomeProject.sln`)
   - Select the `Debug` configuration and the `x64` platform from the combo box controls to the left of the `Run` button and underneath the `Team` and `Tools` menu item.
   - Run `yarn start` from your project directory, and wait for the React Native packager to report success.
   - Click the `Run` button to the right of the platform combo box control in VS, or select the `Debug`->`Start without Debugging` menu item. You now see your new app and Chrome should have loaded `http://localhost:8081/debugger-ui/` in a new tab. Press `F12` or `Ctrl+Shift+I` in Chrome to open its Developer Tools. :tada:


### PR DESCRIPTION
Following the Get Started guide omits a now required step to run the auto-link command which wasn't previously called out as part of the "Using Visual Studio" steps. This PR adds that detail. 