### PR TITLE
Add copy button to all code blocks as recently documented by docusaurus

### DIFF
--- a/docs/rnw-dependencies.md
+++ b/docs/rnw-dependencies.md
@@ -8,18 +8,15 @@ You can run React-Native for Windows apps only on Windows 10 devices with Window
 To develop React-Native for Windows apps, you need to install several dependencies.
 
 ## Install the development dependencies
-To check or install dependencies, run the script [`rnw-dependencies.ps1`](https://github.com/microsoft/react-native-windows/blob/master/vnext/Scripts/rnw-dependencies.ps1) in an elevated PowerShell window.
+To check or install dependencies, run the script [`rnw-dependencies.ps1`](https://aka.ms/rnw-deps.ps1) in an elevated PowerShell window.
 
 **Run this command:**
 Start an **elevated** PowerShell window and run:
-<html>
-<body>
-  <div>
-    <div style="padding: 10px; font-family: monospace; font-size: 9pt; display: inline-block; width: 90%; background: #dddddd; border-radius: 6px;" id="rnwdepCmd">Set-ExecutionPolicy Unrestricted -Scope Process -Force; iex (New-Object System.Net.WebClient).DownloadString('<font color="#2020cc">https://raw.githubusercontent.com/microsoft/react-native-windows/master/vnext/Scripts/rnw-dependencies.ps1</font>')</div>
-    <inline style="font-size: 24pt; cursor: pointer" onClick="javascript:navigator.clipboard.writeText(document.getElementById('rnwdepCmd').innerText)">📋</inline>
-  </div>
-</body>
-</html>
+
+```powershell
+Set-ExecutionPolicy Unrestricted -Scope Process -Force;
+iex (New-Object System.Net.WebClient).DownloadString('https://aka.ms/rnw-deps.ps1')
+```
 
 ### Manual setup
 

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -66,7 +66,13 @@ const siteConfig = {
   scripts: [
     "https://cdn.jsdelivr.net/npm/focus-visible@5.0.2/dist/focus-visible.min.js",
     "https://platform.twitter.com/widgets.js",
-    "https://buttons.github.io/buttons.js"
+    "https://buttons.github.io/buttons.js",
+    'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js',
+    '/react-native-windows/js/code-block-buttons.js',
+  ],
+
+  stylesheets: [
+    '/react-native-windows/css/code-block-buttons.css',
   ],
 
   // On page navigation for the current documentation page.

--- a/website/static/css/code-block-buttons.css
+++ b/website/static/css/code-block-buttons.css
@@ -1,0 +1,41 @@
+/* "Copy" code block button */
+pre {
+  position: relative;
+}
+
+pre .btnIcon {
+  position: absolute;
+  top: 4px;
+  z-index: 2;
+  cursor: pointer;
+  border: 1px solid transparent;
+  padding: 0;
+  color: #fff;
+  background-color: transparent;
+  height: 30px;
+  transition: all .25s ease-out;
+  font-size: 20pt;
+}
+
+pre .btnIcon:hover {
+  text-decoration: none;
+}
+
+.btnIcon__body {
+  align-items: center;
+  display: flex;
+}
+
+.btnIcon svg {
+  fill: currentColor;
+  margin-right: .4em;
+}
+
+.btnIcon__label {
+  font-size: 11px;
+  font-weight: lighter;
+}
+
+.btnClipboard {
+  right: 10px;
+}

--- a/website/static/js/code-block-buttons.js
+++ b/website/static/js/code-block-buttons.js
@@ -1,0 +1,48 @@
+// Turn off ESLint for this file because it's sent down to users as-is.
+/* eslint-disable */
+window.addEventListener('load', function() {
+    function button(label, ariaLabel, icon, className) {
+      const btn = document.createElement('button');
+      btn.classList.add('btnIcon', className);
+      btn.setAttribute('type', 'button');
+      btn.setAttribute('aria-label', ariaLabel);
+      btn.innerHTML =
+        '<div class="btnIcon__body">' +
+        icon +
+        '<strong class="btnIcon__label">' +
+        label +
+        '</strong>' +
+        '</div>';
+      return btn;
+    }
+  
+    function addButtons(codeBlockSelector, btn) {
+      document.querySelectorAll(codeBlockSelector).forEach(function(code) {
+        code.parentNode.appendChild(btn.cloneNode(true));
+      });
+    }
+  
+    const copyIcon =
+      '📋';
+    //   '<svg width="22" height="22" viewBox="340 364 14 15" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M342 375.974h4v.998h-4v-.998zm5-5.987h-5v.998h5v-.998zm2 2.994v-1.995l-3 2.993 3 2.994v-1.996h5v-1.995h-5zm-4.5-.997H342v.998h2.5v-.997zm-2.5 2.993h2.5v-.998H342v.998zm9 .998h1v1.996c-.016.28-.11.514-.297.702-.187.187-.422.28-.703.296h-10c-.547 0-1-.452-1-.998v-10.976c0-.546.453-.998 1-.998h3c0-1.107.89-1.996 2-1.996 1.11 0 2 .89 2 1.996h3c.547 0 1 .452 1 .998v4.99h-1v-2.995h-10v8.98h10v-1.996zm-9-7.983h8c0-.544-.453-.996-1-.996h-1c-.547 0-1-.453-1-.998 0-.546-.453-.998-1-.998-.547 0-1 .452-1 .998 0 .545-.453.998-1 .998h-1c-.547 0-1 .452-1 .997z" fill-rule="evenodd"/></svg>';
+  
+    addButtons(
+      '.hljs',
+      button('Copy', 'Copy code to clipboard', copyIcon, 'btnClipboard'),
+    );
+  
+    const clipboard = new ClipboardJS('.btnClipboard', {
+      target: function(trigger) {
+        return trigger.parentNode.querySelector('code');
+      },
+    });
+  
+    clipboard.on('success', function(event) {
+      event.clearSelection();
+      const textEl = event.trigger.querySelector('.btnIcon__label');
+      textEl.textContent = 'Copied';
+      setTimeout(function() {
+        textEl.textContent = 'Copy';
+      }, 2000);
+    });
+  });

--- a/website/versioned_docs/version-0.64/rnw-dependencies.md
+++ b/website/versioned_docs/version-0.64/rnw-dependencies.md
@@ -9,18 +9,15 @@ You can run React-Native for Windows apps only on Windows 10 devices with Window
 To develop React-Native for Windows apps, you need to install several dependencies.
 
 ## Install the development dependencies
-To check or install dependencies, run the script [`rnw-dependencies.ps1`](https://github.com/microsoft/react-native-windows/blob/master/vnext/Scripts/rnw-dependencies.ps1) in an elevated PowerShell window.
+To check or install dependencies, run the script [`rnw-dependencies.ps1`](https://aka.ms/rnw-deps.ps1) in an elevated PowerShell window.
 
 **Run this command:**
 Start an **elevated** PowerShell window and run:
-<html>
-<body>
-  <div>
-    <div style="padding: 10px; font-family: monospace; font-size: 9pt; display: inline-block; width: 90%; background: #dddddd; border-radius: 6px;" id="rnwdepCmd">Set-ExecutionPolicy Unrestricted -Scope Process -Force; iex (New-Object System.Net.WebClient).DownloadString('<font color="#2020cc">https://raw.githubusercontent.com/microsoft/react-native-windows/master/vnext/Scripts/rnw-dependencies.ps1</font>')</div>
-    <inline style="font-size: 24pt; cursor: pointer" onClick="javascript:navigator.clipboard.writeText(document.getElementById('rnwdepCmd').innerText)">📋</inline>
-  </div>
-</body>
-</html>
+
+```powershell
+Set-ExecutionPolicy Unrestricted -Scope Process -Force;
+iex (New-Object System.Net.WebClient).DownloadString('https://aka.ms/rnw-deps.ps1')
+```
 
 ### Manual setup
 


### PR DESCRIPTION
This gets rid of the one off hacky copy button in rnw-dependencies and uses the recommended way to add the copy button to code blocks - see https://gist.github.com/yangshun/55db997ed0f8f4e6527571fc3bee4675
Also created an aka.ms redirect for the dependencies ps1 so it looks neater on the website, it's easier to remember, and allows us to move the file if we ever need to : )

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/467)