### PR TITLE
add `npm start` option to getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,7 +81,7 @@ This sends telemetry to Microsoft by default. You can prevent the telemetry from
     ```
   - Open the solution file in the application folder in Visual Studio (e.g., `AwesomeProject/windows/AwesomeProject.sln` if you used `AwesomeProject` as `<projectName>`)
   - Select the `Debug` configuration and the `x64` platform from the combo box controls to the left of the `Run` button and underneath the `Team` and `Tools` menu item.
-  - Run `yarn start` from your project directory, and wait for the React Native packager to report success.
+  - Run `yarn start` (or `npm start`) from your project directory, and wait for the React Native packager to report success.
   - Click the `Run` button to the right of the platform combo box control in VS, or select the `Debug`->`Start without Debugging` menu item. You now see your new app and Chrome should have loaded `http://localhost:8081/debugger-ui/` in a new tab. Press `F12` or `Ctrl+Shift+I` in Chrome to open its Developer Tools. :tada:
 
 - With VS Code


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/445)