### PR TITLE
Adds Correct Pathing to Calculator Workflow

### DIFF
--- a/.github/workflows/samples-Calculator-CI.yml
+++ b/.github/workflows/samples-Calculator-CI.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Decode the pfx
         run: |
           $PfxBytes = [System.Convert]::FromBase64String("${{ secrets.SAMPLES_BASE64_ENCODED_PFX }}")
-          $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path ProjectDirectoryPath -ChildPath GitHubActionsWorkflow.pfx) )
+          $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path "samples\${{ matrix.sample }}\windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx) )
           [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
 
       - name: Run react-native run-windows
@@ -49,7 +49,7 @@ jobs:
 
       - name: Remove the pfx
         run: |
-          $certificatePath = Join-Path -Path ProjectDirectoryPath -ChildPath GitHubActionsWorkflow.pfx
+          $certificatePath = Join-Path -Path "samples\${{ matrix.sample }}\windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx
           Write-Host $certificatePath
           Remove-Item -path $certificatePath
 

--- a/.github/workflows/samples-Calculator-CI.yml
+++ b/.github/workflows/samples-Calculator-CI.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: ..\..\src
 
       - name: Run react-native run-windows
-        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=ProjectDirectoryPath\GitHubActionsWorkflow.pfx
+        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=windows\${{ matrix.sample }}\GitHubActionsWorkflow.pfx
         working-directory: ..\..\src
 
       - name: Remove the pfx

--- a/.github/workflows/samples-Calculator-CI.yml
+++ b/.github/workflows/samples-Calculator-CI.yml
@@ -40,8 +40,9 @@ jobs:
       - name: Decode the pfx
         run: |
           $PfxBytes = [System.Convert]::FromBase64String("${{ secrets.SAMPLES_BASE64_ENCODED_PFX }}")
-          $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path "samples\${{ matrix.sample }}\windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx) )
+          $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path "windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx) )
           [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
+        working-directory: ..\..\src
 
       - name: Run react-native run-windows
         run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=ProjectDirectoryPath\GitHubActionsWorkflow.pfx
@@ -49,9 +50,10 @@ jobs:
 
       - name: Remove the pfx
         run: |
-          $certificatePath = Join-Path -Path "samples\${{ matrix.sample }}\windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx
+          $certificatePath = Join-Path -Path "windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx
           Write-Host $certificatePath
           Remove-Item -path $certificatePath
+        working-directory: ..\..\src
 
       - name: Get final folder size
         run: ${{github.workspace}}\.github\scripts\GetFolderSize.ps1

--- a/.github/workflows/samples-Calculator-ci-upgrade.yml
+++ b/.github/workflows/samples-Calculator-ci-upgrade.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Run react-native run-windows
         if: ${{ steps.upgrade.outcome == 'success' }}
-        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=ProjectDirectoryPath\GitHubActionsWorkflow.pfx
+        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=windows\${{ matrix.sample }}\GitHubActionsWorkflow.pfx
         working-directory: ..\..\src
 
       - name: Remove the pfx

--- a/.github/workflows/samples-Calculator-ci-upgrade.yml
+++ b/.github/workflows/samples-Calculator-ci-upgrade.yml
@@ -47,8 +47,9 @@ jobs:
       - name: Decode the pfx
         run: |
           $PfxBytes = [System.Convert]::FromBase64String("${{ secrets.SAMPLES_BASE64_ENCODED_PFX }}")
-          $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path "samples\${{ matrix.sample }}\windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx) )
+          $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path "windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx) )
           [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
+        working-directory: ..\..\src
 
       - name: Run react-native run-windows
         if: ${{ steps.upgrade.outcome == 'success' }}
@@ -57,6 +58,8 @@ jobs:
 
       - name: Remove the pfx
         run: |
-          $certificatePath = Join-Path -Path "samples\${{ matrix.sample }}\windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx
+          $certificatePath = Join-Path -Path "windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx
           Write-Host $certificatePath
           Remove-Item -path $certificatePath
+        working-directory: ..\..\src
+

--- a/.github/workflows/samples-Calculator-ci-upgrade.yml
+++ b/.github/workflows/samples-Calculator-ci-upgrade.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Decode the pfx
         run: |
           $PfxBytes = [System.Convert]::FromBase64String("${{ secrets.SAMPLES_BASE64_ENCODED_PFX }}")
-          $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path ProjectDirectoryPath -ChildPath GitHubActionsWorkflow.pfx) )
+          $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path "samples\${{ matrix.sample }}\windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx) )
           [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
 
       - name: Run react-native run-windows
@@ -57,6 +57,6 @@ jobs:
 
       - name: Remove the pfx
         run: |
-          $certificatePath = Join-Path -Path ProjectDirectoryPath -ChildPath GitHubActionsWorkflow.pfx
+          $certificatePath = Join-Path -Path "samples\${{ matrix.sample }}\windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx
           Write-Host $certificatePath
           Remove-Item -path $certificatePath


### PR DESCRIPTION
## Description
Recent changes broke the CI for Calculator Workflow because the default pathing was left in from docs. This fixes the pathing to the correct sample path 

### Why
Hopefully fixes the CI broke in https://github.com/microsoft/react-native-windows-samples/pull/591



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/592)