### PR TITLE
Update Native Modules doc (C#)

### DIFF
--- a/docs/native-modules.md
+++ b/docs/native-modules.md
@@ -175,6 +175,7 @@ import {
   Alert,
   Text,
   View,
+  Button,
 } from 'react-native';
 
 import { NativeModules, NativeEventEmitter } from 'react-native';
@@ -185,12 +186,12 @@ class NativeModuleSample extends Component {
 
   componentDidMount() {
     // Subscribing to FancyMath.AddEvent
-    FancyMathEventEmitter.addListener('AddEvent', eventHandler, this);
+    FancyMathEventEmitter.addListener('AddEvent', this.eventHandler, this);
   }
 
   componentWillUnmount() {
     // Unsubscribing from FancyMath.AddEvent
-    FancyMathEventEmitter.removeListener('AddEvent', eventHandler, this);
+    FancyMathEventEmitter.removeListener('AddEvent', this.eventHandler, this);
   }
 
   eventHandler(result) {

--- a/samples/NativeModuleSample/csharp/windows/NativeModuleSample/FancyMath.cs
+++ b/samples/NativeModuleSample/csharp/windows/NativeModuleSample/FancyMath.cs
@@ -6,27 +6,24 @@ using Microsoft.ReactNative.Managed;
 
 namespace NativeModuleSample
 {
-    namespace NativeModuleSample
+    [ReactModule]
+    class FancyMath
     {
-        [ReactModule]
-        class FancyMath
+        [ReactConstant]
+        public double E = Math.E;
+
+        [ReactConstant("Pi")]
+        public double PI = Math.PI;
+
+        [ReactMethod("add")]
+        public double Add(double a, double b)
         {
-            [ReactConstant]
-            public double E = Math.E;
-
-            [ReactConstant("Pi")]
-            public double PI = Math.PI;
-
-            [ReactMethod("add")]
-            public double Add(double a, double b)
-            {
-                double result = a + b;
-                AddEvent(result);
-                return result;
-            }
-
-            [ReactEvent]
-            public Action<double> AddEvent { get; set; }
+            double result = a + b;
+            AddEvent(result);
+            return result;
         }
+
+        [ReactEvent]
+        public Action<double> AddEvent { get; set; }
     }
 }


### PR DESCRIPTION
## What
Updates [the C# part of Native Modules doc](https://microsoft.github.io/react-native-windows/docs/native-modules#sample-native-module-c) to be aligned [with the provided sample](https://github.com/microsoft/react-native-windows-samples/tree/master/samples/NativeModuleSample/csharp/windows/NativeModuleSample) and use RNW 0.63 compile time code generation approach.

## Why
Without this change, the Native Module guide wasn't working - the new native module wasn't available in React's `NativeModules` object.