### PR TITLE
add note to include 1-2 Windows 10 SDK versions back

### DIFF
--- a/docs/rnw-dependencies.md
+++ b/docs/rnw-dependencies.md
@@ -30,8 +30,8 @@ Alternatively, you can setup your environment manually:
 - Install [Visual Studio 2019 (version 16.5 or greater)](https://www.visualstudio.com/downloads) **with the following options checked**:
   - Workloads
     - Universal Windows Platform development
-      - Include `C++ (v142) Universal Windows Platform tools` (under 'Optional')
-      - Include 1-2 Windows 10 SDK versions back under "Optional"
+      - Include `C++ (v142) Universal Windows Platform tools` under `Optional` drop-down list
+      - Include 1-2 Windows 10 SDK versions back under `Optional` drop-down list
     - Desktop development with C++
     - .NET Desktop development
   - Individual Components

--- a/docs/rnw-dependencies.md
+++ b/docs/rnw-dependencies.md
@@ -31,6 +31,7 @@ Alternatively, you can setup your environment manually:
   - Workloads
     - Universal Windows Platform development
       - Include `C++ (v142) Universal Windows Platform tools` (under 'Optional')
+      - Include 1-2 Windows 10 SDK versions back under "Optional"
     - Desktop development with C++
     - .NET Desktop development
   - Individual Components


### PR DESCRIPTION
in docs/rnw-dependencies.md

as needed to avoid build errors due to inconsistent Windows 10 SDK version
between react-native-windows and recent Visual Studio 2019 version

related to issue: https://github.com/microsoft/react-native-windows/issues/4960

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/443)