### PR TITLE
Restore NuGet page

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -37,7 +37,7 @@
     ],
     "Experimental" : [
       "hermes",
-      "nuget",
+      "NuGet",
       "nuget-update",
       "winui3"
     ]


### PR DESCRIPTION
Adds back the NuGet page - Docusaurus is case sensitive wrt page IDs and we recently changed the casing of the ID to make spell checking happy

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/431)