### PR TITLE
Update Website References of Branch Name to main

### DIFF
--- a/.github/workflows/samples-Calculator-CI.yml
+++ b/.github/workflows/samples-Calculator-CI.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 15 * * 2' # Tuesday 3PM UTC (8AM PST)
   push:
     branches:
-      - master
+      - main
     paths:
       - 'samples/Calculator/**'
       - '.github/workflows/samples-Calculator-CI.yml'

--- a/.github/workflows/samples-Calculator-ci-upgrade.yml
+++ b/.github/workflows/samples-Calculator-ci-upgrade.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 15 * * 2' # Tuesday 3PM UTC (8AM PST)
   push:
     branches:
-      - master
+      - main
     paths:
       - '.github/workflows/samples-Calculator-ci-upgrade.yml'
 

--- a/.github/workflows/samples-Calculator-pr.yml
+++ b/.github/workflows/samples-Calculator-pr.yml
@@ -3,7 +3,7 @@ name: Calculator PR
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - 'samples/Calculator/**'
       - '.github/workflows/samples-Calculator-*.yml'

--- a/.github/workflows/samples-CalculatorNuGet-ci-upgrade.yml
+++ b/.github/workflows/samples-CalculatorNuGet-ci-upgrade.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 15 * * 2' # Tuesday 3PM UTC (8AM PST)
   push:
     branches:
-      - master
+      - main
     paths:
       - '.github/workflows/samples-CalculatorNuGet-ci-upgrade.yml'
 

--- a/.github/workflows/samples-CalculatorNuGet-ci.yml
+++ b/.github/workflows/samples-CalculatorNuGet-ci.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 15 * * 2' # Tuesday 3PM UTC (8AM PST)
   push:
     branches:
-      - master
+      - main
     paths:
       - 'samples/CalculatorNuGet/**'
       - '.github/workflows/samples-CalculatorNuGet-ci.yml'

--- a/.github/workflows/samples-CalculatorNuGet-pr.yml
+++ b/.github/workflows/samples-CalculatorNuGet-pr.yml
@@ -3,7 +3,7 @@ name: CalculatorNuGet PR
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - 'samples/CalculatorNuGet/**'
       - '.github/workflows/samples-CalculatorNuGet-*.yml'

--- a/.github/workflows/samples-CameraDemo-ci-upgrade.yml
+++ b/.github/workflows/samples-CameraDemo-ci-upgrade.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 15 * * 2' # Tuesday 3PM UTC (8AM PST)
   push:
     branches:
-      - master
+      - main
     paths:
       - '.github/workflows/samples-CameraDemo-ci-upgrade.yml'
 

--- a/.github/workflows/samples-CameraDemo-ci.yml
+++ b/.github/workflows/samples-CameraDemo-ci.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 15 * * 2' # Tuesday 3PM UTC (8AM PST)
   push:
     branches:
-      - master
+      - main
     paths:
       - 'samples/CameraDemo/**'
       - '.github/workflows/samples-CameraDemo-ci.yml'

--- a/.github/workflows/samples-CameraDemo-pr.yml
+++ b/.github/workflows/samples-CameraDemo-pr.yml
@@ -3,7 +3,7 @@ name: CameraDemo PR
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - 'samples/CameraDemo/**'
       - '.github/workflows/samples-CameraDemo-*.yml'

--- a/.github/workflows/samples-NativeModuleSample-CI.yml
+++ b/.github/workflows/samples-NativeModuleSample-CI.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 15 * * 2' # Tuesday 3PM UTC (8AM PST)
   push:
     branches:
-      - master
+      - main
     paths:
       - 'samples/NativeModuleSample/**'
       - '.github/workflows/samples-NativeModuleSample-CI.yml'

--- a/.github/workflows/samples-NativeModuleSample-ci-upgrade.yml
+++ b/.github/workflows/samples-NativeModuleSample-ci-upgrade.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 15 * * 2' # Tuesday 3PM UTC (8AM PST)
   push:
     branches:
-      - master
+      - main
     paths:
       - '.github/workflows/samples-NativeModuleSample-ci-upgrade.yml'
 

--- a/.github/workflows/samples-NativeModuleSample-pr.yml
+++ b/.github/workflows/samples-NativeModuleSample-pr.yml
@@ -3,7 +3,7 @@ name: NativeModuleSample PR
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - 'samples/NativeModuleSample/**'
       - '.github/workflows/samples-NativeModuleSample-*.yml'

--- a/.github/workflows/samples-RssReader-CI.yml
+++ b/.github/workflows/samples-RssReader-CI.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 15 * * 2' # Tuesday 3PM UTC (8AM PST)
   push:
     branches:
-      - master
+      - main
     paths:
       - 'samples/rssreader/**'
       - '.github/workflows/samples-RssReader-CI.yml'

--- a/.github/workflows/samples-RssReader-ci-upgrade.yml
+++ b/.github/workflows/samples-RssReader-ci-upgrade.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 15 * * 2' # Tuesday 3PM UTC (8AM PST)
   push:
     branches:
-      - master
+      - main
     paths:
       - '.github/workflows/samples-RssReader-ci-upgrade.yml'
 

--- a/.github/workflows/samples-RssReader-pr.yml
+++ b/.github/workflows/samples-RssReader-pr.yml
@@ -3,7 +3,7 @@ name: RssReader PR
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - 'samples/rssreader/**'
       - '.github/workflows/samples-RssReader-*.yml'

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 15 * * 2' # Tuesday 3PM UTC (8AM PST)
   push:
     branches:
-      - master
+      - main
     paths:
       - '.github/workflows/website-ci.yml'
       - '.github/workflows/website-pr.yml'

--- a/.github/workflows/website-pr.yml
+++ b/.github/workflows/website-pr.yml
@@ -3,7 +3,7 @@ name: RNW Website PR
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - '.github/workflows/website-ci.yml'
       - '.github/workflows/website-pr.yml'

--- a/.github/workflows/website-publish.yml
+++ b/.github/workflows/website-publish.yml
@@ -3,7 +3,7 @@ name: RNW Website Publish
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - '.github/workflows/website-publish.yml'
       - 'docs/**'

--- a/docs/native-modules-advanced.md
+++ b/docs/native-modules-advanced.md
@@ -5,7 +5,7 @@ title: Native Modules (Advanced)
 
 >**This documentation and the underlying platform code is a work in progress.**
 >**Examples (C# and C++/WinRT):**
-> - [Native Module Sample in `microsoft/react-native-windows-samples`](https://github.com/microsoft/react-native-windows-samples/tree/master/samples/NativeModuleSample)
+> - [Native Module Sample in `microsoft/react-native-windows-samples`](https://github.com/microsoft/react-native-windows-samples/tree/main/samples/NativeModuleSample)
 > - [Sample App in `microsoft/react-native-windows/packages/microsoft-reactnative-sampleapps`](https://github.com/microsoft/react-native-windows/tree/master/packages/sample-apps)
 
 ## Writing Native Modules without using Attributes (C#)

--- a/docs/native-modules-async.md
+++ b/docs/native-modules-async.md
@@ -9,7 +9,7 @@ A common scenario for [Native Modules](native-modules.md) is to call one or more
 
 This document proposes some best patterns to follow when bridging asynchronous methods from JS to native code for React Native Windows. It assumes you've already familiar with the basics of setting up and writing [Native Modules](native-modules.md).
 
-> The complete source for the examples below are provided within the [Native Module Sample in `microsoft/react-native-windows-samples`](https://github.com/microsoft/react-native-windows-samples/tree/master/samples/NativeModuleSample).
+> The complete source for the examples below are provided within the [Native Module Sample in `microsoft/react-native-windows-samples`](https://github.com/microsoft/react-native-windows-samples/tree/main/samples/NativeModuleSample).
 
 ## Writing Native Modules that call Asynchronous Windows APIs
 
@@ -115,7 +115,7 @@ as well as store the status code and update the return statement from `return co
 
 But wait, we've only discussed the success path, what happens if `GetHttpResponse` doesn't succeed? We don't handle any exceptions in this example. If an exception is thrown, how do we marshal an error back to JavaScript? That is actually taken care of for you by the framework: any exception in the task will be marshaled to the JavaScript side as a JavaScript exception.
 
-That's it! If you want to see the complete `SimpleHttpModule`, see [`AsyncMethodExamples.cs`](https://github.com/microsoft/react-native-windows-samples/blob/master/samples/NativeModuleSample/csharp/windows/NativeModuleSample/AsyncMethodExamples.cs).
+That's it! If you want to see the complete `SimpleHttpModule`, see [`AsyncMethodExamples.cs`](https://github.com/microsoft/react-native-windows-samples/blob/main/samples/NativeModuleSample/csharp/windows/NativeModuleSample/AsyncMethodExamples.cs).
 
 ### `SimpleHttpModule` in C++/WinRT
 
@@ -256,7 +256,7 @@ We've defined an `AsyncActionCompletedHandler` lambda and set it to be run when 
 
 > **Important:** This example shows the minimum case, where you don't handle any errors within `GetHttpResponseAsync`, but you're not limited to this. You're free to detect error conditions within your code and call `capturedPromise.Reject()` yourself with (more useful) error messages at any time. However you should *always* include this final handler, to catch any unexpected and unhandled exceptions that may occur, especially when calling Windows APIs. Just be sure that you only call `Reject()` once and that nothing executes afterwards.
 
-That's it! If you want to see the complete `SimpleHttpModule`, see [`AsyncMethodExamples.h`](https://github.com/microsoft/react-native-windows-samples/blob/master/samples/NativeModuleSample/cppwinrt/windows/NativeModuleSample/AsyncMethodExamples.h).
+That's it! If you want to see the complete `SimpleHttpModule`, see [`AsyncMethodExamples.h`](https://github.com/microsoft/react-native-windows-samples/blob/main/samples/NativeModuleSample/cppwinrt/windows/NativeModuleSample/AsyncMethodExamples.h).
 
 ## Executing calls to API on the UI thread
 

--- a/docs/native-modules-marshalling-data.md
+++ b/docs/native-modules-marshalling-data.md
@@ -37,7 +37,7 @@ The end-to-end data flow looks something like this:
 
 ## Examples
 
-For examples of using data automatically marshaled into both static and dynamic native types, see the `DataMarshalingExamples` module within the [Native Module Sample in `microsoft/react-native-windows-samples`](https://github.com/microsoft/react-native-windows-samples/tree/master/samples/NativeModuleSample). Implementations for both C# and C++/WinRT are provided.
+For examples of using data automatically marshaled into both static and dynamic native types, see the `DataMarshalingExamples` module within the [Native Module Sample in `microsoft/react-native-windows-samples`](https://github.com/microsoft/react-native-windows-samples/tree/main/samples/NativeModuleSample). Implementations for both C# and C++/WinRT are provided.
 
 For further examples of using the dynamic `JSValue` type, see [Using `JSValue`](native-modules-jsvalue.md).
 

--- a/docs/native-modules-setup.md
+++ b/docs/native-modules-setup.md
@@ -6,7 +6,7 @@ title: Native Module Setup
 > **This documentation is a work in progress and version-specific. Please check that the version of this document (top of page) matches the version of RN/RNW you're targeting.**
 > **Examples (C# and C++/WinRT):**
 >
-> - [Native Module Sample in `microsoft/react-native-windows-samples`](https://github.com/microsoft/react-native-windows-samples/tree/master/samples/NativeModuleSample)
+> - [Native Module Sample in `microsoft/react-native-windows-samples`](https://github.com/microsoft/react-native-windows-samples/tree/main/samples/NativeModuleSample)
 > - [Sample App in `microsoft/react-native-windows/packages/microsoft-reactnative-sampleapps`](https://github.com/microsoft/react-native-windows/tree/master/packages/sample-apps)
 
 This guide will help set you up with the Visual Studio infrastructure to author your own stand-alone native module for React Native Windows. In this document we'll be creating the scaffolding for a `NativeModuleSample` native module.

--- a/docs/native-modules.md
+++ b/docs/native-modules.md
@@ -6,7 +6,7 @@ title: Native Modules
 > **This documentation and the underlying platform code is a work in progress.**
 > **Examples (C# and C++/WinRT):**
 >
-> - [Native Module Sample in `microsoft/react-native-windows-samples`](https://github.com/microsoft/react-native-windows-samples/tree/master/samples/NativeModuleSample)
+> - [Native Module Sample in `microsoft/react-native-windows-samples`](https://github.com/microsoft/react-native-windows-samples/tree/main/samples/NativeModuleSample)
 > - [Sample App in `microsoft/react-native-windows/packages/microsoft-reactnative-sampleapps`](https://github.com/microsoft/react-native-windows/tree/master/packages/sample-apps)
 
 Sometimes an app needs access to a platform API that React Native doesn't have a corresponding module for yet. Maybe you want to reuse some existing .NET code without having to re-implement it in JavaScript, or write some high performance, multi-threaded code for image processing, a database, or any number of advanced extensions.

--- a/docs/view-managers.md
+++ b/docs/view-managers.md
@@ -6,7 +6,7 @@ title: Native UI Components
 > **This documentation and the underlying platform code is a work in progress.**
 > **Examples (C# and C++/WinRT):**
 >
-> - [Native Module Sample in `microsoft/react-native-windows-samples`](https://github.com/microsoft/react-native-windows-samples/tree/master/samples/NativeModuleSample)
+> - [Native Module Sample in `microsoft/react-native-windows-samples`](https://github.com/microsoft/react-native-windows-samples/tree/main/samples/NativeModuleSample)
 > - [Sample App in `microsoft/react-native-windows/packages/microsoft-reactnative-sampleapps`](https://github.com/microsoft/react-native-windows/tree/master/packages/sample-apps)
 
 There are tons of native UI widgets out there ready to be used in the latest apps - some of them are part of the platform, others are available as third-party libraries, and still more might be in use in your very own portfolio. React Native has several of the most critical platform components already wrapped, like `ScrollView` and `TextInput`, but not all of them, and certainly not ones you might have written yourself for a previous app. Fortunately, we can wrap up these existing components for seamless integration with your React Native application.

--- a/samples/ContinuousIntegration/GitHubActions/0.62/build-app-ci.yml
+++ b/samples/ContinuousIntegration/GitHubActions/0.62/build-app-ci.yml
@@ -1,5 +1,5 @@
 # This workflow will build all flavors of your React Native for Windows app
-# project every time changes are pushed to master. This checks that every
+# project every time changes are pushed to main. This checks that every
 # change builds on Windows.
 
 name: App CI
@@ -7,7 +7,7 @@ name: App CI
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   # This job builds both Debug and Release versions of the app, for all

--- a/samples/ContinuousIntegration/GitHubActions/0.62/build-app-pr.yml
+++ b/samples/ContinuousIntegration/GitHubActions/0.62/build-app-pr.yml
@@ -1,5 +1,5 @@
 # This workflow will build just one configuration (Debug x86) of your React
-# Native for Windows app project on every pull request targeting master. This
+# Native for Windows app project on every pull request targeting main. This
 # is meant to be a quick sanity check that a pull request doesn't break the
 # build, without spending the resources to build every flavor / configuration.
 
@@ -8,7 +8,7 @@ name: App PR
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   # This job builds the Debug x86 version of the app.

--- a/samples/ContinuousIntegration/GitHubActions/0.62/build-nativemodule-ci.yml
+++ b/samples/ContinuousIntegration/GitHubActions/0.62/build-nativemodule-ci.yml
@@ -1,5 +1,5 @@
 # This workflow will build all flavors of your React Native for Windows native
-#  module project every time changes are pushed to master. This checks that
+#  module project every time changes are pushed to main. This checks that
 # every change builds on Windows.
 
 name: Native Module CI
@@ -7,7 +7,7 @@ name: Native Module CI
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   # This job builds both Debug and Release versions of the native module, for

--- a/samples/ContinuousIntegration/GitHubActions/0.62/build-nativemodule-pr.yml
+++ b/samples/ContinuousIntegration/GitHubActions/0.62/build-nativemodule-pr.yml
@@ -1,6 +1,6 @@
 # This workflow will build just one configuration (Debug x86) of your React
 # Native for Windows native module project on every pull request targeting
-# master. This is meant to be a quick sanity check that a pull request doesn't
+# main. This is meant to be a quick sanity check that a pull request doesn't
 # break the build, without spending the resources to build every flavor /
 # configuration.
 
@@ -9,7 +9,7 @@ name: Native Module PR
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   # This job builds the Debug x86 version of the native module.

--- a/samples/ContinuousIntegration/GitHubActions/0.63/build-app-ci.yml
+++ b/samples/ContinuousIntegration/GitHubActions/0.63/build-app-ci.yml
@@ -1,5 +1,5 @@
 # This workflow will build all flavors of your React Native for Windows app
-# project every time changes are pushed to master. This checks that every
+# project every time changes are pushed to main. This checks that every
 # change builds on Windows.
 
 name: App CI
@@ -7,7 +7,7 @@ name: App CI
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   # This job builds both Debug and Release versions of the app, for all

--- a/samples/ContinuousIntegration/GitHubActions/0.63/build-app-pr.yml
+++ b/samples/ContinuousIntegration/GitHubActions/0.63/build-app-pr.yml
@@ -1,5 +1,5 @@
 # This workflow will build just one configuration (Debug x86) of your React
-# Native for Windows app project on every pull request targeting master. This
+# Native for Windows app project on every pull request targeting main. This
 # is meant to be a quick sanity check that a pull request doesn't break the
 # build, without spending the resources to build every flavor / configuration.
 
@@ -8,7 +8,7 @@ name: App PR
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   # This job builds the Debug x86 version of the app.

--- a/samples/ContinuousIntegration/GitHubActions/0.63/build-nativemodule-ci.yml
+++ b/samples/ContinuousIntegration/GitHubActions/0.63/build-nativemodule-ci.yml
@@ -1,5 +1,5 @@
 # This workflow will build all flavors of your React Native for Windows native
-#  module project every time changes are pushed to master. This checks that
+#  module project every time changes are pushed to main. This checks that
 # every change builds on Windows.
 
 name: Native Module CI
@@ -7,7 +7,7 @@ name: Native Module CI
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   # This job builds both Debug and Release versions of the native module, for

--- a/samples/ContinuousIntegration/GitHubActions/0.63/build-nativemodule-pr.yml
+++ b/samples/ContinuousIntegration/GitHubActions/0.63/build-nativemodule-pr.yml
@@ -1,6 +1,6 @@
 # This workflow will build just one configuration (Debug x86) of your React
 # Native for Windows native module project on every pull request targeting
-# master. This is meant to be a quick sanity check that a pull request doesn't
+# main. This is meant to be a quick sanity check that a pull request doesn't
 # break the build, without spending the resources to build every flavor /
 # configuration.
 
@@ -9,7 +9,7 @@ name: Native Module PR
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   # This job builds the Debug x86 version of the native module.

--- a/samples/ContinuousIntegration/GitHubActions/0.64/build-app-ci.yml
+++ b/samples/ContinuousIntegration/GitHubActions/0.64/build-app-ci.yml
@@ -1,5 +1,5 @@
 # This workflow will build all flavors of your React Native for Windows app
-# project every time changes are pushed to master. This checks that every
+# project every time changes are pushed to main. This checks that every
 # change builds on Windows.
 
 name: App CI
@@ -7,7 +7,7 @@ name: App CI
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   # This job builds both Debug and Release versions of the app, for all

--- a/samples/ContinuousIntegration/GitHubActions/0.64/build-app-pr.yml
+++ b/samples/ContinuousIntegration/GitHubActions/0.64/build-app-pr.yml
@@ -1,5 +1,5 @@
 # This workflow will build just one configuration (Debug x86) of your React
-# Native for Windows app project on every pull request targeting master. This
+# Native for Windows app project on every pull request targeting main. This
 # is meant to be a quick sanity check that a pull request doesn't break the
 # build, without spending the resources to build every flavor / configuration.
 
@@ -8,7 +8,7 @@ name: App PR
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   # This job builds the Debug x86 version of the app.

--- a/samples/ContinuousIntegration/GitHubActions/0.64/build-nativemodule-ci.yml
+++ b/samples/ContinuousIntegration/GitHubActions/0.64/build-nativemodule-ci.yml
@@ -1,5 +1,5 @@
 # This workflow will build all flavors of your React Native for Windows native
-#  module project every time changes are pushed to master. This checks that
+#  module project every time changes are pushed to main. This checks that
 # every change builds on Windows.
 
 name: Native Module CI
@@ -7,7 +7,7 @@ name: Native Module CI
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   # This job builds both Debug and Release versions of the native module, for

--- a/samples/ContinuousIntegration/GitHubActions/0.64/build-nativemodule-pr.yml
+++ b/samples/ContinuousIntegration/GitHubActions/0.64/build-nativemodule-pr.yml
@@ -1,6 +1,6 @@
 # This workflow will build just one configuration (Debug x86) of your React
 # Native for Windows native module project on every pull request targeting
-# master. This is meant to be a quick sanity check that a pull request doesn't
+# main. This is meant to be a quick sanity check that a pull request doesn't
 # break the build, without spending the resources to build every flavor /
 # configuration.
 
@@ -9,7 +9,7 @@ name: Native Module PR
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   # This job builds the Debug x86 version of the native module.

--- a/samples/ContinuousIntegration/GitHubActions/0.65/build-app-ci.yml
+++ b/samples/ContinuousIntegration/GitHubActions/0.65/build-app-ci.yml
@@ -1,5 +1,5 @@
 # This workflow will build all flavors of your React Native for Windows app
-# project every time changes are pushed to master. This checks that every
+# project every time changes are pushed to main. This checks that every
 # change builds on Windows.
 
 name: App CI
@@ -7,7 +7,7 @@ name: App CI
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   # This job builds both Debug and Release versions of the app, for all

--- a/samples/ContinuousIntegration/GitHubActions/0.65/build-app-pr.yml
+++ b/samples/ContinuousIntegration/GitHubActions/0.65/build-app-pr.yml
@@ -1,5 +1,5 @@
 # This workflow will build just one configuration (Debug x86) of your React
-# Native for Windows app project on every pull request targeting master. This
+# Native for Windows app project on every pull request targeting main. This
 # is meant to be a quick sanity check that a pull request doesn't break the
 # build, without spending the resources to build every flavor / configuration.
 
@@ -8,7 +8,7 @@ name: App PR
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   # This job builds the Debug x86 version of the app.

--- a/samples/ContinuousIntegration/GitHubActions/0.65/build-nativemodule-ci.yml
+++ b/samples/ContinuousIntegration/GitHubActions/0.65/build-nativemodule-ci.yml
@@ -1,5 +1,5 @@
 # This workflow will build all flavors of your React Native for Windows native
-#  module project every time changes are pushed to master. This checks that
+#  module project every time changes are pushed to main. This checks that
 # every change builds on Windows.
 
 name: Native Module CI
@@ -7,7 +7,7 @@ name: Native Module CI
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   # This job builds both Debug and Release versions of the native module, for

--- a/samples/ContinuousIntegration/GitHubActions/0.65/build-nativemodule-pr.yml
+++ b/samples/ContinuousIntegration/GitHubActions/0.65/build-nativemodule-pr.yml
@@ -1,6 +1,6 @@
 # This workflow will build just one configuration (Debug x86) of your React
 # Native for Windows native module project on every pull request targeting
-# master. This is meant to be a quick sanity check that a pull request doesn't
+# main. This is meant to be a quick sanity check that a pull request doesn't
 # break the build, without spending the resources to build every flavor /
 # configuration.
 
@@ -9,7 +9,7 @@ name: Native Module PR
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   # This job builds the Debug x86 version of the native module.

--- a/website/README.md
+++ b/website/README.md
@@ -197,22 +197,22 @@ For more information about custom pages, click [here](https://v1.docusaurus.io/d
 
 1. Submit code updates to react-native-windows `main` branch.
 1. Submit documentation updates to this repo's `main` branch.
-    1. Documents should be added/updated in [docs](docs/)
-    1. Update sidebar contents in **sidebars.json** in [website](website/)
+    1. Documents should be added/updated in [docs](../docs/)
+    1. Update sidebar contents in **sidebars.json** in [website](../website/)
 
 ## Changes to a stable version 0.XX
 
 1. Submit code updates to react-native-windows `0.XX-stable` branch.
 1. Submit documentation updates to this repo's `main` branch.
-    1. Documents should be added/updated in **version-0.XX** folder under [website/versioned_docs](website/versioned_docs/).
-    1. Update sidebar contents in **version-0.XX-sidebars.json** in [website/versioned_sidebars](website/versioned_sidebars/).
+    1. Documents should be added/updated in **version-0.XX** folder under [/website/versioned_docs](../website/versioned_docs/).
+    1. Update sidebar contents in **version-0.XX-sidebars.json** in [/website/versioned_sidebars](../website/versioned_sidebars/).
 
 ## Changes in main and backported to stable version 0.XX
 
 Complete the documentation updates for both main and stable version 0.XX above.
 
 ## Cutting Documentation for a New React Native Windows Release
-1. Update necessary version references in [docs](docs/).
+1. Update necessary version references in [docs](../docs/).
 2. Snapshot the website for version 0.XX: 
     1. `cd website`
     1. `yarn run version 0.XX`

--- a/website/blog/2020-05-19-rn4mupdadates.md
+++ b/website/blog/2020-05-19-rn4mupdadates.md
@@ -58,7 +58,7 @@ Lastly, in addition to contributing to these community modules personally, we wa
 
 The WebView module sets you up with the barebones web hosting tech that's available nativly on the device you're targetting. This module has been updated to support Windows and macOS.
 
-> To get your own version of the app in this short clip, check out the [RssReader sample](https://github.com/microsoft/react-native-windows-samples/tree/master/samples/rssreader).
+> To get your own version of the app in this short clip, check out the [RssReader sample](https://github.com/microsoft/react-native-windows-samples/tree/main/samples/rssreader).
 
 ### Camera
 

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -59,7 +59,7 @@ class Footer extends React.Component {
               GitHub
             </a>
             <a
-              href="https://github.com/microsoft/react-native-windows-samples/tree/master/samples"
+              href="https://github.com/microsoft/react-native-windows-samples/tree/main/samples"
               target="_blank"
             >
               Samples

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -87,8 +87,8 @@ If you're curious about the **sample apps** we have published for inspiration:
 [check out our list here]: docs/flyout-component
 [Native modules]: docs/native-modules
 [Native UI components]: docs/view-managers
-[Calculator app]: https://github.com/microsoft/react-native-windows-samples/tree/master/samples/Calculator
-[ToDos Feed app]: https://github.com/microsoft/react-native-windows-samples/tree/master/samples/TodosFeed
+[Calculator app]: https://github.com/microsoft/react-native-windows-samples/tree/main/samples/Calculator
+[ToDos Feed app]: https://github.com/microsoft/react-native-windows-samples/tree/main/samples/TodosFeed
 [Windows AppConsult blog]: https://techcommunity.microsoft.com/t5/Windows-Dev-AppConsult/Getting-started-with-React-Native-for-Windows/ba-p/912093
   `
 };

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -23,7 +23,7 @@ const siteConfig = {
   organizationName: "microsoft",
 
   editUrl:
-    "https://github.com/microsoft/react-native-windows-samples/blob/master/docs/",
+    "https://github.com/microsoft/react-native-windows-samples/blob/main/docs/",
 
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [
@@ -31,7 +31,7 @@ const siteConfig = {
     { doc: "flyout-component", label: "APIs" },
     { blog: true, label: "Blog" },
     { page: "resources", label: "Resources" },
-    { href: repoUrl + "-samples/tree/master/samples", label: "Samples" },
+    { href: repoUrl + "-samples/tree/main/samples", label: "Samples" },
     // { search: true }, https://community.algolia.com/docsearch/what-is-docsearch.html
   ],
 


### PR DESCRIPTION
**_Why_**
Following move of repo's default branch name to 'main', all references to default branch must be altered to not break website functionality. 

**_What_**
Updated all references of 'master' to 'main'.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/485)