### PR TITLE
Makes Filepath names the same in examples

### DIFF
--- a/docs/setup-ci.md
+++ b/docs/setup-ci.md
@@ -72,7 +72,7 @@ In a YAML file the basic steps to generate your certificate from an encoded stri
 - name: Decode the pfx
   run: |
     $PfxBytes = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
-    $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path ProjectDirectoryPath -ChildPath EncodedKey.pfx) )
+    $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path ProjectDirectoryPath -ChildPath GitHubActionsWorkflow.pfx))
     [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
 ```
 where your encoded string is a GitHub secret named `Base64_Encoded_Pfx`.

--- a/docs/setup-ci.md
+++ b/docs/setup-ci.md
@@ -72,7 +72,7 @@ In a YAML file the basic steps to generate your certificate from an encoded stri
 - name: Decode the pfx
   run: |
     $PfxBytes = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
-    $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path ProjectDirectoryPath -ChildPath GitHubActionsWorkflow.pfx))
+    $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path ProjectDirectoryPath -ChildPath GitHubActionsWorkflow.pfx) )
     [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
 ```
 where your encoded string is a GitHub secret named `Base64_Encoded_Pfx`.


### PR DESCRIPTION
## Description
Makes the example code match each other. Before was using both GitHubActionsWorkflow.pfx and EncodedKey.pfx but resolves it to use just GitHubActionsWorkflow.pfx.

### Why
Makes the documentation easier to understand.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/590)