### PR TITLE
Remove Nuget Setup from CI Loop Example Code

### DIFF
--- a/docs/native-modules-setup.md
+++ b/docs/native-modules-setup.md
@@ -180,9 +180,6 @@ Next you need to create a YAML file for GitHub Actions, the basic steps are:
       with:
         vs-version: 16.5
 
-    - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1
-
     - name: Check node modules cache
       uses: actions/cache@v1
       id: yarn-cache

--- a/docs/native-modules-setup.md
+++ b/docs/native-modules-setup.md
@@ -176,12 +176,12 @@ Next you need to create a YAML file for GitHub Actions, the basic steps are:
         node-version: '12.9.1'
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
       with:
         vs-version: 16.5
 
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1.0.2
+      uses: NuGet/setup-nuget@v1
 
     - name: Check node modules cache
       uses: actions/cache@v1

--- a/website/versioned_docs/version-0.63/native-modules-setup.md
+++ b/website/versioned_docs/version-0.63/native-modules-setup.md
@@ -399,12 +399,12 @@ Next you need to create a YAML file for GitHub Actions, the basic steps are:
         node-version: '12.9.1'
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
       with:
         vs-version: 16.5
        
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1.0.2
+      uses: NuGet/setup-nuget@v1
 
     - name: Check node modules cache
       uses: actions/cache@v1


### PR DESCRIPTION
Remove Nuget setup from CI Loop Example Code for 64+ because of RNW #6548. Now using built in nuget within msbuild. 