### PR TITLE
Lowercase bug docs update

### DIFF
--- a/website/versioned_docs/version-0.63/rnm-getting-started.md
+++ b/website/versioned_docs/version-0.63/rnm-getting-started.md
@@ -49,3 +49,6 @@ npx react-native-macos-init
   Open macos\test.xcworkspace in Xcode or run `xed -b macos`; `yarn start:macos`. Hit the Run button.
 
 A new Command Prompt window will open with the React packager as well as a `react-native-macos` app. This step may take a while during first run since it involves building the entire project and all dependencies. You can now start developing! 🎉
+
+### `ProjectName` has not been registered
+There is an existing bug where the casing of the project name affects it's ability to register properly. If you see this error, you can workaround it by navigating to your `app.json` and lowercasing the `name` field.


### PR DESCRIPTION
There's a bug on macOS right now where you'll hit a registration error if you follow the steps in the docs. The issue is that it fails with casing differences and defaults to all lowercase.

We should fix this but in the meantime, let's update our docs so new developers can be easily unblocked.

I created this [GH issue](https://github.com/microsoft/react-native-macos/issues/819) to track it

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/524)