### PR TITLE
Fix rssreader sample build

### DIFF
--- a/.github/workflows/samples-RssReader-CI.yml
+++ b/.github/workflows/samples-RssReader-CI.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         sample: [rssreader]
-        architecture: [ARM, ARM64]
+        architecture: [ARM64]
         configuration: [Debug, Release]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/samples-RssReader-ci-upgrade.yml
+++ b/.github/workflows/samples-RssReader-ci-upgrade.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         sample: [RssReader]
-        architecture: [ARM, ARM64]
+        architecture: [ARM64]
         configuration: [Debug, Release]
         reactNativeWindowsVersion: [latest, preview, canary]
     steps:

--- a/samples/rssreader/yarn.lock
+++ b/samples/rssreader/yarn.lock
@@ -5471,9 +5471,9 @@ react-native-webview@^10.9.2:
     invariant "2.2.4"
 
 react-native-windows@^0.62.0-0:
-  version "0.62.0"
-  resolved "https://registry.yarnpkg.com/react-native-windows/-/react-native-windows-0.62.0.tgz#c2cfa83ee235bbba0823350db4271f0218733344"
-  integrity sha512-yufBtsEPDJ4V+SR76v3+2tt+hHsbOQo4X4Boc6Etu1NmEC37956WS0YAyGez6a1RTxKMky+TBvX1cVHb7THZdA==
+  version "0.62.22"
+  resolved "https://registry.yarnpkg.com/react-native-windows/-/react-native-windows-0.62.22.tgz#4c8c6544496199702180c9c7b4cd34492966c842"
+  integrity sha512-kYM+VczfDRNhs8vifa/D5ibSIGWDkVHZ8J2913HR8lPkz/qx5Tmnfq0IOj0KOMNN1ZDx4/I1PsTvfpxgOeIbvQ==
   dependencies:
     "@babel/runtime" "^7.8.4"
     cli-spinners "^2.2.0"


### PR DESCRIPTION
* Bumped react-native-windows from 0.62.0 to 0.62.22 to fix build break.
* Removed ARM from CI workflows


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/459)