### PR TITLE
Fix: `--module-name` is no longer supported in `create-react-native-module`

### DIFF
--- a/docs/native-modules-setup.md
+++ b/docs/native-modules-setup.md
@@ -41,7 +41,9 @@ The steps to create a new native module library project are:
 
 ### Creating a blank native module project
 
-Follow the official React Native instructions at https://reactnative.dev/docs/native-modules-setup.
+Follow the official React Native instructions at https://reactnative.dev/docs/native-modules-setup,
+
+or execute the following commands:
 
 ```bat
 npx create-react-native-module NativeModuleSample

--- a/docs/native-modules-setup.md
+++ b/docs/native-modules-setup.md
@@ -44,7 +44,7 @@ The steps to create a new native module library project are:
 Follow the official React Native instructions at https://reactnative.dev/docs/native-modules-setup.
 
 ```bat
-npx create-react-native-module --module-name "NativeModuleSample" NativeModuleSample
+npx create-react-native-module NativeModuleSample
 cd NativeModuleSample
 yarn install
 ```


### PR DESCRIPTION
This pull request removes the `--module-name` option from the example of creating the native module library project using the [create-react-native-module](https://github.com/brodybits/create-react-native-module) library.

The `--module-name` option has been renamed to `--package-name` in [PR#431](https://github.com/brodybits/create-react-native-module/pull/431), moreover it is optional to use, as it defaults to the name given in the parameter.

---

Another change introduced in this pull request is the separation of following official React Native instructions from following the *bat* code steps presented below it.
React Native instructions use [callstack/react-native-builder-bob](https://github.com/callstack/react-native-builder-bob) while examples presented in these docs use [brodybits/create-react-native-module](https://github.com/brodybits/create-react-native-module).
It is important to emphasize that these two libraries are different and may (and soon will) lead to different results.

**IMPORTANT NOTE:** Within next week (24.05 - 28.05) the [callstack/react-native-builder-bob](https://github.com/callstack/react-native-builder-bob) will be provided with Windows support, which will make the further steps presented in this document unnecessary (but still necessary if *brodybits/create-react-native-module* is used instead).
Once this happens, the guide will have to be further modified, but the scope of this PR is to ensure the difference is known to user/developer and no `--module-name` option is there to increase confusion.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/440)