### PR TITLE
Remove ARM from sample CI in preparation for 65 upgrade

### DIFF
--- a/.github/workflows/samples-Calculator-CI.yml
+++ b/.github/workflows/samples-Calculator-CI.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         sample: [Calculator]
-        architecture: [ARM, ARM64]
+        architecture: [ARM64]
         configuration: [Debug, Release]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/samples-Calculator-ci-upgrade.yml
+++ b/.github/workflows/samples-Calculator-ci-upgrade.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         sample: [Calculator]
-        architecture: [ARM, ARM64]
+        architecture: [ARM64]
         configuration: [Debug, Release]
         reactNativeWindowsVersion: [latest, preview, canary]
     steps:

--- a/.github/workflows/samples-CalculatorNuGet-ci.yml
+++ b/.github/workflows/samples-CalculatorNuGet-ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         sample: [CalculatorNuGet]
-        architecture: [ARM, ARM64]
+        architecture: [ARM64]
         configuration: [Debug, Release]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/samples-CameraDemo-ci-upgrade.yml
+++ b/.github/workflows/samples-CameraDemo-ci-upgrade.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         sample: [CameraDemo]
-        architecture: [ARM, ARM64]
+        architecture: [ARM64]
         configuration: [Debug, Release]
         reactNativeWindowsVersion: [latest, preview, canary]
     steps:

--- a/.github/workflows/samples-CameraDemo-ci.yml
+++ b/.github/workflows/samples-CameraDemo-ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         sample: [CameraDemo]
-        architecture: [ARM, ARM64]
+        architecture: [ARM64]
         configuration: [Debug, Release]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/samples-NativeModuleSample-CI.yml
+++ b/.github/workflows/samples-NativeModuleSample-CI.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         sample: [NativeModuleSample\cppwinrt, NativeModuleSample\csharp]
-        architecture: [x86, x64, ARM, ARM64]
+        architecture: [x86, x64, ARM64]
         configuration: [Debug, Release]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/samples-NativeModuleSample-ci-upgrade.yml
+++ b/.github/workflows/samples-NativeModuleSample-ci-upgrade.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         sample: [NativeModuleSample\cppwinrt, NativeModuleSample\csharp]
-        architecture: [x86, x64, ARM, ARM64]
+        architecture: [x86, x64, ARM64]
         configuration: [Debug, Release]
         reactNativeWindowsVersion: [latest, preview, canary]
     steps:


### PR DESCRIPTION
We no longer build ARM in 0.65, so the upgrade CI fails prematurely. This PR removes that config from our workflows so we can get a better idea of what other issues there may be upgrading to 0.65.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/458)