### PR TITLE
Add code tabs, consolidate some content

### DIFF
--- a/docs/native-modules-jsvalue.md
+++ b/docs/native-modules-jsvalue.md
@@ -11,9 +11,10 @@ Two `JSValue` implementations are provided: one for C++ developers in the `Micro
 
 > This purpose of this document is to provide equivalency to the scenarios supported by [`folly/dynamic.h`](https://github.com/facebook/folly/blob/master/folly/docs/Dynamic.md).
 
-## Overview
+<!--DOCUSAURUS_CODE_TABS-->
+<!--C#-->
 
-### C#
+## Overview
 
 Here are some code samples to get started (assumes a `using Microsoft.ReactNative.Managed;` was used):
 
@@ -63,7 +64,88 @@ JSValue map4 = map2;
 Debug.Assert(map4.AsObject().Count == 2);
 ```
 
-### C++/WinRT
+## Runtime Type Checking and Conversions
+
+While most unsupported operations will cause compilation errors, some operations on `JSValue`s require checking at runtime that the stored type is compatible with the operation. Some operations may throw runtime exceptions or produce unexpected behavior as type conversions fail and default values are returned.
+
+More examples should hopefully clarify this:
+
+```csharp
+JSValue dint = 42;
+
+JSValue str = "foo";
+JSValue anotherStr = str + "something"; // fine
+JSValue thisDoesNotCompile = str + dint; // compilation error
+```
+
+Explicit type conversions can be requested for some of the basic types:
+
+```csharp
+JSValue dint = 12345678;
+JSValue doub = dint.AsDouble(); // doub will hold 12345678.0
+JSValue str = dint.AsString(); // str == "12345678"
+
+JSValue hugeInt = long.MaxValue; // hugeInt = 9223372036854775807
+JSValue hugeDoub = hugeInt.AsDouble(); // hugeDoub = 9.2233720368547758E+18
+```
+
+## Iteration and Lookup
+
+You can iterate over `JSValueArray`s as you would over any C# enumerable.
+
+```csharp
+JSValueArray array = new JSValueArray() { 2, 3, "foo" };
+
+foreach (var val in array)
+{
+    doSomethingWith(val);
+}
+```
+
+You can iterate over `JSValueObject`s just like any other `IDictionary<string, JSValue>`.
+
+```csharp
+JSValueObject obj = new JSValueObject() { { "2", 3}, { "hello", "world" }, { "x", 4 } };
+
+foreach (var kvp in obj)
+{
+    // Key is kvp.Key, value is kvp.Value
+    processKey(kvp.Key);
+    processValue(kvp.Value);
+}
+
+foreach (var key in obj.Keys)
+{
+    processKey(key);
+}
+
+foreach (var value in obj.Values)
+{
+    processValue(value);
+}
+```
+
+You can find an element by key in a `JSValueObject` using the `TryGetValue()` method,
+which takes the key and returns `true` if a key is present and provides the value as an out variable. If the key is not preset, it returns `false` and the out variable will be null.
+
+```csharp
+JSValueObject obj = new JSValueObject() { { "2", 3}, { "hello", "world" }, { "x", 4 } };
+
+if (obj.TryGetValue("hello", out JSValue value))
+{
+    // value is "world"
+}
+
+if (obj.TryGetValue("no_such_key", out JSValue value2))
+{
+    // this block will not be executed
+}
+// value2 is null
+```
+
+<!--C++/WinRT-->
+
+## Overview
 
 Here are some code samples to get started (assumes a `#include "JSValue.h"` was used):
 
@@ -119,29 +201,6 @@ While most unsupported operations will cause compilation errors, some operations
 
 More examples should hopefully clarify this:
 
-### C#
-
-```csharp
-JSValue dint = 42;
-
-JSValue str = "foo";
-JSValue anotherStr = str + "something"; // fine
-JSValue thisDoesNotCompile = str + dint; // compilation error
-```
-
-Explicit type conversions can be requested for some of the basic types:
-
-```csharp
-JSValue dint = 12345678;
-JSValue doub = dint.AsDouble(); // doub will hold 12345678.0
-JSValue str = dint.AsString(); // str == "12345678"
-
-JSValue hugeInt = long.MaxValue; // hugeInt = 9223372036854775807
-JSValue hugeDoub = hugeInt.AsDouble(); // hugeDoub = 9.2233720368547758E+18
-```
-
-### C++/WinRT
-
 ```c++
 JSValue dint = 42;
 
@@ -166,61 +225,6 @@ JSValue hugeDoub = hugeInt.AsDouble();
 
 ## Iteration and Lookup
 
-### C#
-
-You can iterate over `JSValueArray`s as you would over any C# enumerable.
-
-```csharp
-JSValueArray array = new JSValueArray() { 2, 3, "foo" };
-
-foreach (var val in array)
-{
-    doSomethingWith(val);
-}
-```
-
-You can iterate over `JSValueObject`s just like any other `IDictionary<string, JSValue>`.
-
-```csharp
-JSValueObject obj = new JSValueObject() { { "2", 3}, { "hello", "world" }, { "x", 4 } };
-
-foreach (var kvp in obj)
-{
-    // Key is kvp.Key, value is kvp.Value
-    processKey(kvp.Key);
-    processValue(kvp.Value);
-}
-
-foreach (var key in obj.Keys)
-{
-    processKey(key);
-}
-
-foreach (var value in obj.Values)
-{
-    processValue(value);
-}
-```
-
-You can find an element by key in a `JSValueObject` using the `TryGetValue()` method,
-which takes the key and returns `true` if a key is present and provides the value as an out variable. If the key is not preset, it returns `false` and the out variable will be null.
-
-```csharp
-JSValueObject obj = new JSValueObject() { { "2", 3}, { "hello", "world" }, { "x", 4 } };
-
-if (obj.TryGetValue("hello", out JSValue value))
-{
-    // value is "world"
-}
-
-if (obj.TryGetValue("no_such_key", out JSValue value2))
-{
-    // this block will not be executed
-}
-// value2 is null
-```
-
-### C++/WinRT
 
 You can iterate over `JSValueArray`s as you would over any C++ sequence container.
 
@@ -259,6 +263,8 @@ auto pos = obj.find("hello");
 auto pos = obj.find("no_such_key");
 // pos == obj.end()
 ```
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ## Use for JSON
 

--- a/docs/native-modules.md
+++ b/docs/native-modules.md
@@ -37,8 +37,10 @@ Once you have set up your development environment and project structure, you are
 
 Open the Visual Studio solution in the `windows` folder and add the new files directly to the app project.
 
-## Sample Native Module (C#)
+## Sample Native Module
+<!--DOCUSAURUS_CODE_TABS-->
 
+<!--C#-->
 ### Attributes
 
 | Attribute               | Use                                                       |
@@ -102,6 +104,7 @@ The `[ReactMethod]` attribute is how you define methods. In `FancyMath` we have 
 
 The `[ReactEvent]` attribute is how you define events. In `FancyMath` we have one event, `AddEvent`, which uses the `ReactEvent<double>` delegate, where the double represents the type of the event data. Now whenever we invoke the `AddEvent` delegate in our native code (as we do above), an event named `"AddEvent"` will be raised in JavaScript. As before, you could have optionally customized the name in JS like this: `[ReactEvent("addEvent")]`.
 
+
 ### 2. Registering your Native Module
 
 > IMPORTANT NOTE: When you create a new project via the CLI, the generated `ReactApplication` class will automatically register all native modules defined within the app. **You will not need to manually register native modules that are defined within your app's scope, as they will be registered automatically.**
@@ -155,77 +158,7 @@ This example assumes that the `NativeModuleSample.ReactPackageProvider` we creat
 
 The `Microsoft.ReactNative.Managed.ReactPackageProvider` is a convenience that makes sure that all native modules and view managers defined within the app project automatically get registered. So if you're creating your native modules directly within the app project, you won't actually want to define a separate `ReactPackageProvider`.
 
-### 3. Using your Native Module in JS
-
-Now we have a Native Module which is registered with React Native Windows. How do we access it in JS? Here's a simple RN app:
-
-`NativeModuleSample.js`:
-
-```js
-import React, { Component } from 'react';
-import {
-  AppRegistry,
-  Alert,
-  Text,
-  View,
-} from 'react-native';
-
-import { NativeModules, NativeEventEmitter } from 'react-native';
-
-const FancyMathEventEmitter = new NativeEventEmitter(NativeModules.FancyMath);
-
-class NativeModuleSample extends Component {
-
-  componentDidMount() {
-    // Subscribing to FancyMath.AddEvent
-    FancyMathEventEmitter.addListener('AddEvent', eventHandler, this);
-  }
-
-  componentWillUnmount() {
-    // Unsubscribing from FancyMath.AddEvent
-    FancyMathEventEmitter.removeListener('AddEvent', eventHandler, this);
-  }
-
-  eventHandler(result) {
-    console.log("Event was fired with: " + result);
-  }
-
-  _onPressHandler() {
-    // Calling FancyMath.add method
-    NativeModules.FancyMath.add(
-      /* arg a */ NativeModules.FancyMath.Pi,
-      /* arg b */ NativeModules.FancyMath.E,
-      /* callback */ function (result) {
-        Alert.alert(
-          'FancyMath',
-          `FancyMath says ${NativeModules.FancyMath.Pi} + ${NativeModules.FancyMath.E} = ${result}`,
-          [{ text: 'OK' }],
-          {cancelable: false});
-      });
-  }
-
-  render() {
-    return (
-      <View>
-         <Text>FancyMath says PI = {NativeModules.FancyMath.Pi}</Text>
-         <Text>FancyMath says E = {NativeModules.FancyMath.E}</Text>
-         <Button onPress={this._onPressHandler} title="Click me!"/>
-      </View>);
-  }
-}
-
-AppRegistry.registerComponent('NativeModuleSample', () => NativeModuleSample);
-```
-
-To access your native modules, you need to import `NativeModules` from `react-native`. All of the native modules registered with your host application (including both the built-in ones that come with React Native for Windows in addition to the ones you've added) are available as members of `NativeModules`. Since our native modules fires events, we're also bringing in `NativeEventEmitter`.
-
-To access our `FancyMath` constants, we can simply call `NativeModules.FancyMath.E` and `NativeModules.FancyMath.Pi`.
-
-Calls to methods are a little different due to the asynchronous nature of the JS engine. If the native method returns nothing, we can simply call the method. However, in this case `FancyMath.add()` returns a value, so in addition to the two necessary parameters we also include a callback function which will be called with the result of `FancyMath.add()`. In the example above, we can see that the callback raises an Alert dialog with the result value.
-
-For events, you'll see that we created an instance of `NativeEventEmitter` passing in our `NativeModules.FancyMath` module, and called it `FancyMathEventEmitter`. We can then use the `FancyMathEventEmitter.addListener()` and `FancyMathEventEmitter.removeListener()` methods to subscribe to our `FancyMath.AddEvent`. In this case, when `AddEvent` is fired in the native code, `eventHandler` will get called, which logs the result to the console log.
-
-## Sample Native Module (C++)
+<!-- C++ -->
 
 > NOTE: C++ does not have custom attributes and reflection as C#. Instead we use macros to simulate use of custom attributes and C++ templates to implement the binding. The binding is done during compilation time and there is virtually no overhead at runtime.
 
@@ -446,6 +379,13 @@ This example assumes that the `NativeModuleSample::ReactPackageProvider` we crea
 
 The `SampleApp::ReactPackageProvider` is a convenience that makes sure that all native modules and view managers defined within the app project automatically get registered. So if you're creating your native modules directly within the app project, you won't actually want to define a separate `ReactPackageProvider`.
 
+
+### JavaScript and Windows Runtime strings
+Note that JavaScript strings are UTF8 (i.e. `std::string`) but WinRT strings are UTF16 (i.e. `winrt::hstring` in C++/WinRT), so when inter-operating between JavaScript and WinRT APIs, you will need to convert between these two encodings.
+See [String handling in C++/WinRT](https://docs.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/strings), specifically [`winrt::to_string`](https://docs.microsoft.com/uwp/cpp-ref-for-winrt/to-string) and [`winrt::to_hstring`](https://docs.microsoft.com/uwp/cpp-ref-for-winrt/to-hstring).
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
 ### 3. Using your Native Module in JS
 
 Now we have a Native Module which is registered with React Native Windows. How do we access it in JS? Here's a simple RN app:
@@ -514,8 +454,9 @@ To access our `FancyMath` constants, we can simply call `NativeModules.FancyMath
 
 Calls to methods are a little different due to the asynchronous nature of the JS engine. If the native method returns nothing, we can simply call the method. However, in this case `FancyMath.add()` returns a value, so in addition to the two necessary parameters we also include a callback function which will be called with the result of `FancyMath.add()`. In the example above, we can see that the callback raises an Alert dialog with the result value.
 
-For events, you'll see that we created an instance of `NativeEventEmitter` passing in our `NativeModules.FancyMath` module, and called it `FancyMathEventEmitter`. We can then use the `FancyMathEventEmitter.addListener()` and `FancyMathEventEmitter.removeListener()` methods to subscribe to our `FancyMath::AddEvent`. In this case, when `AddEvent` is fired in the native code, `eventHandler` will get called, which logs the result to the console log.
+For events, you'll see that we created an instance of `NativeEventEmitter` passing in our `NativeModules.FancyMath` module, and called it `FancyMathEventEmitter`. We can then use the `FancyMathEventEmitter.addListener()` and `FancyMathEventEmitter.removeListener()` methods to subscribe to our `FancyMath.AddEvent`. In this case, when `AddEvent` is fired in the native code, `eventHandler` will get called, which logs the result to the console log.
 
-### JavaScript and Windows Runtime strings
-Note that JavaScript strings are UTF8 (i.e. `std::string`) but WinRT strings are UTF16 (i.e. `winrt::hstring` in C++/WinRT), so when inter-operating between JavaScript and WinRT APIs, you will need to convert between these two encodings.
-See [String handling in C++/WinRT](https://docs.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/strings), specifically [`winrt::to_string`](https://docs.microsoft.com/uwp/cpp-ref-for-winrt/to-string) and [`winrt::to_hstring`](https://docs.microsoft.com/uwp/cpp-ref-for-winrt/to-hstring).
+
+
+
+

--- a/docs/nuget.md
+++ b/docs/nuget.md
@@ -29,7 +29,9 @@ When you enable react-native-windows on your new project, you can pass `--experi
 Of course all the other flags still work.
 
 # How to update a previously created project
-## C# projects
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--C# projects-->
 1. Add a NuGet configuration file `NuGet.config` in the `windows` folder next to the `.sln` file
    ```xml
    <?xml version="1.0" encoding="utf-8"?>
@@ -66,7 +68,7 @@ Of course all the other flags still work.
 
 1. Update the C# logic for the new [compile-time C# codeGen](native-modules-csharp-codegen.md)
 
-## C++ projects
+<!--C++ projects-->
 1. Update the solution file `windows\<projectName>.sln`:
    1. Open the project in Visual Studio
    1. Remove all projects that are not your project
@@ -84,6 +86,8 @@ Of course all the other flags still work.
 
       C++ packages do not support `PackageReference` so it is not recommended to manually add these dependencies to the project file, instead add the dependencies via the Visual Studio IDE.
       > Note: You'll need to match the NuGet version with the npm version
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 # Version match
 The versions of the NuGet package in your project must match the npm package version. If you need to update the NuGet packages there is a separate page on [Updating NuGet packages](nuget-update.md)

--- a/docs/view-managers.md
+++ b/docs/view-managers.md
@@ -44,7 +44,10 @@ Then you can simply open the Visual Studio solution in the `windows` folder and 
 
 If you are instead creating a standalone native module, or adding Windows support to an existing native module, check out the [Native Modules Setup](native-modules-setup.md) guide first.
 
-## Sample view manager (C#)
+## Sample view manager
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--C#-->
 
 ### Attributes
 
@@ -240,14 +243,14 @@ The `Microsoft.ReactNative.Managed.ReactPackageProvider` is a convenience that m
 ### More extensibility points
 
 - In some scenarios, a view manager might need to have more context at view creation time in order to decide what kind of control to instantiate.
-This can be achieved by having the view manager implement the `IViewManagerCreateWithProperties` interface. The `CreateWithProperties` method can then access the properties set in JSX by inspecting the `propertyMapReader`.
+This can be achieved by having the view manager implement the [`IViewManagerCreateWithProperties`](IViewManagerCreateWithProperties) interface. The `CreateViewWithProperties` method can then access the properties set in JSX by inspecting the `propertyMapReader`.
 
 ```diff
 -internal class CustomUserControlViewManager : AttributedViewManager<CustomUserControl> {
 +internal class CustomUserControlViewManager : AttributedViewManager<CustomUserControl>, IViewManagerCreateWithProperties {
 // rest of the view manager goes here...
 +  // IViewManagerCreateWithProperties
-+  public virtual object CreateWithProperties(Microsoft.ReactNative.IJSValueReader propertyMapReader) {
++  public virtual object CreateViewWithProperties(Microsoft.ReactNative.IJSValueReader propertyMapReader) {
 +    propertyMapReader.ReaderValue(out IDictionary<string, JSValue> propertyMap);
 +    // create a XAML FrameworkElement based on properties in propertyMap
 +    if (propertyMap.ContainsKey("foo)) { 
@@ -271,62 +274,7 @@ This is useful in scenarios where you are wrapping a native XAML control. To do 
 +   virtual bool RequiresNativeLayout() { return true; }
 ```
 
-
-### 3. Using your View Manager in JSX
-
-`ViewManagerSample.js`:
-
-```js
-import React, { Component } from 'react';
-import {
-  AppRegistry,
-  Button,
-  requireNativeComponent,
-  StyleSheet,
-  UIManager,
-  View,
-} from 'react-native';
-
-let CustomUserControl = requireNativeComponent('CustomUserControl');
-
-class ViewManagerSample extends Component {
-  onPress() {
-    if (_customControlRef) {
-      const tag = findNodeHandle(this._customControlRef);
-      UIManager.dispatchViewManagerCommand(tag, UIManager.getViewManagerConfig('CustomUserControl').Commands.CustomCommand, ['arg1', 'arg2']);
-    }
-  }
-
-  render() {
-    return (
-      <View style={styles.container}>
-         <CustomUserControl style={styles.customcontrol} label="CustomUserControl!" ref={(ref) => { this._customControlRef = ref; }} />
-         <Button onPress={() => { this.onPress(); }} title="Call CustomUserControl Commands!" />
-      </View>);
-  }
-}
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F5FCFF',
-  },
-  customcontrol: {
-    color: '#333333',
-    backgroundColor: '#006666',
-    width: 200,
-    height: 20,
-    margin: 10,
-  },
-});
-
-AppRegistry.registerComponent('ViewManagerSample', () => ViewManagerSample);
-```
-
-## Sample view manager (C++)
-
+<!--C++-->
 For this sample, assume we already have the `CustomUserControl` defined in the C# example.
 
 ### 1. Authoring your View Manager
@@ -520,7 +468,7 @@ void CustomUserControlViewManager::ReactContext(IReactContext reactContext) noex
 ### More extensibility points
 
 - In some scenarios, a view manager might need to have more context at view creation time in order to decide what kind of control to instantiate.
-This can be achieved by having the view manager implement the `IViewManagerCreateWithProperties` interface:
+This can be achieved by having the view manager implement the [`IViewManagerCreateWithProperties`](IViewManagerCreateWithProperties) interface:
 ```diff
 struct CustomUserControlViewManager : winrt::implements<
                                              CustomUserControlViewManager,
@@ -531,9 +479,9 @@ struct CustomUserControlViewManager : winrt::implements<
 +                                             winrt::Microsoft::ReactNative::IViewManagerCreateWithProperties,
                                              winrt::Microsoft::ReactNative::IViewManagerWithReactContext> {
 +  // IViewManagerCreateWithProperties
-+  winrt::Windows::Foundation::IInspectable CreateWithProperties(winrt::Microsoft::ReactNative::IJSValueReader const &propertyMapReader);
++  winrt::Windows::Foundation::IInspectable CreateViewWithProperties(winrt::Microsoft::ReactNative::IJSValueReader const &propertyMapReader);
 ```
-The `CreateWithProperties` method can then access the properties set in JSX by inspecting the `propertyMapReader` just like it is done in the `UpdateProperties` method.
+The `CreateViewWithProperties` method can then access the properties set in JSX by inspecting the `propertyMapReader` just like it is done in the `UpdateProperties` method.
 
 
 - Your view manager is also able to declare that it wants to be responsible for its own sizing and layout. This is useful in scenarios where you are wrapping a native XAML control. To do so, implement the `winrt::Microsoft::ReactNative::IViewManagerRequiresNativeLayout` interface:
@@ -655,6 +603,8 @@ This example assumes that the `ViewManagerSample::ReactPackageProvider` we creat
 
 The `SampleApp::ReactPackageProvider` is a convenience that makes sure that all native modules and view managers defined within the app project automatically get registered. So if you're creating your native modules directly within the app project, you won't actually want to define a separate `ReactPackageProvider`.
 
+<!--END_DOCUSAURUS_CODE_TABS-->
+
 ### 3. Using your View Manager in JSX
 
 `ViewManagerSample.js`:
@@ -676,15 +626,20 @@ class ViewManagerSample extends Component {
   onPress() {
     if (_customControlRef) {
       const tag = findNodeHandle(this._customControlRef);
-      UIManager.dispatchViewManagerCommand(tag, UIManager.getViewManagerConfig('CustomUserControl').Commands.CustomCommand, ['arg1', 'arg2']);
+      UIManager.dispatchViewManagerCommand(tag, 
+        UIManager.getViewManagerConfig('CustomUserControl').Commands.CustomCommand,
+        ['arg1', 'arg2']);
     }
   }
 
   render() {
     return (
       <View style={styles.container}>
-         <CustomUserControl style={styles.customcontrol} label="CustomUserControl!" ref={(ref) => { this._customControlRef = ref; }} />
-         <Button onPress={() => { this.onPress(); }} title="Call CustomUserControl Commands!" />
+         <CustomUserControl style={styles.customcontrol} 
+           label="CustomUserControl!" 
+           ref={(ref) => { this._customControlRef = ref; }} />
+         <Button onPress={() => { this.onPress(); }} 
+           title="Call CustomUserControl Commands!" />
       </View>);
   }
 }
@@ -707,3 +662,4 @@ const styles = StyleSheet.create({
 
 AppRegistry.registerComponent('ViewManagerSample', () => ViewManagerSample);
 ```
+


### PR DESCRIPTION
This adds code tabs to our usage docs, so that we get this kind of header where people can pick which language to see docs for:
![image](https://user-images.githubusercontent.com/22989529/124410489-743f2a80-dcff-11eb-8cc0-6a81c8c4a0cf.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/466)