### PR TITLE
Stop running PR pipeline when updating CI files

### DIFF
--- a/.github/workflows/samples-Calculator-pr.yml
+++ b/.github/workflows/samples-Calculator-pr.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - 'samples/Calculator/**'
-      - '.github/workflows/samples-Calculator-*.yml'
+      - '.github/workflows/samples-Calculator-pr.yml'
 
 jobs:
   build:

--- a/.github/workflows/samples-CalculatorNuGet-ci-upgrade.yml
+++ b/.github/workflows/samples-CalculatorNuGet-ci-upgrade.yml
@@ -46,5 +46,5 @@ jobs:
 
       - name: Run react-native run-windows
         if: ${{ steps.upgrade.outcome == 'success' }}
-        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release --deploy-from-layout' || '' }}
+        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }}
         working-directory: ..\..\src

--- a/.github/workflows/samples-CalculatorNuGet-pr.yml
+++ b/.github/workflows/samples-CalculatorNuGet-pr.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - 'samples/CalculatorNuGet/**'
-      - '.github/workflows/samples-CalculatorNuGet-*.yml'
+      - '.github/workflows/samples-CalculatorNuGet-pr.yml'
 
 jobs:
   build:

--- a/.github/workflows/samples-CameraDemo-pr.yml
+++ b/.github/workflows/samples-CameraDemo-pr.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - 'samples/CameraDemo/**'
-      - '.github/workflows/samples-CameraDemo-*.yml'
+      - '.github/workflows/samples-CameraDemo-pr.yml'
 
 jobs:
   build:

--- a/.github/workflows/samples-NativeModuleSample-pr.yml
+++ b/.github/workflows/samples-NativeModuleSample-pr.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - 'samples/NativeModuleSample/**'
-      - '.github/workflows/samples-NativeModuleSample-*.yml'
+      - '.github/workflows/samples-NativeModuleSample-pr.yml'
 
 jobs:
   build:

--- a/.github/workflows/samples-RssReader-pr.yml
+++ b/.github/workflows/samples-RssReader-pr.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - 'samples/rssreader/**'
-      - '.github/workflows/samples-RssReader-*.yml'
+      - '.github/workflows/samples-RssReader-pr.yml'
 
 jobs:
   build:


### PR DESCRIPTION
There's no need to run the PR workflow because it won't catch any problems in the CI files.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/559)