### PR TITLE
Improved Readability for View Managers Documentation

### DIFF
--- a/docs/view-managers.md
+++ b/docs/view-managers.md
@@ -121,7 +121,7 @@ namespace ViewManagerSample
 </ResourceDictionary>
 ```
 
-#### 1. Authoring your View Manager
+### 1. Authoring your View Manager
 
 Here is a sample view manager written in C# called `CustomUserControlViewManager`.
 
@@ -186,7 +186,7 @@ namespace ViewManagerSample
 }
 ```
 
-#### 2. Registering your View Manager
+### 2. Registering your View Manager
 
 As with native modules, we want to register our new `CustomUserControlViewManager` with React Native so we can actually use it. To do this, first we're going to create a `ReactPackageProvider` which implements [`Microsoft.ReactNative.IReactPackageProvider`](https://github.com/microsoft/react-native-windows/blob/master/vnext/Microsoft.ReactNative/IReactPackageProvider.idl).
 
@@ -237,7 +237,7 @@ This example assumes that the `ViewManagerSample.ReactPackageProvider` we create
 
 The `Microsoft.ReactNative.Managed.ReactPackageProvider` is a convenience that makes sure that all native modules and view managers defined within the app project automatically get registered. So if you're creating your view managers directly within the app project, you won't actually want to define a separate `ReactPackageProvider`.
 
-#### 3. Using your View Manager in JSX
+### 3. Using your View Manager in JSX
 
 `ViewManagerSample.js`:
 
@@ -294,7 +294,7 @@ AppRegistry.registerComponent('ViewManagerSample', () => ViewManagerSample);
 
 For this sample, assume we already have the `CustomUserControl` defined in the C# example.
 
-#### 1. Authoring your View Manager
+### 1. Authoring your View Manager
 
 Here is a sample view manager written in C++ called `CustomUserControlViewManager`.
 
@@ -481,7 +481,7 @@ void CustomUserControlViewManager::ReactContext(IReactContext reactContext) noex
 }
 ```
 
-#### 2. Registering your View Manager
+### 2. Registering your View Manager
 
 As with native modules, we want to register our new `CustomUserControlViewManager` with React Native so we can actually use it. To do this, first we're going to create a `ReactPackageProvider` which implements [`Microsoft.ReactNative.IReactPackageProvider`](https://github.com/microsoft/react-native-windows/blob/master/vnext/Microsoft.ReactNative/IReactPackageProvider.idl).
 
@@ -584,7 +584,7 @@ This example assumes that the `ViewManagerSample::ReactPackageProvider` we creat
 
 The `SampleApp::ReactPackageProvider` is a convenience that makes sure that all native modules and view managers defined within the app project automatically get registered. So if you're creating your native modules directly within the app project, you won't actually want to define a separate `ReactPackageProvider`.
 
-#### 3. Using your View Manager in JSX
+### 3. Using your View Manager in JSX
 
 `ViewManagerSample.js`:
 

--- a/docs/view-managers.md
+++ b/docs/view-managers.md
@@ -300,7 +300,7 @@ Here is a sample view manager written in C++ called `CustomUserControlViewManage
 
 `CustomUserControlViewManager.h`:
 
-```c++
+```cpp
 #pragma once
 
 #include "pch.h"
@@ -360,7 +360,7 @@ private:
 
 `CustomUserControlViewManager.cpp`:
 
-```c++
+```cpp
 #include "pch.h"
 #include "CustomUserControlViewManager.h"
 
@@ -487,7 +487,7 @@ As with native modules, we want to register our new `CustomUserControlViewManage
 
 `ReactPackageProvider.idl`:
 
-```c++
+```cpp
 namespace ViewManagerSample
 {
     [webhosthidden]
@@ -558,7 +558,7 @@ Now that we have the `ReactPackageProvider`, it's time to register it within our
 
 `App.cpp`:
 
-```c++
+```cpp
 #include "pch.h"
 
 #include "App.h"

--- a/website/versioned_docs/version-0.63/view-managers.md
+++ b/website/versioned_docs/version-0.63/view-managers.md
@@ -122,7 +122,7 @@ namespace ViewManagerSample
 </ResourceDictionary>
 ```
 
-#### 1. Authoring your View Manager
+### 1. Authoring your View Manager
 
 Here is a sample view manager written in C# called `CustomUserControlViewManager`.
 
@@ -187,7 +187,7 @@ namespace ViewManagerSample
 }
 ```
 
-#### 2. Registering your View Manager
+### 2. Registering your View Manager
 
 As with native modules, we want to register our new `CustomUserControlViewManager` with React Native so we can actually use it. To do this, first we're going to create a `ReactPackageProvider` which implements [Microsoft.ReactNative.IReactPackageProvider](https://github.com/microsoft/react-native-windows/blob/master/vnext/Microsoft.ReactNative/IReactPackageProvider.idl).
 
@@ -238,7 +238,7 @@ This example assumes that the `ViewManagerSample.ReactPackageProvider` we create
 
 The `Microsoft.ReactNative.Managed.ReactPackageProvider` is a convenience that makes sure that all native modules and view managers defined within the app project automatically get registered. So if you're creating your view managers directly within the app project, you won't actually want to define a separate `ReactPackageProvider`.
 
-#### 3. Using your View Manager in JSX
+### 3. Using your View Manager in JSX
 
 _ViewManagerSample.js_
 
@@ -295,7 +295,7 @@ AppRegistry.registerComponent('ViewManagerSample', () => ViewManagerSample);
 
 For this sample, assume we already have the `CustomUserControl` defined in the C# example.
 
-#### 1. Authoring your View Manager
+### 1. Authoring your View Manager
 
 Here is a sample view manager written in C++ called `CustomUserControlViewManager`.
 
@@ -441,7 +441,7 @@ void CustomUserControlViewManager::DispatchCommand(
 }
 ```
 
-#### 2. Registering your View Manager
+### 2. Registering your View Manager
 
 As with native modules, we want to register our new `CustomUserControlViewManager` with React Native so we can actually use it. To do this, first we're going to create a `ReactPackageProvider` which implements [Microsoft.ReactNative.IReactPackageProvider](https://github.com/microsoft/react-native-windows/blob/master/vnext/Microsoft.ReactNative/IReactPackageProvider.idl).
 
@@ -544,7 +544,7 @@ This example assumes that the `ViewManagerSample::ReactPackageProvider` we creat
 
 The `SampleApp::ReactPackageProvider` is a convenience that makes sure that all native modules and view managers defined within the app project automatically get registered. So if you're creating your native modules directly within the app project, you won't actually want to define a separate `ReactPackageProvider`.
 
-#### 3. Using your View Manager in JSX
+### 3. Using your View Manager in JSX
 
 _ViewManagerSample.js_
 

--- a/website/versioned_docs/version-0.63/view-managers.md
+++ b/website/versioned_docs/version-0.63/view-managers.md
@@ -301,7 +301,7 @@ Here is a sample view manager written in C++ called `CustomUserControlViewManage
 
 _CustomUserControlViewManager.h_
 
-```c++
+```cpp
 #pragma once
 
 #include "pch.h"
@@ -346,7 +346,7 @@ struct CustomUserControlViewManager : winrt::implements<
 
 _CustomUserControlViewManager.cpp_
 
-```c++
+```cpp
 #include "pch.h"
 #include "CustomUserControlViewManager.h"
 
@@ -447,7 +447,7 @@ As with native modules, we want to register our new `CustomUserControlViewManage
 
 _ReactPackageProvider.idl_
 
-```c++
+```cpp
 namespace ViewManagerSample
 {
     [webhosthidden]
@@ -518,7 +518,7 @@ Now that we have the `ReactPackageProvider`, it's time to register it within our
 
 _App.cpp_
 
-```c++
+```cpp
 #include "pch.h"
 
 #include "App.h"


### PR DESCRIPTION
The subsection headers were a size small, making it hard to read(compared to the size up as in "Native Modules" page). 

Also, some code snippets were missing syntax highlighting, for example:
![c++1](https://user-images.githubusercontent.com/41223743/108139557-eaf7c600-7085-11eb-8b7f-dfc465ad117e.PNG)
![cppfix1](https://user-images.githubusercontent.com/41223743/108139560-ecc18980-7085-11eb-99a7-3d3e90663cfc.PNG)


