### PR TITLE
Flip Default Version to 0.65

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -8,7 +8,7 @@
 // See https://docusaurus.io/docs/site-config for all the possible
 // site configuration options.
 
-const defaultVersionShown = '0.64';
+const defaultVersionShown = '0.65';
 const repoUrl = "https://github.com/microsoft/react-native-windows";
 
 const siteConfig = {


### PR DESCRIPTION
**_Why_**
Flip default version displayed by website to 0.65.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/520)