### PR TITLE
Adds Direct Path to Certificates in Calculator workflow

### DIFF
--- a/.github/workflows/samples-Calculator-CI.yml
+++ b/.github/workflows/samples-Calculator-CI.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Gather environment info
         run: npx envinfo
-
+git
       - name: Relocate to reduce long paths
         run:  Copy-item -Force -Recurse -Verbose "samples\${{ matrix.sample }}" -Destination "..\..\src"
 
@@ -41,6 +41,7 @@ jobs:
         run: |
           $PfxBytes = [System.Convert]::FromBase64String("${{ secrets.SAMPLES_BASE64_ENCODED_PFX }}")
           $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path "windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx) )
+          echo $PfxPath
           [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
         working-directory: ..\..\src
 

--- a/.github/workflows/samples-Calculator-CI.yml
+++ b/.github/workflows/samples-Calculator-CI.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Gather environment info
         run: npx envinfo
-git
+
       - name: Relocate to reduce long paths
         run:  Copy-item -Force -Recurse -Verbose "samples\${{ matrix.sample }}" -Destination "..\..\src"
 

--- a/.github/workflows/samples-Calculator-CI.yml
+++ b/.github/workflows/samples-Calculator-CI.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: ..\..\src
 
       - name: Run react-native run-windows
-        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=windows\${{ matrix.sample }}\GitHubActionsWorkflow.pfx
+        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=[System.IO.Path]::GetFullPath(windows\${{ matrix.sample }}\GitHubActionsWorkflow.pfx)
         working-directory: ..\..\src
 
       - name: Remove the pfx

--- a/.github/workflows/samples-Calculator-CI.yml
+++ b/.github/workflows/samples-Calculator-CI.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           $PfxBytes = [System.Convert]::FromBase64String("${{ secrets.SAMPLES_BASE64_ENCODED_PFX }}")
           $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path "windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx) )
-          echo $PfxPath
+          WriteHost $PfxPath
           [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
         working-directory: ..\..\src
 

--- a/.github/workflows/samples-Calculator-ci-upgrade.yml
+++ b/.github/workflows/samples-Calculator-ci-upgrade.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           $PfxBytes = [System.Convert]::FromBase64String("${{ secrets.SAMPLES_BASE64_ENCODED_PFX }}")
           $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path "windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx) )
+          echo $PfxPath
           [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
         working-directory: ..\..\src
 

--- a/.github/workflows/samples-Calculator-ci-upgrade.yml
+++ b/.github/workflows/samples-Calculator-ci-upgrade.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Run react-native run-windows
         if: ${{ steps.upgrade.outcome == 'success' }}
-        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=windows\${{ matrix.sample }}\GitHubActionsWorkflow.pfx
+        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=[System.IO.Path]::GetFullPath(windows\${{ matrix.sample }}\GitHubActionsWorkflow.pfx)
         working-directory: ..\..\src
 
       - name: Remove the pfx

--- a/.github/workflows/samples-Calculator-ci-upgrade.yml
+++ b/.github/workflows/samples-Calculator-ci-upgrade.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           $PfxBytes = [System.Convert]::FromBase64String("${{ secrets.SAMPLES_BASE64_ENCODED_PFX }}")
           $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path "windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx) )
-          echo $PfxPath
+          WriteHost $PfxPath
           [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
         working-directory: ..\..\src
 


### PR DESCRIPTION
## Description
Fixes the path to the certificate in react-native run-windows to use a direct path. 

### Why
Hopefully fixes the broken CI from https://github.com/microsoft/react-native-windows-samples/pull/592 and https://github.com/microsoft/react-native-windows-samples/pull/591



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/594)