### PR TITLE
Fix Highlighting of Misspelled Words in CI Output 

### DIFF
--- a/.github/workflows/website-pr.yml
+++ b/.github/workflows/website-pr.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Spell-check docs
-      run: npx markdown-spellcheck "docs\*.md" "!docs\*-api-windows.md" --en-us --ignore-acronyms --ignore-numbers --report
+      run: npx markdown-spellcheck "docs\*.md" "!docs\*-api-windows.md" --en-us --ignore-acronyms --ignore-numbers --report --color
 
     - name: Check unbroken exclusions file
       run: ${{github.workspace}}\.github\scripts\CheckUnbrokenExclusions.ps1

--- a/docs/windowsbrush-and-theme.md
+++ b/docs/windowsbrush-and-theme.md
@@ -13,7 +13,7 @@ In this example, we'll look at three things:
 
 - How to set up your React Native app to be style and event sensitive to the system themes
 - How to switch styles when a theme change has occurred
-- Handling a theme changed event
+- Handlingggg a theme changed event
 
 #### Using hooks to be sensitive to theme changes
 

--- a/docs/windowsbrush-and-theme.md
+++ b/docs/windowsbrush-and-theme.md
@@ -13,7 +13,7 @@ In this example, we'll look at three things:
 
 - How to set up your React Native app to be style and event sensitive to the system themes
 - How to switch styles when a theme change has occurred
-- Handlingggg a theme changed event
+- Handling a theme changed event
 
 #### Using hooks to be sensitive to theme changes
 


### PR DESCRIPTION
This repo uses markdown-spellcheck to catch document spelling errors. Its output shows the word it does not recognize via coloration. It uses Chalk to do this, which will by default noop when running in a non-interactive console (i.e. something that doesn't know how to show color).

This lack of color means we can't tell the word being complained about. GitHub Actions can render color, but we need to force chalk to. We pass the `--color` CLI arg for chalk to read, and override default logic to omit ANSI escape codes.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/478)