### PR TITLE
Remove `--ignore-existing` option from Getting Started page

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,8 +17,6 @@ Remember to call `react-native init` from the place you want your project direct
 npx react-native init <projectName> --template react-native@^0.65.0
 ```
 >To create TypeScript template, run `npx react-native init <projectName> --template react-native-template-typescript`.<br><br>
-> If you've installed react native globally in the past, via `npm install -g react-native`, and are having issues with the new instructions, try adding `--ignore-existing` to your `npx` command:<br>
-> `npx --ignore-existing react-native init <projectName> --template react-native@^0.65.0` instead.
 
 ### Navigate into this newly created directory
 


### PR DESCRIPTION
Unfortunately the `--getting-started` option is no longer used (for the v7).
This is stated in the npm docs -> [Compatibility with Older npm Versions](https://docs.npmjs.com/cli/v7/commands/npx#compatibility-with-older-npx-versions).

So this pull request removes the information about using this option as a workaround for issues with global installation.

**How to test:**
Information about this option is deprecated is also printed when used:
```
PS C:\Dev\ReproProjects> npx --ignore-existing react-native init RNWReproApp
npx: the --ignore-existing argument has been removed.
See `npm help exec` for more information
```

---

I didn't find any information what about other solutions to conflicts with globally installed packages, but on the other hand as it's stated in the explanation:
> Locally installed bins are always present in the executed process `PATH`

So I believe that this should no longer be an issue.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/555)