### PR TITLE
Update fix-unbroken.js to load existing file, add PR to check file is up to date

### DIFF
--- a/.github/scripts/CheckUnbrokenExclusions.ps1
+++ b/.github/scripts/CheckUnbrokenExclusions.ps1
@@ -1,0 +1,30 @@
+#
+# CheckUnbrokenExclusions.ps1 is a PowerShell script designed to check that
+# website/.unbroken_exclusions is properly configured to handle the
+# versioning system that docusaurus uses.
+
+param()
+
+Write-Host "CheckUnbrokenExclusions"
+
+[string] $WebsiteRoot = Resolve-Path "$PSScriptRoot\..\..\website"
+
+$StartingLocation = Get-Location
+Set-Location -Path $WebsiteRoot
+
+Write-Host "Running fix-unbroken"
+$YarnOutput = yarn.cmd run fix-unbroken
+
+Write-Host "Checking no files have changed"
+$GitOutput = git status --porcelain=v1
+
+$ErrorCode = 0
+
+if ($GitOutput)
+{
+    Write-Error "The website/.unbroken_exclusions file is out of sync. Please run 'yarn run fix-unbroken' in the website directory and commit the changes."
+    $ErrorCode = 1
+}
+
+Set-Location -Path $StartingLocation
+exit $ErrorCode

--- a/.github/workflows/website-pr.yml
+++ b/.github/workflows/website-pr.yml
@@ -17,19 +17,27 @@ jobs:
     steps:
     - name: Git Checkout
       uses: actions/checkout@v2
+
     - name: Spell-check docs
       run: npx markdown-spellcheck "docs\*.md" "!docs\*-api-windows.md" --en-us --ignore-acronyms --ignore-numbers --report
+
+    - name: Check unbroken exclusions file
+      run: ${{github.workspace}}\.github\scripts\CheckUnbrokenExclusions.ps1
+
     - name: Check for Broken Links (Docs)
       run: npx unbroken --parse-ids
       working-directory: ./docs
+
     - name: Check for Broken Links (Website)
       if: success() || failure()
       run: npx unbroken --parse-ids
       working-directory: ./website
+
     - name: Yarn Install (Website)
       if: success() || failure()
       run: yarn install --frozen-lockfile
       working-directory: ./website
+
     - name: Yarn Build (Website)
       run: yarn build
       working-directory: ./website

--- a/website/.unbroken_exclusions
+++ b/website/.unbroken_exclusions
@@ -3,6 +3,7 @@
 !blog/2020-*
 !versioned_docs/version-0.63/*-api-windows*.md
 
+#fix-unbroken.js auto-generated do not edit this line or below
 File not found native-modules.md while parsing versioned_docs/version-0.63/getting-started.md
 File not found rnw-dependencies.md while parsing versioned_docs/version-0.63/getting-started.md
 File not found native-modules.md while parsing versioned_docs/version-0.63/getting-started.md

--- a/website/fix-unbroken.js
+++ b/website/fix-unbroken.js
@@ -66,8 +66,8 @@ var exclusions = [];
 // Load existing base exclusions
 const existingExclusions = fs.readFileSync('.unbroken_exclusions').toString().split(/\r?\n/) || [];
 
-for (var i = 0; i < existingExclusions.length; i++) {
-    const exclusion = existingExclusions[i].trim();
+for (let exclusion of existingExclusions) {
+    exclusion = exclusion.trim();
 
     if (exclusion === '') {
         exclusions.push(exclusion);

--- a/website/fix-unbroken.js
+++ b/website/fix-unbroken.js
@@ -63,11 +63,24 @@ console.log('Generating exclusions...');
 
 var exclusions = [];
 
-// Base exclusions
-exclusions.push(normalizePath('!node_modules'));
-exclusions.push(normalizePath('!blog\\2019-*'));
-exclusions.push(normalizePath('!blog\\2020-*'));
-exclusions.push('');
+// Load existing base exclusions
+const existingExclusions = fs.readFileSync('.unbroken_exclusions').toString().split(/\r?\n/) || [];
+
+for (var i = 0; i < existingExclusions.length; i++) {
+    const exclusion = existingExclusions[i].trim();
+
+    if (exclusion === '') {
+        exclusions.push(exclusion);
+    }
+    else if (exclusion.startsWith('#fix-unbroken.js')) {
+        exclusions.push(exclusion);
+        break;
+    }
+    else
+    {
+        exclusions.push(normalizePath(exclusion));
+    }
+}
 
 // Redirected files exclusions
 redirectedFiles.forEach(redirectedFile => {


### PR DESCRIPTION
Docusarus rewrites the relative URLs for markdown files, but not for assets. This causes unbroken to freak out. So we have the fix-unbroken.js script to generate an exclusions file so unbroken only catches "real" unbroken links.

The script should be run any time someone changes links, add/removed markdown files or assets, etc, however people constantly forget, and their PR fails. Or users add exclusions manually to the file, and then the script overwrites them the next time it's run.

This PR updates fix-unbroken.js to read in the list of statically define exclusions from the existing file and keep them in the newly generated file. It also adds a check to the Website PR to make sure that the file is up to date, and more specifically, give a useful error message so people re-run the script.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/405)