### PR TITLE
Fixing Broken Links in Documentation 

### DIFF
--- a/docs/native-modules-setup.md
+++ b/docs/native-modules-setup.md
@@ -19,8 +19,8 @@ Make sure you have installed all of the [development dependencies](rnw-dependenc
 
 Once your development environment has been correctly configured, you have several options about how to access native APIs. You can either:
 
-- [Reference the APIs directly from within a React Native for Windows project](#Referencing-Windows-APIs-within-a-React-Native-for-Windows-app-project)
-- [Create a new native module library that can be can be distributed separately from your app](#Creating-a-new-native-module-library-project)
+- [Reference the APIs directly from within a React Native for Windows project](#referencing-windows-apis-within-a-react-native-for-windows-app-project)
+- [Create a new native module library that can be can be distributed separately from your app](#creating-a-new-native-module-library-project)
 - [Add Windows support to an existing community library](#adding-windows-support-to-an-existing-library)
 
 ## Referencing Windows APIs within a React Native for Windows app project

--- a/website/versioned_docs/version-0.63/native-modules-setup.md
+++ b/website/versioned_docs/version-0.63/native-modules-setup.md
@@ -22,8 +22,8 @@ If you're planning on writing in C++, you *must* install the [C++/WinRT Visual S
 
 Once your development environment has been correctly configured, you have several options about how to access native APIs. You can either:
 
-- [Reference the APIs directly from within a React Native for Windows project](#Referencing-Windows-APIs-within-a-React-Native-for-Windows-project)
-- [Create a new native module library that can be can be distributed separately from your app](#Creating-a-new-native-module-library-project)
+- [Reference the APIs directly from within a React Native for Windows project](#referencing-windows-apis-within-a-react-native-for-windows-project)
+- [Create a new native module library that can be can be distributed separately from your app](#creating-a-new-native-module-library-project)
 - [Add Windows support to an existing community library](#adding-windows-support-to-an-existing-library)
 
 ## Referencing Windows APIs within a React Native for Windows project


### PR DESCRIPTION
Two of the links in the "Choose Your Adventure" section on the [Native Modules Setup](https://microsoft.github.io/react-native-windows/docs/next/native-modules-setup) page were broken. I fixed the links in master and 0.63