### PR TITLE
Add Setup CI Page to Sidebars

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -7,7 +7,8 @@
       "config",
       "windowsbrush-and-theme",
       "releases",
-      "platform"
+      "platform",
+      "setup-ci"
     ],
     "Native Modules (Windows)": [
       "native-modules",


### PR DESCRIPTION
**_Why_**
In #558, PR is missing update to sidebars. Page will currently not be shown on webstie. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/581)