### PR TITLE
Update Docs for 0.65

### DIFF
--- a/docs/AccessibilityAction-api-windows.md
+++ b/docs/AccessibilityAction-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: AccessibilityAction
+id: version-0.65-AccessibilityAction
 title: AccessibilityAction
+original_id: AccessibilityAction
 ---
 
 Kind: `struct`

--- a/docs/AccessibilityActionEventHandler-api-windows.md
+++ b/docs/AccessibilityActionEventHandler-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: AccessibilityActionEventHandler
+id: version-0.65-AccessibilityActionEventHandler
 title: AccessibilityActionEventHandler
+original_id: AccessibilityActionEventHandler
 ---
 
 Kind: `delegate`

--- a/docs/AccessibilityInvokeEventHandler-api-windows.md
+++ b/docs/AccessibilityInvokeEventHandler-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: AccessibilityInvokeEventHandler
+id: version-0.65-AccessibilityInvokeEventHandler
 title: AccessibilityInvokeEventHandler
+original_id: AccessibilityInvokeEventHandler
 ---
 
 Kind: `delegate`

--- a/docs/AccessibilityRoles-api-windows.md
+++ b/docs/AccessibilityRoles-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: AccessibilityRoles
+id: version-0.65-AccessibilityRoles
 title: AccessibilityRoles
+original_id: AccessibilityRoles
 ---
 
 Kind: `enum`

--- a/docs/AccessibilityStates-api-windows.md
+++ b/docs/AccessibilityStates-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: AccessibilityStates
+id: version-0.65-AccessibilityStates
 title: AccessibilityStates
+original_id: AccessibilityStates
 ---
 
 Kind: `enum`

--- a/docs/AccessibilityValue-api-windows.md
+++ b/docs/AccessibilityValue-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: AccessibilityValue
+id: version-0.65-AccessibilityValue
 title: AccessibilityValue
+original_id: AccessibilityValue
 ---
 
 Kind: `enum`

--- a/docs/BorderEffect-api-windows.md
+++ b/docs/BorderEffect-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: BorderEffect
+id: version-0.65-BorderEffect
 title: BorderEffect
+original_id: BorderEffect
 ---
 
 Kind: `class`

--- a/docs/CanvasComposite-api-windows.md
+++ b/docs/CanvasComposite-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: CanvasComposite
+id: version-0.65-CanvasComposite
 title: CanvasComposite
+original_id: CanvasComposite
 ---
 
 Kind: `enum`

--- a/docs/CanvasEdgeBehavior-api-windows.md
+++ b/docs/CanvasEdgeBehavior-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: CanvasEdgeBehavior
+id: version-0.65-CanvasEdgeBehavior
 title: CanvasEdgeBehavior
+original_id: CanvasEdgeBehavior
 ---
 
 Kind: `enum`

--- a/docs/ColorSourceEffect-api-windows.md
+++ b/docs/ColorSourceEffect-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ColorSourceEffect
+id: version-0.65-ColorSourceEffect
 title: ColorSourceEffect
+original_id: ColorSourceEffect
 ---
 
 Kind: `class`

--- a/docs/CompositeStepEffect-api-windows.md
+++ b/docs/CompositeStepEffect-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: CompositeStepEffect
+id: version-0.65-CompositeStepEffect
 title: CompositeStepEffect
+original_id: CompositeStepEffect
 ---
 
 Kind: `class`

--- a/docs/ConstantProviderDelegate-api-windows.md
+++ b/docs/ConstantProviderDelegate-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ConstantProviderDelegate
+id: version-0.65-ConstantProviderDelegate
 title: ConstantProviderDelegate
+original_id: ConstantProviderDelegate
 ---
 
 Kind: `delegate`

--- a/docs/DesktopWindowMessage-api-windows.md
+++ b/docs/DesktopWindowMessage-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: DesktopWindowMessage
+id: version-0.65-DesktopWindowMessage
 title: DesktopWindowMessage
+original_id: DesktopWindowMessage
 ---
 
 Kind: `struct`

--- a/docs/DevMenuControl-api-windows.md
+++ b/docs/DevMenuControl-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: DevMenuControl
+id: version-0.65-DevMenuControl
 title: DevMenuControl
+original_id: DevMenuControl
 ---
 
 Kind: `class`

--- a/docs/DynamicAutomationPeer-api-windows.md
+++ b/docs/DynamicAutomationPeer-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: DynamicAutomationPeer
+id: version-0.65-DynamicAutomationPeer
 title: DynamicAutomationPeer
+original_id: DynamicAutomationPeer
 ---
 
 Kind: `class`

--- a/docs/DynamicAutomationProperties-api-windows.md
+++ b/docs/DynamicAutomationProperties-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: DynamicAutomationProperties
+id: version-0.65-DynamicAutomationProperties
 title: DynamicAutomationProperties
+original_id: DynamicAutomationProperties
 ---
 
 Kind: `class`

--- a/docs/DynamicValueProvider-api-windows.md
+++ b/docs/DynamicValueProvider-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: DynamicValueProvider
+id: version-0.65-DynamicValueProvider
 title: DynamicValueProvider
+original_id: DynamicValueProvider
 ---
 
 Kind: `class`

--- a/docs/EffectBorderMode-api-windows.md
+++ b/docs/EffectBorderMode-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: EffectBorderMode
+id: version-0.65-EffectBorderMode
 title: EffectBorderMode
+original_id: EffectBorderMode
 ---
 
 Kind: `enum`

--- a/docs/EffectOptimization-api-windows.md
+++ b/docs/EffectOptimization-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: EffectOptimization
+id: version-0.65-EffectOptimization
 title: EffectOptimization
+original_id: EffectOptimization
 ---
 
 Kind: `enum`

--- a/docs/GaussianBlurEffect-api-windows.md
+++ b/docs/GaussianBlurEffect-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: GaussianBlurEffect
+id: version-0.65-GaussianBlurEffect
 title: GaussianBlurEffect
+original_id: GaussianBlurEffect
 ---
 
 Kind: `class`

--- a/docs/IJSValueReader-api-windows.md
+++ b/docs/IJSValueReader-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IJSValueReader
+id: version-0.65-IJSValueReader
 title: IJSValueReader
+original_id: IJSValueReader
 ---
 
 Kind: `interface`

--- a/docs/IJSValueWriter-api-windows.md
+++ b/docs/IJSValueWriter-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IJSValueWriter
+id: version-0.65-IJSValueWriter
 title: IJSValueWriter
+original_id: IJSValueWriter
 ---
 
 Kind: `interface`

--- a/docs/IJsiByteBuffer-api-windows.md
+++ b/docs/IJsiByteBuffer-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IJsiByteBuffer
+id: version-0.65-IJsiByteBuffer
 title: IJsiByteBuffer
+original_id: IJsiByteBuffer
 ---
 
 Kind: `interface`

--- a/docs/IJsiHostObject-api-windows.md
+++ b/docs/IJsiHostObject-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IJsiHostObject
+id: version-0.65-IJsiHostObject
 title: IJsiHostObject
+original_id: IJsiHostObject
 ---
 
 Kind: `interface`

--- a/docs/IReactContext-api-windows.md
+++ b/docs/IReactContext-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IReactContext
+id: version-0.65-IReactContext
 title: IReactContext
+original_id: IReactContext
 ---
 
 Kind: `interface`
@@ -87,10 +88,12 @@ The `paramsArgWriter` is a [`JSValueArgWriter`](JSValueArgWriter) delegate that 
 
 
 ## Referenced by
+- [`IReactViewInstance`](IReactViewInstance)
 - [`IViewManagerWithReactContext`](IViewManagerWithReactContext)
 - [`InitializerDelegate`](InitializerDelegate)
 - [`InstanceCreatedEventArgs`](InstanceCreatedEventArgs)
 - [`InstanceDestroyedEventArgs`](InstanceDestroyedEventArgs)
 - [`InstanceLoadedEventArgs`](InstanceLoadedEventArgs)
+- [`ReactCoreInjection`](ReactCoreInjection)
 - [`ReactNativeHost`](ReactNativeHost)
 - [`XamlUIService`](XamlUIService)

--- a/docs/IReactDispatcher-api-windows.md
+++ b/docs/IReactDispatcher-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IReactDispatcher
+id: version-0.65-IReactDispatcher
 title: IReactDispatcher
+original_id: IReactDispatcher
 ---
 
 Kind: `interface`

--- a/docs/IReactModuleBuilder-api-windows.md
+++ b/docs/IReactModuleBuilder-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IReactModuleBuilder
+id: version-0.65-IReactModuleBuilder
 title: IReactModuleBuilder
+original_id: IReactModuleBuilder
 ---
 
 Kind: `interface`

--- a/docs/IReactNonAbiValue-api-windows.md
+++ b/docs/IReactNonAbiValue-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IReactNonAbiValue
+id: version-0.65-IReactNonAbiValue
 title: IReactNonAbiValue
+original_id: IReactNonAbiValue
 ---
 
 Kind: `interface`

--- a/docs/IReactNotificationArgs-api-windows.md
+++ b/docs/IReactNotificationArgs-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IReactNotificationArgs
+id: version-0.65-IReactNotificationArgs
 title: IReactNotificationArgs
+original_id: IReactNotificationArgs
 ---
 
 Kind: `interface`

--- a/docs/IReactNotificationService-api-windows.md
+++ b/docs/IReactNotificationService-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IReactNotificationService
+id: version-0.65-IReactNotificationService
 title: IReactNotificationService
+original_id: IReactNotificationService
 ---
 
 Kind: `interface`

--- a/docs/IReactNotificationSubscription-api-windows.md
+++ b/docs/IReactNotificationSubscription-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IReactNotificationSubscription
+id: version-0.65-IReactNotificationSubscription
 title: IReactNotificationSubscription
+original_id: IReactNotificationSubscription
 ---
 
 Kind: `interface`

--- a/docs/IReactPackageBuilder-api-windows.md
+++ b/docs/IReactPackageBuilder-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IReactPackageBuilder
+id: version-0.65-IReactPackageBuilder
 title: IReactPackageBuilder
+original_id: IReactPackageBuilder
 ---
 
 Kind: `interface`

--- a/docs/IReactPackageBuilderExperimental-api-windows.md
+++ b/docs/IReactPackageBuilderExperimental-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IReactPackageBuilderExperimental
+id: version-0.65-IReactPackageBuilderExperimental
 title: IReactPackageBuilderExperimental
+original_id: IReactPackageBuilderExperimental
 ---
 
 Kind: `interface`

--- a/docs/IReactPackageProvider-api-windows.md
+++ b/docs/IReactPackageProvider-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IReactPackageProvider
+id: version-0.65-IReactPackageProvider
 title: IReactPackageProvider
+original_id: IReactPackageProvider
 ---
 
 Kind: `interface`

--- a/docs/IReactPropertyBag-api-windows.md
+++ b/docs/IReactPropertyBag-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IReactPropertyBag
+id: version-0.65-IReactPropertyBag
 title: IReactPropertyBag
+original_id: IReactPropertyBag
 ---
 
 Kind: `interface`
@@ -44,6 +45,8 @@ If the new value is null, then the property is removed.
 
 ## Referenced by
 - [`IReactContext`](IReactContext)
+- [`ReactCoreInjection`](ReactCoreInjection)
 - [`ReactInstanceSettings`](ReactInstanceSettings)
 - [`ReactPropertyBagHelper`](ReactPropertyBagHelper)
+- [`UIBatchCompleteCallback`](UIBatchCompleteCallback)
 - [`XamlUIService`](XamlUIService)

--- a/docs/IReactPropertyName-api-windows.md
+++ b/docs/IReactPropertyName-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IReactPropertyName
+id: version-0.65-IReactPropertyName
 title: IReactPropertyName
+original_id: IReactPropertyName
 ---
 
 Kind: `interface`

--- a/docs/IReactPropertyNamespace-api-windows.md
+++ b/docs/IReactPropertyNamespace-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IReactPropertyNamespace
+id: version-0.65-IReactPropertyNamespace
 title: IReactPropertyNamespace
+original_id: IReactPropertyNamespace
 ---
 
 Kind: `interface`

--- a/docs/IReactSettingsSnapshot-api-windows.md
+++ b/docs/IReactSettingsSnapshot-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IReactSettingsSnapshot
+id: version-0.65-IReactSettingsSnapshot
 title: IReactSettingsSnapshot
+original_id: IReactSettingsSnapshot
 ---
 
 Kind: `interface`

--- a/docs/IReactViewHost-api-windows.md
+++ b/docs/IReactViewHost-api-windows.md
@@ -1,0 +1,57 @@
+---
+id: version-0.65-IReactViewHost
+title: IReactViewHost
+original_id: IReactViewHost
+---
+
+Kind: `interface`
+
+
+
+> **EXPERIMENTAL**
+
+Used to implement a non-XAML platform ReactRootView.
+
+
+
+## Methods
+### AttachViewInstance
+void **`AttachViewInstance`**([`IReactViewInstance`](IReactViewInstance) viewInstance)
+
+Attaches IReactViewInstance to the IReactViewHost.
+
+
+
+### DetachViewInstance
+void **`DetachViewInstance`**()
+
+Detaches IReactViewInstance from the IReactViewHost.
+
+
+
+### ReloadViewInstance
+void **`ReloadViewInstance`**()
+
+Reloads the IReactViewInstance if it is attached.
+
+
+
+### ReloadViewInstanceWithOptions
+void **`ReloadViewInstanceWithOptions`**([`ReactViewOptions`](ReactViewOptions) options)
+
+Reloads IReactViewInstance if it is attached with a new set of options.
+
+
+
+### UnloadViewInstance
+void **`UnloadViewInstance`**()
+
+Unloads the attached IReactViewInstance.
+
+
+
+
+
+
+## Referenced by
+- [`ReactCoreInjection`](ReactCoreInjection)

--- a/docs/IReactViewInstance-api-windows.md
+++ b/docs/IReactViewInstance-api-windows.md
@@ -1,0 +1,43 @@
+---
+id: version-0.65-IReactViewInstance
+title: IReactViewInstance
+original_id: IReactViewInstance
+---
+
+Kind: `interface`
+
+
+
+> **EXPERIMENTAL**
+
+Used to implement a non-XAML platform ReactRootView.
+
+
+
+## Methods
+### InitRootView
+void **`InitRootView`**([`IReactContext`](IReactContext) context, [`ReactViewOptions`](ReactViewOptions) viewOptions)
+
+Initialize ReactRootView with the reactInstance and view-specific settings
+
+
+
+### UninitRootView
+void **`UninitRootView`**()
+
+Uninitialize ReactRootView and destroy UI tree
+
+
+
+### UpdateRootView
+void **`UpdateRootView`**()
+
+Update ReactRootView with changes in ReactInstance
+
+
+
+
+
+
+## Referenced by
+- [`IReactViewHost`](IReactViewHost)

--- a/docs/IRedBoxErrorFrameInfo-api-windows.md
+++ b/docs/IRedBoxErrorFrameInfo-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IRedBoxErrorFrameInfo
+id: version-0.65-IRedBoxErrorFrameInfo
 title: IRedBoxErrorFrameInfo
+original_id: IRedBoxErrorFrameInfo
 ---
 
 Kind: `interface`

--- a/docs/IRedBoxErrorInfo-api-windows.md
+++ b/docs/IRedBoxErrorInfo-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IRedBoxErrorInfo
+id: version-0.65-IRedBoxErrorInfo
 title: IRedBoxErrorInfo
+original_id: IRedBoxErrorInfo
 ---
 
 Kind: `interface`

--- a/docs/IRedBoxHandler-api-windows.md
+++ b/docs/IRedBoxHandler-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IRedBoxHandler
+id: version-0.65-IRedBoxHandler
 title: IRedBoxHandler
+original_id: IRedBoxHandler
 ---
 
 Kind: `interface`

--- a/docs/IViewManager-api-windows.md
+++ b/docs/IViewManager-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IViewManager
+id: version-0.65-IViewManager
 title: IViewManager
+original_id: IViewManager
 ---
 
 Kind: `interface`

--- a/docs/IViewManagerCreateWithProperties-api-windows.md
+++ b/docs/IViewManagerCreateWithProperties-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IViewManagerCreateWithProperties
+id: version-0.65-IViewManagerCreateWithProperties
 title: IViewManagerCreateWithProperties
+original_id: IViewManagerCreateWithProperties
 ---
 
 Kind: `interface`

--- a/docs/IViewManagerRequiresNativeLayout-api-windows.md
+++ b/docs/IViewManagerRequiresNativeLayout-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IViewManagerRequiresNativeLayout
+id: version-0.65-IViewManagerRequiresNativeLayout
 title: IViewManagerRequiresNativeLayout
+original_id: IViewManagerRequiresNativeLayout
 ---
 
 Kind: `interface`

--- a/docs/IViewManagerWithChildren-api-windows.md
+++ b/docs/IViewManagerWithChildren-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IViewManagerWithChildren
+id: version-0.65-IViewManagerWithChildren
 title: IViewManagerWithChildren
+original_id: IViewManagerWithChildren
 ---
 
 Kind: `interface`

--- a/docs/IViewManagerWithCommands-api-windows.md
+++ b/docs/IViewManagerWithCommands-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IViewManagerWithCommands
+id: version-0.65-IViewManagerWithCommands
 title: IViewManagerWithCommands
+original_id: IViewManagerWithCommands
 ---
 
 Kind: `interface`

--- a/docs/IViewManagerWithExportedEventTypeConstants-api-windows.md
+++ b/docs/IViewManagerWithExportedEventTypeConstants-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IViewManagerWithExportedEventTypeConstants
+id: version-0.65-IViewManagerWithExportedEventTypeConstants
 title: IViewManagerWithExportedEventTypeConstants
+original_id: IViewManagerWithExportedEventTypeConstants
 ---
 
 Kind: `interface`

--- a/docs/IViewManagerWithExportedViewConstants-api-windows.md
+++ b/docs/IViewManagerWithExportedViewConstants-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IViewManagerWithExportedViewConstants
+id: version-0.65-IViewManagerWithExportedViewConstants
 title: IViewManagerWithExportedViewConstants
+original_id: IViewManagerWithExportedViewConstants
 ---
 
 Kind: `interface`

--- a/docs/IViewManagerWithNativeProperties-api-windows.md
+++ b/docs/IViewManagerWithNativeProperties-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IViewManagerWithNativeProperties
+id: version-0.65-IViewManagerWithNativeProperties
 title: IViewManagerWithNativeProperties
+original_id: IViewManagerWithNativeProperties
 ---
 
 Kind: `interface`

--- a/docs/IViewManagerWithReactContext-api-windows.md
+++ b/docs/IViewManagerWithReactContext-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: IViewManagerWithReactContext
+id: version-0.65-IViewManagerWithReactContext
 title: IViewManagerWithReactContext
+original_id: IViewManagerWithReactContext
 ---
 
 Kind: `interface`

--- a/docs/InitializerDelegate-api-windows.md
+++ b/docs/InitializerDelegate-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: InitializerDelegate
+id: version-0.65-InitializerDelegate
 title: InitializerDelegate
+original_id: InitializerDelegate
 ---
 
 Kind: `delegate`

--- a/docs/InstanceCreatedEventArgs-api-windows.md
+++ b/docs/InstanceCreatedEventArgs-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: InstanceCreatedEventArgs
+id: version-0.65-InstanceCreatedEventArgs
 title: InstanceCreatedEventArgs
+original_id: InstanceCreatedEventArgs
 ---
 
 Kind: `class`

--- a/docs/InstanceDestroyedEventArgs-api-windows.md
+++ b/docs/InstanceDestroyedEventArgs-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: InstanceDestroyedEventArgs
+id: version-0.65-InstanceDestroyedEventArgs
 title: InstanceDestroyedEventArgs
+original_id: InstanceDestroyedEventArgs
 ---
 
 Kind: `class`

--- a/docs/InstanceLoadedEventArgs-api-windows.md
+++ b/docs/InstanceLoadedEventArgs-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: InstanceLoadedEventArgs
+id: version-0.65-InstanceLoadedEventArgs
 title: InstanceLoadedEventArgs
+original_id: InstanceLoadedEventArgs
 ---
 
 Kind: `class`

--- a/docs/JSIEngine-api-windows.md
+++ b/docs/JSIEngine-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JSIEngine
+id: version-0.65-JSIEngine
 title: JSIEngine
+original_id: JSIEngine
 ---
 
 Kind: `enum`

--- a/docs/JSValueArgWriter-api-windows.md
+++ b/docs/JSValueArgWriter-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JSValueArgWriter
+id: version-0.65-JSValueArgWriter
 title: JSValueArgWriter
+original_id: JSValueArgWriter
 ---
 
 Kind: `delegate`
@@ -18,5 +19,6 @@ void **`Invoke`**([`IJSValueWriter`](IJSValueWriter) writer)
 ## Referenced by
 - [`IReactContext`](IReactContext)
 - [`ReactRootView`](ReactRootView)
+- [`ReactViewOptions`](ReactViewOptions)
 - [`XamlHelper`](XamlHelper)
 - [`XamlUIService`](XamlUIService)

--- a/docs/JSValueType-api-windows.md
+++ b/docs/JSValueType-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JSValueType
+id: version-0.65-JSValueType
 title: JSValueType
+original_id: JSValueType
 ---
 
 Kind: `enum`

--- a/docs/JsiByteArrayUser-api-windows.md
+++ b/docs/JsiByteArrayUser-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JsiByteArrayUser
+id: version-0.65-JsiByteArrayUser
 title: JsiByteArrayUser
+original_id: JsiByteArrayUser
 ---
 
 Kind: `delegate`

--- a/docs/JsiError-api-windows.md
+++ b/docs/JsiError-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JsiError
+id: version-0.65-JsiError
 title: JsiError
+original_id: JsiError
 ---
 
 Kind: `class`

--- a/docs/JsiErrorType-api-windows.md
+++ b/docs/JsiErrorType-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JsiErrorType
+id: version-0.65-JsiErrorType
 title: JsiErrorType
+original_id: JsiErrorType
 ---
 
 Kind: `enum`

--- a/docs/JsiHostFunction-api-windows.md
+++ b/docs/JsiHostFunction-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JsiHostFunction
+id: version-0.65-JsiHostFunction
 title: JsiHostFunction
+original_id: JsiHostFunction
 ---
 
 Kind: `delegate`

--- a/docs/JsiObjectRef-api-windows.md
+++ b/docs/JsiObjectRef-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JsiObjectRef
+id: version-0.65-JsiObjectRef
 title: JsiObjectRef
+original_id: JsiObjectRef
 ---
 
 Kind: `struct`

--- a/docs/JsiPreparedJavaScript-api-windows.md
+++ b/docs/JsiPreparedJavaScript-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JsiPreparedJavaScript
+id: version-0.65-JsiPreparedJavaScript
 title: JsiPreparedJavaScript
+original_id: JsiPreparedJavaScript
 ---
 
 Kind: `class`

--- a/docs/JsiPropertyIdRef-api-windows.md
+++ b/docs/JsiPropertyIdRef-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JsiPropertyIdRef
+id: version-0.65-JsiPropertyIdRef
 title: JsiPropertyIdRef
+original_id: JsiPropertyIdRef
 ---
 
 Kind: `struct`

--- a/docs/JsiRuntime-api-windows.md
+++ b/docs/JsiRuntime-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JsiRuntime
+id: version-0.65-JsiRuntime
 title: JsiRuntime
+original_id: JsiRuntime
 ---
 
 Kind: `class`
@@ -123,6 +124,11 @@ Note that the JSI is defined only for C++ code. We plan to add the .Net support 
 
 ### CreateWeakObject
 [`JsiWeakObjectRef`](JsiWeakObjectRef) **`CreateWeakObject`**([`JsiObjectRef`](JsiObjectRef) obj)
+
+
+
+### DrainMicrotasks
+bool **`DrainMicrotasks`**(int maxMicrotasksHint)
 
 
 

--- a/docs/JsiScopeState-api-windows.md
+++ b/docs/JsiScopeState-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JsiScopeState
+id: version-0.65-JsiScopeState
 title: JsiScopeState
+original_id: JsiScopeState
 ---
 
 Kind: `struct`

--- a/docs/JsiStringRef-api-windows.md
+++ b/docs/JsiStringRef-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JsiStringRef
+id: version-0.65-JsiStringRef
 title: JsiStringRef
+original_id: JsiStringRef
 ---
 
 Kind: `struct`

--- a/docs/JsiSymbolRef-api-windows.md
+++ b/docs/JsiSymbolRef-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JsiSymbolRef
+id: version-0.65-JsiSymbolRef
 title: JsiSymbolRef
+original_id: JsiSymbolRef
 ---
 
 Kind: `struct`

--- a/docs/JsiValueKind-api-windows.md
+++ b/docs/JsiValueKind-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JsiValueKind
+id: version-0.65-JsiValueKind
 title: JsiValueKind
+original_id: JsiValueKind
 ---
 
 Kind: `enum`

--- a/docs/JsiValueRef-api-windows.md
+++ b/docs/JsiValueRef-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JsiValueRef
+id: version-0.65-JsiValueRef
 title: JsiValueRef
+original_id: JsiValueRef
 ---
 
 Kind: `struct`

--- a/docs/JsiWeakObjectRef-api-windows.md
+++ b/docs/JsiWeakObjectRef-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: JsiWeakObjectRef
+id: version-0.65-JsiWeakObjectRef
 title: JsiWeakObjectRef
+original_id: JsiWeakObjectRef
 ---
 
 Kind: `struct`

--- a/docs/MethodDelegate-api-windows.md
+++ b/docs/MethodDelegate-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: MethodDelegate
+id: version-0.65-MethodDelegate
 title: MethodDelegate
+original_id: MethodDelegate
 ---
 
 Kind: `delegate`

--- a/docs/MethodResultCallback-api-windows.md
+++ b/docs/MethodResultCallback-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: MethodResultCallback
+id: version-0.65-MethodResultCallback
 title: MethodResultCallback
+original_id: MethodResultCallback
 ---
 
 Kind: `delegate`

--- a/docs/MethodReturnType-api-windows.md
+++ b/docs/MethodReturnType-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: MethodReturnType
+id: version-0.65-MethodReturnType
 title: MethodReturnType
+original_id: MethodReturnType
 ---
 
 Kind: `enum`

--- a/docs/QuirkSettings-api-windows.md
+++ b/docs/QuirkSettings-api-windows.md
@@ -1,11 +1,14 @@
 ---
-id: QuirkSettings
+id: version-0.65-QuirkSettings
 title: QuirkSettings
+original_id: QuirkSettings
 ---
 
 Kind: `class`
 
 
+
+> **EXPERIMENTAL**
 
 This can be used to add settings that allow react-native-windows behavior to be maintained across version updates to facilitate upgrades. Settings in this class are likely to be removed in future releases, so apps should try to update their code to not rely on these settings.
 
@@ -19,6 +22,11 @@ Runtime setting allowing Networking (HTTP, WebSocket) connections to skip certif
 
 
 
+### SetEnableFabric
+`static` void **`SetEnableFabric`**([`ReactInstanceSettings`](ReactInstanceSettings) settings, bool value)
+
+
+
 ### SetMatchAndroidAndIOSStretchBehavior
 `static` void **`SetMatchAndroidAndIOSStretchBehavior`**([`ReactInstanceSettings`](ReactInstanceSettings) settings, bool value)
 
@@ -26,13 +34,6 @@ Runtime setting allowing Networking (HTTP, WebSocket) connections to skip certif
 
 Older versions of react-native-windows did not use [Yoga](https://github.com/facebook/yoga)'s legacy stretch behavior. This meant that react-native-windows would layout views slightly differently that in iOS and Android.
 Set this setting to false to maintain the behavior from react-native-windows <= 0.62.
-
-
-
-### SetUseLegacyWebSocketModule
-`static` void **`SetUseLegacyWebSocketModule`**([`ReactInstanceSettings`](ReactInstanceSettings) settings, bool value)
-
-Transitional setting allowing to use the deprecated `LegacyWebSocketModule`.
 
 
 

--- a/docs/ReactApplication-api-windows.md
+++ b/docs/ReactApplication-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ReactApplication
+id: version-0.65-ReactApplication
 title: ReactApplication
+original_id: ReactApplication
 ---
 
 Kind: `class`
@@ -27,13 +28,6 @@ Generally, changes to these settings will not take effect if the React instance 
  string `JavaScriptBundleFile`
 
 See [`ReactInstanceSettings.JavaScriptBundleFile`](ReactInstanceSettings#javascriptbundlefile).
-
-### JavaScriptMainModuleName
- string `JavaScriptMainModuleName`
-
-> **Deprecated**: Use [`JavaScriptBundleFile`](#javascriptbundlefile) instead
-
-See [`ReactInstanceSettings.JavaScriptMainModuleName`](ReactInstanceSettings#javascriptmainmodulename).
 
 ### PackageProviders
 `readonly`  [`IVector`](https://docs.microsoft.com/uwp/api/Windows.Foundation.Collections.IVector-1)<[`IReactPackageProvider`](IReactPackageProvider)> `PackageProviders`

--- a/docs/ReactCoreInjection-api-windows.md
+++ b/docs/ReactCoreInjection-api-windows.md
@@ -1,0 +1,39 @@
+---
+id: version-0.65-ReactCoreInjection
+title: ReactCoreInjection
+original_id: ReactCoreInjection
+---
+
+Kind: `class`
+
+
+
+> **EXPERIMENTAL**
+
+Used to inject platform specific implementations to create react-native targets targeting non-XAML platforms.
+
+
+
+## Methods
+### MakeViewHost
+`static` [`IReactViewHost`](IReactViewHost) **`MakeViewHost`**([`ReactNativeHost`](ReactNativeHost) host, [`ReactViewOptions`](ReactViewOptions) viewOptions)
+
+Custom ReactViewInstances use this to create a host to connect to.
+
+
+
+### PostToUIBatchingQueue
+`static` void **`PostToUIBatchingQueue`**([`IReactContext`](IReactContext) context, [`ReactDispatcherCallback`](ReactDispatcherCallback) callback)
+
+Post something to the main UI dispatcher using the batching queue
+
+
+
+### SetUIBatchCompleteCallback
+`static` void **`SetUIBatchCompleteCallback`**([`IReactPropertyBag`](IReactPropertyBag) properties, [`UIBatchCompleteCallback`](UIBatchCompleteCallback) xamlRoot)
+
+Sets the Callback to call when a UI batch is completed. 
+
+
+
+

--- a/docs/ReactCreatePropertyValue-api-windows.md
+++ b/docs/ReactCreatePropertyValue-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ReactCreatePropertyValue
+id: version-0.65-ReactCreatePropertyValue
 title: ReactCreatePropertyValue
+original_id: ReactCreatePropertyValue
 ---
 
 Kind: `delegate`

--- a/docs/ReactDispatcherCallback-api-windows.md
+++ b/docs/ReactDispatcherCallback-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ReactDispatcherCallback
+id: version-0.65-ReactDispatcherCallback
 title: ReactDispatcherCallback
+original_id: ReactDispatcherCallback
 ---
 
 Kind: `delegate`
@@ -16,3 +17,4 @@ void **`Invoke`**()
 
 ## Referenced by
 - [`IReactDispatcher`](IReactDispatcher)
+- [`ReactCoreInjection`](ReactCoreInjection)

--- a/docs/ReactDispatcherHelper-api-windows.md
+++ b/docs/ReactDispatcherHelper-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ReactDispatcherHelper
+id: version-0.65-ReactDispatcherHelper
 title: ReactDispatcherHelper
+original_id: ReactDispatcherHelper
 ---
 
 Kind: `class`

--- a/docs/ReactInstanceSettings-api-windows.md
+++ b/docs/ReactInstanceSettings-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ReactInstanceSettings
+id: version-0.65-ReactInstanceSettings
 title: ReactInstanceSettings
+original_id: ReactInstanceSettings
 ---
 
 Kind: `class`
@@ -26,16 +27,7 @@ Set this to a location the application has write access to in order for bytecode
 ### DebugBundlePath
  string `DebugBundlePath`
 
-When loading from a bundle server (such as metro), this is the path that will be requested from the server. If this is not provided the value of [`JavaScriptBundleFile`](#javascriptbundlefile) or [`JavaScriptMainModuleName`](#javascriptmainmodulename) is used.
-
-### DebugHost
- string `DebugHost`
-
-> **Deprecated**: This has been replaced with [`SourceBundleHost`](#sourcebundlehost) and [`SourceBundlePort`](#sourcebundleport) and will be removed in version 0.65.
-
-**Default value**: `localhost:8081`
-
-When using a [`UseFastRefresh`](#usefastrefresh), [`UseLiveReload`](#uselivereload) or [`UseWebDebugger`](#usewebdebugger) this is the server that will be used to load the bundle from.
+When loading from a bundle server (such as metro), this is the path that will be requested from the server. If this is not provided, the value of [`JavaScriptBundleFile`](#javascriptbundlefile) is used.
 
 ### DebuggerBreakOnNextLine
  bool `DebuggerBreakOnNextLine`
@@ -89,13 +81,6 @@ In order the override to work the Microsoft.ReactNative must be compiled with su
 **Default value**: `index.windows`
 
 The name of the JavaScript bundle file to load. This should be a relative path from [`BundleRootPath`](#bundlerootpath). The `.bundle` extension will be appended to the end, when looking for the bundle file.
-
-### JavaScriptMainModuleName
- string `JavaScriptMainModuleName`
-
-> **Deprecated**: Use [`JavaScriptBundleFile`](#javascriptbundlefile) instead. It will be removed in version 0.65.
-
-Name of the JavaScript bundle file. If [`JavaScriptBundleFile`](#javascriptbundlefile) is specified it is used instead.
 
 ### Notifications
 `readonly`  [`IReactNotificationService`](IReactNotificationService) `Notifications`

--- a/docs/ReactModuleProvider-api-windows.md
+++ b/docs/ReactModuleProvider-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ReactModuleProvider
+id: version-0.65-ReactModuleProvider
 title: ReactModuleProvider
+original_id: ReactModuleProvider
 ---
 
 Kind: `delegate`

--- a/docs/ReactNativeHost-api-windows.md
+++ b/docs/ReactNativeHost-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ReactNativeHost
+id: version-0.65-ReactNativeHost
 title: ReactNativeHost
+original_id: ReactNativeHost
 ---
 
 Kind: `class`
@@ -71,5 +72,6 @@ The React instance destruction can be observed with the [`ReactInstanceSettings.
 
 ## Referenced by
 - [`ReactApplication`](ReactApplication)
+- [`ReactCoreInjection`](ReactCoreInjection)
 - [`ReactRootView`](ReactRootView)
 - [`RedBoxHelper`](RedBoxHelper)

--- a/docs/ReactNotificationHandler-api-windows.md
+++ b/docs/ReactNotificationHandler-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ReactNotificationHandler
+id: version-0.65-ReactNotificationHandler
 title: ReactNotificationHandler
+original_id: ReactNotificationHandler
 ---
 
 Kind: `delegate`

--- a/docs/ReactNotificationServiceHelper-api-windows.md
+++ b/docs/ReactNotificationServiceHelper-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ReactNotificationServiceHelper
+id: version-0.65-ReactNotificationServiceHelper
 title: ReactNotificationServiceHelper
+original_id: ReactNotificationServiceHelper
 ---
 
 Kind: `class`

--- a/docs/ReactPropertyBagHelper-api-windows.md
+++ b/docs/ReactPropertyBagHelper-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ReactPropertyBagHelper
+id: version-0.65-ReactPropertyBagHelper
 title: ReactPropertyBagHelper
+original_id: ReactPropertyBagHelper
 ---
 
 Kind: `class`

--- a/docs/ReactRootView-api-windows.md
+++ b/docs/ReactRootView-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ReactRootView
+id: version-0.65-ReactRootView
 title: ReactRootView
+original_id: ReactRootView
 ---
 
 Kind: `class`

--- a/docs/ReactViewManagerProvider-api-windows.md
+++ b/docs/ReactViewManagerProvider-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ReactViewManagerProvider
+id: version-0.65-ReactViewManagerProvider
 title: ReactViewManagerProvider
+original_id: ReactViewManagerProvider
 ---
 
 Kind: `delegate`

--- a/docs/ReactViewOptions-api-windows.md
+++ b/docs/ReactViewOptions-api-windows.md
@@ -1,0 +1,40 @@
+---
+id: version-0.65-ReactViewOptions
+title: ReactViewOptions
+original_id: ReactViewOptions
+---
+
+Kind: `class`
+
+
+
+> **EXPERIMENTAL**
+
+Settings per each IReactViewHost associated with an IReactHost instance.
+
+## Properties
+### ComponentName
+ string `ComponentName`
+
+Name of a component registered in JavaScript via AppRegistry.registerComponent('ModuleName', () => ModuleName);
+
+### InitialProps
+ [`JSValueArgWriter`](JSValueArgWriter) `InitialProps`
+
+Set of initial component properties. It is a JSON string.
+
+
+## Constructors
+### ReactViewOptions
+ **`ReactViewOptions`**()
+
+
+
+
+
+
+
+## Referenced by
+- [`IReactViewHost`](IReactViewHost)
+- [`IReactViewInstance`](IReactViewInstance)
+- [`ReactCoreInjection`](ReactCoreInjection)

--- a/docs/RedBoxErrorType-api-windows.md
+++ b/docs/RedBoxErrorType-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: RedBoxErrorType
+id: version-0.65-RedBoxErrorType
 title: RedBoxErrorType
+original_id: RedBoxErrorType
 ---
 
 Kind: `enum`

--- a/docs/RedBoxHelper-api-windows.md
+++ b/docs/RedBoxHelper-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: RedBoxHelper
+id: version-0.65-RedBoxHelper
 title: RedBoxHelper
+original_id: RedBoxHelper
 ---
 
 Kind: `class`

--- a/docs/SyncMethodDelegate-api-windows.md
+++ b/docs/SyncMethodDelegate-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: SyncMethodDelegate
+id: version-0.65-SyncMethodDelegate
 title: SyncMethodDelegate
+original_id: SyncMethodDelegate
 ---
 
 Kind: `delegate`

--- a/docs/UIBatchCompleteCallback-api-windows.md
+++ b/docs/UIBatchCompleteCallback-api-windows.md
@@ -1,0 +1,21 @@
+---
+id: version-0.65-UIBatchCompleteCallback
+title: UIBatchCompleteCallback
+original_id: UIBatchCompleteCallback
+---
+
+Kind: `delegate`
+
+> **EXPERIMENTAL**
+
+The delegate is called when a UI batch is completed.
+
+## Invoke
+void **`Invoke`**([`IReactPropertyBag`](IReactPropertyBag) properties)
+
+
+
+
+
+## Referenced by
+- [`ReactCoreInjection`](ReactCoreInjection)

--- a/docs/ViewControl-api-windows.md
+++ b/docs/ViewControl-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ViewControl
+id: version-0.65-ViewControl
 title: ViewControl
+original_id: ViewControl
 ---
 
 Kind: `class`

--- a/docs/ViewManagerPropertyType-api-windows.md
+++ b/docs/ViewManagerPropertyType-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ViewManagerPropertyType
+id: version-0.65-ViewManagerPropertyType
 title: ViewManagerPropertyType
+original_id: ViewManagerPropertyType
 ---
 
 Kind: `enum`

--- a/docs/ViewPanel-api-windows.md
+++ b/docs/ViewPanel-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: ViewPanel
+id: version-0.65-ViewPanel
 title: ViewPanel
+original_id: ViewPanel
 ---
 
 Kind: `class`

--- a/docs/XamlHelper-api-windows.md
+++ b/docs/XamlHelper-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: XamlHelper
+id: version-0.65-XamlHelper
 title: XamlHelper
+original_id: XamlHelper
 ---
 
 Kind: `class`

--- a/docs/XamlMetaDataProvider-api-windows.md
+++ b/docs/XamlMetaDataProvider-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: XamlMetaDataProvider
+id: version-0.65-XamlMetaDataProvider
 title: XamlMetaDataProvider
+original_id: XamlMetaDataProvider
 ---
 
 Kind: `class`

--- a/docs/XamlUIService-api-windows.md
+++ b/docs/XamlUIService-api-windows.md
@@ -1,6 +1,7 @@
 ---
-id: XamlUIService
+id: version-0.65-XamlUIService
 title: XamlUIService
+original_id: XamlUIService
 ---
 
 Kind: `class`
@@ -50,7 +51,7 @@ Gets the window handle HWND (as an UInt64) used as the XAML Island window for th
 ### GetXamlRoot
 `static` [`XamlRoot`](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.XamlRoot) **`GetXamlRoot`**([`IReactPropertyBag`](IReactPropertyBag) properties)
 
-Retrieves the default [`XamlRoot`](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.XamlRoot) for the app.
+Retrieves the default [`Xaml.XamlRoot`](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.XamlRoot) for the app.
 
 
 
@@ -73,7 +74,7 @@ Pass the value returned by IDesktopWindowXamlSourceNative get_WindowHandle.
 ### SetXamlRoot
 `static` void **`SetXamlRoot`**([`IReactPropertyBag`](IReactPropertyBag) properties, [`XamlRoot`](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.XamlRoot) xamlRoot)
 
-Sets the [`XamlRoot`](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.XamlRoot) element for the app. This must be manually provided to the [`ReactInstanceSettings`](ReactInstanceSettings) object when using XAML Islands so that certain APIs work correctly.
+Sets the [`Xaml.XamlRoot`](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.XamlRoot) element for the app. This must be manually provided to the [`ReactInstanceSettings`](ReactInstanceSettings) object when using XAML Islands so that certain APIs work correctly.
 For more information, see [Host WinRT XAML Controls in desktop apps (XAML Islands)](https://docs.microsoft.com/windows/apps/desktop/modernize/xaml-islands).
 
 

--- a/docs/index-api-windows.md
+++ b/docs/index-api-windows.md
@@ -1,7 +1,9 @@
 ---
-id: Native-API-Reference
+id: version-0.65-Native-API-Reference
 title: namespace Microsoft.ReactNative
 sidebar_label: Full reference
+original_id: Native-API-Reference
+
 ---
 
 ## Enums
@@ -38,6 +40,8 @@ sidebar_label: Full reference
 - [`IReactPropertyName`](IReactPropertyName)
 - [`IReactPropertyNamespace`](IReactPropertyNamespace)
 - [`IReactSettingsSnapshot`](IReactSettingsSnapshot)
+- [`IReactViewHost`](IReactViewHost)
+- [`IReactViewInstance`](IReactViewInstance)
 - [`IRedBoxErrorFrameInfo`](IRedBoxErrorFrameInfo)
 - [`IRedBoxErrorInfo`](IRedBoxErrorInfo)
 - [`IRedBoxHandler`](IRedBoxHandler)
@@ -77,12 +81,14 @@ sidebar_label: Full reference
 - [`JsiRuntime`](JsiRuntime)
 - [`QuirkSettings`](QuirkSettings)
 - [`ReactApplication`](ReactApplication)
+- [`ReactCoreInjection`](ReactCoreInjection)
 - [`ReactDispatcherHelper`](ReactDispatcherHelper)
 - [`ReactInstanceSettings`](ReactInstanceSettings)
 - [`ReactNativeHost`](ReactNativeHost)
 - [`ReactNotificationServiceHelper`](ReactNotificationServiceHelper)
 - [`ReactPropertyBagHelper`](ReactPropertyBagHelper)
 - [`ReactRootView`](ReactRootView)
+- [`ReactViewOptions`](ReactViewOptions)
 - [`RedBoxHelper`](RedBoxHelper)
 - [`ViewControl`](ViewControl)
 - [`ViewPanel`](ViewPanel)
@@ -105,3 +111,4 @@ sidebar_label: Full reference
 - [`ReactNotificationHandler`](ReactNotificationHandler)
 - [`ReactViewManagerProvider`](ReactViewManagerProvider)
 - [`SyncMethodDelegate`](SyncMethodDelegate)
+- [`UIBatchCompleteCallback`](UIBatchCompleteCallback)


### PR DESCRIPTION
**_Why_**
Updating docs, so that new edition of docs will be ready for the 0.65 release. 

**_What_**
Copied over docs changes from [0.65-stable](https://github.com/microsoft/react-native-windows/tree/0.65-stable/docs).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/470)