### PR TITLE
Fix missing VS dep info

### DIFF
--- a/docs/rnw-dependencies.md
+++ b/docs/rnw-dependencies.md
@@ -30,6 +30,7 @@ Alternatively, you can setup your environment manually:
 - Install [Visual Studio 2019 (version 16.5 or greater)](https://www.visualstudio.com/downloads) **with the following options checked**:
   - Workloads
     - Universal Windows Platform development
+      - Include C++ (v142) Universal Windows Platform tools (under 'Optional')
     - Desktop development with C++
     - .NET Desktop development
   - Individual Components

--- a/docs/rnw-dependencies.md
+++ b/docs/rnw-dependencies.md
@@ -30,7 +30,7 @@ Alternatively, you can setup your environment manually:
 - Install [Visual Studio 2019 (version 16.5 or greater)](https://www.visualstudio.com/downloads) **with the following options checked**:
   - Workloads
     - Universal Windows Platform development
-      - Include C++ (v142) Universal Windows Platform tools (under 'Optional')
+      - Include `C++ (v142) Universal Windows Platform tools` (under 'Optional')
     - Desktop development with C++
     - .NET Desktop development
   - Individual Components


### PR DESCRIPTION
In the list of manual installation steps, we don't mention a VS component that needs to be installed in order to build the project.