### PR TITLE
Update AppTheme Docs for 0.65

### DIFF
--- a/docs/apptheme-api-windows.md
+++ b/docs/apptheme-api-windows.md
@@ -15,26 +15,26 @@ import { Text } from 'react-native';
 import { AppTheme } from 'react-native-windows';
 
 const HighContrastEnabledText = () => {
-  const [isHighConstrast, setHighContrast] = useState(AppTheme.isHighContrast);
-  
+  const [isHighContrast, setHighContrast] = useState(AppTheme.isHighContrast);
+
   useEffect(() => {
     function onHighContrastChanged() {
       setHighContrast(AppTheme.isHighContrast);
     }
-  
-    AppTheme.addListener("highContrastChanged", onHighContrastChanged);
-    
+
+    AppTheme.addListener('highContrastChanged', onHighContrastChanged);
+
     return () => {
-      AppTheme.removeListener("highContrastChanged", onHighContrastChanged);
-    }
+      AppTheme.removeListener('highContrastChanged', onHighContrastChanged);
+    };
   });
-  
+
   if (isHighContrast) {
     return <Text>High Contrast Enabled</Text>;
   } else {
     return <Text>High Contrast Disabled</Text>;
   }
-}
+};
 
 export default HighContrastEnabledText;
 ```

--- a/docs/apptheme-api-windows.md
+++ b/docs/apptheme-api-windows.md
@@ -10,7 +10,7 @@ title: AppTheme
 `AppTheme` allows you to detect when an application is in high constrast mode, and the colors that should be used when inside of it.
 
 ```jsx
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Text } from 'react-native';
 import { AppTheme } from 'react-native-windows';
 

--- a/docs/apptheme-api-windows.md
+++ b/docs/apptheme-api-windows.md
@@ -15,7 +15,7 @@ import { Text } from 'react-native';
 import { AppTheme } from 'react-native-windows';
 
 const HighContrastEnabledText = () => {
-  const [isHighConstrast, setHighContrast] = useState(false);
+  const [isHighConstrast, setHighContrast] = useState(AppTheme.isHighContrast);
   
   useEffect(() => {
     function onHighContrastChanged() {

--- a/docs/apptheme-api-windows.md
+++ b/docs/apptheme-api-windows.md
@@ -3,81 +3,65 @@ id: apptheme-api
 title: AppTheme
 ---
 
-> This API name is deprecated.  Use react-native's [``Appearance``](https://reactnative.dev/docs/appearance) API instead.
+> This API previously allowed responding to light/dark mode, but this functionality was removed in favor of react-native's
+> [``Appearance``](https://reactnative.dev/docs/appearance) API. We hope to
+> [reconcile](https://github.com/microsoft/react-native-windows/issues/3701) high APIs in a future release of `react-native-windows`.
 
-`AppTheme` allows you to detect Windows app theme changes - dark, light or high contrast - as well as which theme the app is in and the theme colors being used when in high contrast mode.
+`AppTheme` allows you to detect when an application is in high constrast mode, and the colors that should be used when inside of it.
 
-```
-import { AppTheme } from 'react-native-windows'
+```jsx
+import { useState } from 'react';
+import { Text } from 'react-native';
+import { AppTheme } from 'react-native-windows';
 
-const App = class App extends React.Component {
-  state = {
-    currentTheme: AppTheme.currentTheme
-  }
-
-  componentDidMount() {
-    AppTheme.addListener("appThemeChanged", this.onAppThemeChanged);
-  }
-
-  componentWillUnmount() {
-    AppTheme.removeListener("appThemeChanged", this.onAppThemeChanged);
-  }
-
-  onAppThemeChanged = (event) => {
-    const currentTheme = AppTheme.currentTheme;
-    this.setState({currentTheme});
-  };
-
-  render() {
-    return (
-      <Button title="click me" color={this.state.currentTheme === "dark" ? "grey" : "orange"}/>
-    );
+const HighContrastEnabledText = () => {
+  const [isHighConstrast, setHighContrast] = useState(false);
+  
+  useEffect(() => {
+    function onHighContrastChanged() {
+      setHighContrast(AppTheme.isHighContrast);
+    }
+  
+    AppTheme.addListener("highContrastChanged", onHighContrastChanged);
+    
+    return () => {
+      AppTheme.removeListener("highContrastChanged", onHighContrastChanged);
+    }
+  });
+  
+  if (isHighContrast) {
+    return <Text>High Contrast Enabled</Text>;
+  } else {
+    return <Text>High Contrast Disabled</Text>;
   }
 }
 
-export default App;
+export default HighContrastEnabledText;
 ```
 
 # Reference
 
-## Methods
+## Events
 
-### ``getCurrentTheme()``
-
-```
-string getCurrentTheme()
-```
-
-Returns the string either ``dark`` or ``light`` depending on which theme the app is in.
-
-### ``isHighContrast()``
-
-```
-bool isHighContrast()
-```
-
-Returns ``true`` when the user has set their system to high contrast mode. ``False`` otherwise.
-
-### ``currentHighContrastColors()``
-
-```
-IHighContrastColors currentHighContrastColors()
-```
-
-Returns the list of colors being used in high contrast.
-
-### ``appThemeChanged()``
-
-```
-static appThemeChanged()
-```
-
-An event that fires when the user's app changes theme.
-
-### ``highContrastChanged()``
-
-```
-static highContrastChanged()
-```
+### ``highContrastChanged``
 
 An event that fires when the user's app changes to a high contrast theme.
+
+## Properties
+
+### ``isHighContrast``
+
+```
+bool isHighContrast
+```
+
+``true`` when the user has set their system to high contrast mode. ``false`` otherwise.
+
+### ``currentHighContrastColors``
+
+```
+IHighContrastColors currentHighContrastColors
+```
+
+The list of colors being used in high contrast.
+

--- a/docs/apptheme-api-windows.md
+++ b/docs/apptheme-api-windows.md
@@ -14,19 +14,15 @@ import { useEffect, useState } from 'react';
 import { Text } from 'react-native';
 import { AppTheme } from 'react-native-windows';
 
-const HighContrastEnabledText = () => {
+const SampleComponent = () => {
   const [isHighContrast, setHighContrast] = useState(AppTheme.isHighContrast);
 
   useEffect(() => {
-    function onHighContrastChanged() {
+    const subscription = AppTheme.addListener('highContrastChanged', () => {
       setHighContrast(AppTheme.isHighContrast);
-    }
+    });
 
-    AppTheme.addListener('highContrastChanged', onHighContrastChanged);
-
-    return () => {
-      AppTheme.removeListener('highContrastChanged', onHighContrastChanged);
-    };
+    return () => subscription.remove();
   });
 
   if (isHighContrast) {
@@ -36,7 +32,7 @@ const HighContrastEnabledText = () => {
   }
 };
 
-export default HighContrastEnabledText;
+export default SampleComponent;
 ```
 
 # Reference


### PR DESCRIPTION
Everything in AppTheme that overlapped with Appearance was removed. Remove the APIs, and rewrite the sample to not use them. We convert from a class component to function component when updating the sample. The methods are also exposing as property getters instead of methods, so we change the examples there.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/487)