### PR TITLE
Update description of "--overwrite" flag

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,7 +36,7 @@ Lastly, install the React Native for Windows packages.
 npx react-native-windows-init --overwrite
 ```
 
-> The --overwrite flag is a temporary measure that ensures the correct files are copied to `metro.config.js` for the metro bundler to work with Windows. If you are starting a new app, this should have no impact. If you are adding Windows to your existing app and you have modified the `metro.config.js` file, please back up your changes, run the command and copy over to take effect. We are tracking [this issue here](https://github.com/microsoft/react-native-windows/issues/4698).
+> The --overwrite flag copies a custom `metro.config.js` file. If you are starting a new app, this should have no impact. If you are adding Windows to your existing app and you have modified the `metro.config.js` file, please back up your changes, run the command and copy over to take effect.
 
 Here are the options that `react-native-windows-init` takes:
 | Option          | Input Type                                  | Description                                      |


### PR DESCRIPTION
The referenced issue is no longer re levant, but we still use a windows specific blocklist. Remove the stale issue, and fix some typos.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/406)