### PR TITLE
Describe `UIDispatcher`'s usage in the Using Asynchronous Windows APIs document

### DIFF
--- a/docs/native-modules-async.md
+++ b/docs/native-modules-async.md
@@ -312,7 +312,7 @@ Since the `FileOpenPicker` API requires running on the UI thread, we need to wra
     });
   }
 ```
-> **Note:** `UIDispatcher` is available via the `ReactContext`, which we can inject through a method marked as [`ReactInitializer`](native-modules-advanced.md#c-native-modules-with-initializer-and-as-a-way-to-access-reactcontex)
+> **Note:** `UIDispatcher` is available via the `ReactContext`, which we can inject through a method marked as [`ReactInitializer`](native-modules-advanced.md#c-native-modules-with-initializer-and-as-a-way-to-access-reactcontext)
 > ```cs
 >  [ReactInitializer]
 >  public void Initialize(ReactContext reactContext)

--- a/docs/native-modules-async.md
+++ b/docs/native-modules-async.md
@@ -260,16 +260,16 @@ That's it! If you want to see the complete `SimpleHttpModule`, see [`AsyncMethod
 
 ## Executing calls to API on the UI thread
 
-Since version 0.64 the native module's code no longer runs on the UI thread. It means that each call to the API that should be executed on the UI thread now needs to be explicitly dispatched.
+Since version 0.64, calls to native modules longer run on the UI thread. This means that each call to the APIs that must be executed on the UI thread now needs to be explicitly dispatched.
 
-To do that the [UIDispatcher](https://microsoft.github.io/react-native-windows/docs/IReactDispatcher) should be used.
+To do that the [`UIDispatcher`](https://microsoft.github.io/react-native-windows/docs/IReactDispatcher) should be used.
 
-This part will cover the basic usage scenario of the `UIDispatcher` and its `Post()` method with the *FileOpenPicker* (for the explanation of opening files and folder with a picker on UWP please check the [Open files and folders with a picker](https://docs.microsoft.com/en-us/windows/uwp/files/quickstart-using-file-and-folder-pickers)).
+This section will cover the basic usage scenario of the `UIDispatcher` and its `Post()` method with the WinRT `FileOpenPicker` (for a description of opening files and folder with a picker on UWP please see the [Open files and folders with a picker](https://docs.microsoft.com/en-us/windows/uwp/files/quickstart-using-file-and-folder-pickers)).
 
 ### Using `UIDispatcher` with C#
 
-Let's suppose we have a native module which opens a file using the *FileOpenPicker*.  
-Following the official example the native module's method launching the picker would look like the following:
+Let's suppose we have a native module which opens a file using the `FileOpenPicker`.  
+Following the official example the native module's method launching the picker would look like this:
 
 ```cs
   [ReactMethod("openFile")]
@@ -289,15 +289,15 @@ Following the official example the native module's method launching the picker w
     }
   }
 ```
-However, since v0.64 this method would end up with `System.Exception: Invalid window handle`.
-So to avoid that, we need to wrap this call with the `UIDispatcher.Post` method.
+However, starting with react-native-windows 0.64, this method would end up with `System.Exception: Invalid window handle`.
+Since the `FileOpenPicker` API requires running on the UI thread, we need to wrap this call with the `UIDispatcher.Post` method.
 
-> **Note:** `UIDispatcher` is available via the `ReactContext`, which we can inject through a method marked as `ReactInitializer`:
+> **Note:** `UIDispatcher` is available via the `ReactContext`, which we can inject through a method marked as [`ReactInitializer`](native-modules-advanced.md#c-native-modules-with-initializer-and-as-a-way-to-access-reactcontex)
 > ```cs
 >  [ReactInitializer]
->  public void Initialize( ReactContext reactContext )
+>  public void Initialize(ReactContext reactContext)
 >  {
->      context = reactContext;
+>    context = reactContext;
 >  }
 >```
 
@@ -335,8 +335,8 @@ Now if we call the `openFile` method in our JS code the file picker's window wil
 
 ### Using `UIDispatcher` with C++/WinRT
 
-Let's suppose we have the native module which opens and loads the file using the *FileOpenPicker*.  
-Following the official example the native module's method launching the picker would look like:
+Let's suppose we have the native module which opens and loads the file using the `FileOpenPicker`.  
+Following the official example the native module's method launching the picker would look like this:
 
 ```cpp
   REACT_METHOD( OpenFile, L"openFile" );
@@ -356,10 +356,10 @@ Following the official example the native module's method launching the picker w
     }
   }
 ```
-However, since v0.64 this method would end up with `ERROR_INVALID_WINDOW_HANDLE`.
-So to avoid that, we need to wrap this call with the `UIDispatcher.Post` method.
+However, starting with react-native-windows 0.64, this method would end up with `ERROR_INVALID_WINDOW_HANDLE`.
+Since the `FileOpenPicker` API requires running on the UI thread, we need to wrap this call with the `UIDispatcher.Post` method.
 
-> **Note:** `UIDispatcher` is available via the `ReactContext`, which we can inject through a method marked as `REACT_METHOD`:
+> **Note:** `UIDispatcher` is available via the `ReactContext`, which we can inject through a method marked as [`REACT_METHOD`](native-modules-advanced.md#c-native-modules-with-initializer-and-as-a-way-to-access-reactcontex)
 > ```cpp
 >  REACT_INIT(Initialize);
 >  void Initialize(const winrt::Microsoft::ReactNative::ReactContext& reactContext) noexcept

--- a/docs/native-modules-async.md
+++ b/docs/native-modules-async.md
@@ -369,7 +369,7 @@ Since the `FileOpenPicker` API requires running on the UI thread, we need to wra
     });
   }
 ```
-> **Note:** `UIDispatcher` is available via the `ReactContext`, which we can inject through a method marked as [`REACT_METHOD`](native-modules-advanced.md#c-native-modules-with-initializer-and-as-a-way-to-access-reactcontex)
+> **Note:** `UIDispatcher` is available via the `ReactContext`, which we can inject through a method marked as [`REACT_METHOD`](native-modules-advanced.md#c-native-modules-with-initializer-and-as-a-way-to-access-reactcontext)
 > ```cpp
 >  REACT_INIT(Initialize);
 >  void Initialize(const winrt::Microsoft::ReactNative::ReactContext& reactContext) noexcept

--- a/docs/native-modules-async.md
+++ b/docs/native-modules-async.md
@@ -257,3 +257,15 @@ We've defined an `AsyncActionCompletedHandler` lambda and set it to be run when 
 > **Important:** This example shows the minimum case, where you don't handle any errors within `GetHttpResponseAsync`, but you're not limited to this. You're free to detect error conditions within your code and call `capturedPromise.Reject()` yourself with (more useful) error messages at any time. However you should *always* include this final handler, to catch any unexpected and unhandled exceptions that may occur, especially when calling Windows APIs. Just be sure that you only call `Reject()` once and that nothing executes afterwards.
 
 That's it! If you want to see the complete `SimpleHttpModule`, see [`AsyncMethodExamples.h`](https://github.com/microsoft/react-native-windows-samples/blob/master/samples/NativeModuleSample/cppwinrt/windows/NativeModuleSample/AsyncMethodExamples.h).
+
+## Executing calls to API on the UI thread
+
+From version 0.64 the native module's code does no longer run on the UI thread. It means that each call to the API that should be executed on the UI thread now needs to be explicitly dispatched.
+
+To do that the [UIDispatcher](https://microsoft.github.io/react-native-windows/docs/IReactDispatcher) should be used.
+
+This part will cover the basic usage scenario of the `UIDispatcher` and it's `Post()` method with the *FileOpenPicker* (for the explanation of opening files and folder with a picker on UWP please check the [Open files and folders with a picker](https://docs.microsoft.com/en-us/windows/uwp/files/quickstart-using-file-and-folder-pickers)).
+
+### Using `UIDispatcher` with C#
+
+### Using `UIDispatcher` with C++/WinRT

--- a/docs/native-modules-async.md
+++ b/docs/native-modules-async.md
@@ -329,7 +329,7 @@ Let's suppose we have the native module which opens and loads the file using the
 Following the official example the native module's method launching the picker would look like this:
 
 ```cpp
-  REACT_METHOD( OpenFile, L"openFile" );
+  REACT_METHOD(OpenFile, L"openFile");
   winrt::fire_and_forget OpenFile() noexcept
   {
     winrt::Windows::Storage::Pickers::FileOpenPicker openPicker;
@@ -350,7 +350,7 @@ However, starting with react-native-windows 0.64, this method would end up with 
 Since the `FileOpenPicker` API requires running on the UI thread, we need to wrap this call with the `UIDispatcher.Post` method.
 
 ```cpp
-  REACT_METHOD(OpenFile, L"openFile" );
+  REACT_METHOD(OpenFile, L"openFile");
   void OpenFile() noexcept
   {
     context.UIDispatcher().Post([]()->winrt::fire_and_forget {
@@ -374,7 +374,7 @@ Since the `FileOpenPicker` API requires running on the UI thread, we need to wra
 >  REACT_INIT(Initialize);
 >  void Initialize(const winrt::Microsoft::ReactNative::ReactContext& reactContext) noexcept
 >  {
->      context = reactContext;
+>    context = reactContext;
 >  }
 >```
 

--- a/docs/native-modules-async.md
+++ b/docs/native-modules-async.md
@@ -260,7 +260,7 @@ That's it! If you want to see the complete `SimpleHttpModule`, see [`AsyncMethod
 
 ## Executing calls to API on the UI thread
 
-Since version 0.64, calls to native modules longer run on the UI thread. This means that each call to the APIs that must be executed on the UI thread now needs to be explicitly dispatched.
+Since version 0.64, calls to native modules no longer run on the UI thread. This means that each call to the APIs that must be executed on the UI thread now needs to be explicitly dispatched.
 
 To do that the [`UIDispatcher`](https://microsoft.github.io/react-native-windows/docs/IReactDispatcher) should be used.
 

--- a/docs/native-modules-async.md
+++ b/docs/native-modules-async.md
@@ -260,16 +260,16 @@ That's it! If you want to see the complete `SimpleHttpModule`, see [`AsyncMethod
 
 ## Executing calls to API on the UI thread
 
-From version 0.64 the native module's code does no longer run on the UI thread. It means that each call to the API that should be executed on the UI thread now needs to be explicitly dispatched.
+Since version 0.64 the native module's code no longer runs on the UI thread. It means that each call to the API that should be executed on the UI thread now needs to be explicitly dispatched.
 
 To do that the [UIDispatcher](https://microsoft.github.io/react-native-windows/docs/IReactDispatcher) should be used.
 
-This part will cover the basic usage scenario of the `UIDispatcher` and it's `Post()` method with the *FileOpenPicker* (for the explanation of opening files and folder with a picker on UWP please check the [Open files and folders with a picker](https://docs.microsoft.com/en-us/windows/uwp/files/quickstart-using-file-and-folder-pickers)).
+This part will cover the basic usage scenario of the `UIDispatcher` and its `Post()` method with the *FileOpenPicker* (for the explanation of opening files and folder with a picker on UWP please check the [Open files and folders with a picker](https://docs.microsoft.com/en-us/windows/uwp/files/quickstart-using-file-and-folder-pickers)).
 
 ### Using `UIDispatcher` with C#
 
-Let's suppose we have the native module which opens and loads the file using the *FileOpenPicker*.  
-Following the official example the native module's method launching the picker would look like:
+Let's suppose we have a native module which opens a file using the *FileOpenPicker*.  
+Following the official example the native module's method launching the picker would look like the following:
 
 ```cs
   [ReactMethod("openFile")]
@@ -289,10 +289,10 @@ Following the official example the native module's method launching the picker w
     }
   }
 ```
-However, from 0.64 this method would end up with `System.Exception: Invalid window handle`.
+However, since v0.64 this method would end up with `System.Exception: Invalid window handle`.
 So to avoid that, we need to wrap this call with the `UIDispatcher.Post` method.
 
-> **Note:** `UIDispatcher` is available via the `ReactContext`, which we should get as a `ReactInitializer` method:
+> **Note:** `UIDispatcher` is available via the `ReactContext`, which we can inject through a method marked as `ReactInitializer`:
 > ```cs
 >  [ReactInitializer]
 >  public void Initialize( ReactContext reactContext )
@@ -302,7 +302,7 @@ So to avoid that, we need to wrap this call with the `UIDispatcher.Post` method.
 >```
 
 To do it, let's
-1. separate the file's opening and handling from the UI thread logic, by moving this logic to the private method:
+1. Separate the file's opening and handling from the UI thread logic, by moving this logic to the private method:
 ```cs
   private async void LaunchPicker()
   {
@@ -325,7 +325,9 @@ To do it, let's
   [ReactMethod("openFile")]
   public void OpenFile()
   {
-      context.Handle.UIDispatcher.Post(() => LaunchPicker());
+      context.Handle.UIDispatcher.Post(
+        () => LaunchPicker()
+      );
   }
 ```
 
@@ -354,10 +356,10 @@ Following the official example the native module's method launching the picker w
     }
   }
 ```
-However, from 0.64 this method would end up with `ERROR_INVALID_WINDOW_HANDLE`.
+However, since v0.64 this method would end up with `ERROR_INVALID_WINDOW_HANDLE`.
 So to avoid that, we need to wrap this call with the `UIDispatcher.Post` method.
 
-> **Note:** `UIDispatcher` is available via the `ReactContext`, which we should get as a `REACT_INIT` method:
+> **Note:** `UIDispatcher` is available via the `ReactContext`, which we can inject through a method marked as `REACT_METHOD`:
 > ```cpp
 >  REACT_INIT(Initialize);
 >  void Initialize(const winrt::Microsoft::ReactNative::ReactContext& reactContext) noexcept
@@ -367,9 +369,9 @@ So to avoid that, we need to wrap this call with the `UIDispatcher.Post` method.
 >```
 
 To do it, let's
-1. separate the file's opening and handling from the UI thread logic, by moving this logic to the private method:
+1. Separate the file's opening and handling from the UI thread logic, by moving this logic to the private method:
 ```cpp
-  winrt::fire_and_forget OpenFile() noexcept
+  winrt::fire_and_forget LaunchPicker() noexcept
   {
     winrt::Windows::Storage::Pickers::FileOpenPicker openPicker;
     // Other initialization code


### PR DESCRIPTION
This pull request fixes #427 

It describes the usage of `UIDispatcher.Post()` method in the basic scenarios for both C# and C++.

---

The description contains the brief introduction explaining why is it necessary to use the `UIDispatcher` and points to the decs about `IReactDispatcher` and *FileOpenPicker* used in these examples (to avoid confusions and to present the control that's related to the UI thread).

There are both C# and C++ examples, both having the same descriptions and steps in them.

Note that the code for launching and handling the *FileOpenPicker* is as basic as it can be. It is not the part of this guide to explain the file handling in details. For more curious readers I've linked the official docs about it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/428)