### PR TITLE
Update Hermes Instructions

### DIFF
--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -8,23 +8,6 @@ The [Hermes](https://hermesengine.dev/) engine is an open source JavaScript engi
 
 To learn more about what it is and how to use it, check out the [React Native](https://reactnative.dev/docs/hermes#docsNav) documentation for it.
 
-## Available on macOS
-Hermes is available on React Native for macOS, provided you are using version 0.62 or higher.
-To learn how to upgrade to the latest version, check out the **Upgrading** section of the [macOS Getting Started guide](rnm-getting-started.md).
-
-After you have upgraded to the latest version of React Native for macOS, install and add the following:
-
-1.  Install the npm package `yarn add 'hermes-engine-darwin@^0.4.3'`
-2. Add (or uncomment) the following pod dependencies to your macOS target in your `Podfile`:<br>
-```
-pod 'React-Core/Hermes', :path => '../node_modules/react-native-macos/'
-pod 'hermes', :path => '../node_modules/hermes-engine-darwin'
-pod 'libevent', :podspec => '../node_modules/react-native-macos/third-party-podspecs/libevent.podspec'
-```
-3. Run `pod install`
-
-> Be sure to set your target's deployment target to at least 10.14 before running `pod install`
-
 ## Hermes on Windows:
 Hermes is experimentally supported on Windows, generally providing better performance characteristics than the default Chakra engine.
 
@@ -34,10 +17,10 @@ The easiest way to enable Hermes is to pass the `--useHermes` flag to `react-nat
 ### Using Hermes in an existing project
 Hermes can be enabled in existing projects with a few edits.
 
-First, set the `UseHermes` property to `true` in the `BuildFlags.props` file in your project's `windows` directory:
+First, set the `UseHermes` property to `true` in the `ExperimentalFeatures.props` file in your project's `windows` directory:
 
 ```xml
-<PropertyGroup Label="Microsoft.ReactNative Build Flags">
+<PropertyGroup Label="Microsoft.ReactNative Experimental Features">
   ...
   <UseHermes>true</UseHermes>
 </PropertyGroup>
@@ -70,3 +53,20 @@ If you've built a project using Hermes and want to opt-out, the above instructio
 - Enabling Hermes leads to a very large download on initial build. This will become smaller in the future
 - Hermes is not yet compatible with other experimental features, like NuGet distribution or WinUI 3
 - The binary for Hermes is not yet signed by Microsoft
+
+## Hermes on macOS
+Hermes is available on React Native for macOS, provided you are using version 0.62 or higher.
+To learn how to upgrade to the latest version, check out the **Upgrading** section of the [macOS Getting Started guide](rnm-getting-started.md).
+
+After you have upgraded to the latest version of React Native for macOS, install and add the following:
+
+1.  Install the npm package `yarn add 'hermes-engine-darwin@^0.4.3'`
+2. Add (or uncomment) the following pod dependencies to your macOS target in your `Podfile`:<br>
+```
+pod 'React-Core/Hermes', :path => '../node_modules/react-native-macos/'
+pod 'hermes', :path => '../node_modules/hermes-engine-darwin'
+pod 'libevent', :podspec => '../node_modules/react-native-macos/third-party-podspecs/libevent.podspec'
+```
+3. Run `pod install`
+
+> Be sure to set your target's deployment target to at least 10.14 before running `pod install`


### PR DESCRIPTION
Depends on https://github.com/microsoft/react-native-windows/pull/7101/files

This updates Hermes instructions for new build logic, changes headings between macOS and Windows to be consistent, and moves the macOS section below Windows, since Windows has more usage.