### PR TITLE
fix link casing

### DIFF
--- a/docs/nuget.md
+++ b/docs/nuget.md
@@ -86,4 +86,4 @@ Of course all the other flags still work.
       > Note: You'll need to match the NuGet version with the npm version
 
 # Version match
-The versions of the NuGet package in your project must match the npm package version. If you need to update the NuGet packages there is a separate page on [Updating NuGet packages](NuGet-update.md)
+The versions of the NuGet package in your project must match the npm package version. If you need to update the NuGet packages there is a separate page on [Updating NuGet packages](nuget-update.md)


### PR DESCRIPTION
wrong casing on a doc. Note that this doc is not currently discoverable, it's not in the sidebar or anything, but building the website generates a warning due to a broken link (it's not really broken on Windows, but worth fixing anyway)