### PR TITLE
Updating the compatibility matrix to include the hermes+ICU limitations.

### DIFF
--- a/docs/win10-compat.md
+++ b/docs/win10-compat.md
@@ -11,7 +11,7 @@ _Note : There is an ongoing effort to decouple the Windows UI platform from the 
 | [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive) | React Native for Windows support |
 | :-----------------------------------------------------------------------------------: | ----- |
 | **May 2019 update**<br> Version 1903 ; Build 10.0.18362.1 | **All APIs, scenarios supported** |
-| **October 2018 update**<br> Version 1809 ; Build 10.0.17763.0 | Unsupported: <ul><li>`useNativeDriver` for animations</li><li>`View.transform` property</li><li>React Native for Windows in XAML islands for hosting inside WPF/Win32 scenarios</li> |
+| **October 2018 update**<br> Version 1809 ; Build 10.0.17763.0 | Unsupported: <ul><li>`useNativeDriver` for animations</li><li>`View.transform` property</li><li>React Native for Windows in XAML islands for hosting inside WPF/Win32 scenarios</li><li>When using Hermes engine, the default locale will always be `en_US` and the default time zone will always be `Etc/UTC`, irrespective of the system settings </li> |
 | **April 2018 Update**<br> Version 1803 ; Build 10.0.17134.12 | Unsupported : (Same as above plus): <ul><li>Flyout: edge alignments, `ShowAt` capability</li><li>`Picker.editable`, `Picker.text`</li> |
 | **Fall Creators Update**<br> Version 1709 ; Build 10.0.16299.91 | Unsupported : Same as above |
 | **Creators Update**<br> Version 1703 ; Build 10.0.15063.468 | Unsupported : (Same as above plus): <ul><li>Keyboard events</li><li>`TextInput.placeholderTextColor`</li><li>`TextInput.secureTextEntry` may have some fast typing issues</li> |


### PR DESCRIPTION
Hermes is going to load ICU dlls from Windows with this PR : https://github.com/microsoft/react-native-windows/pull/8657

This wiki has some details on the ICU consumption in Windows: https://www.osgwiki.com/wiki/Using_ICU_on_Windows

ICU is available in Windows from RS2+ (Version 1703). One of the requirements is that the client must call CoInitializeEx prior to first call to ICU. 

19H1+ (Version 1903) doesn't require CoInitializeEx call, and the integration is cleaner. Hence, we want to keep 19H1+ as the minimum supported version for full support of locale aware APIs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/554)