### PR TITLE
Remove reference to acceptsKeyboardFocus

### DIFF
--- a/docs/iviewwindowsprops-api-windows.md
+++ b/docs/iviewwindowsprops-api-windows.md
@@ -9,12 +9,6 @@ This extends the [View Props](https://reactnative.dev/docs/view#props) and [`IKe
 
 ## Methods
 
-### `acceptsKeyboardFocus`
-
-| type | required |
-|:--|:--|
-| bool | No |
-
 ### `accessibilityPosInSet`
 
 Indicates to accessibility services that the Component is within a set and has the given numbered position.


### PR DESCRIPTION
We removed this a while back

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/492)