### PR TITLE
Removes pfx Pathing to use working directory

### DIFF
--- a/.github/workflows/samples-Calculator-CI.yml
+++ b/.github/workflows/samples-Calculator-CI.yml
@@ -40,18 +40,18 @@ jobs:
       - name: Decode the pfx
         run: |
           $PfxBytes = [System.Convert]::FromBase64String("${{ secrets.SAMPLES_BASE64_ENCODED_PFX }}")
-          $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path "windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx) )
+          $PfxPath = [System.IO.Path]::GetFullPath(GitHubActionsWorkflow.pfx)
           Write-Host $PfxPath
           [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
         working-directory: ..\..\src
 
       - name: Run react-native run-windows
-        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=[System.IO.Path]::GetFullPath(windows\${{ matrix.sample }}\GitHubActionsWorkflow.pfx)
+        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=GitHubActionsWorkflow.pfx
         working-directory: ..\..\src
 
       - name: Remove the pfx
         run: |
-          $certificatePath = Join-Path -Path "windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx
+          $certificatePath = GitHubActionsWorkflow.pfx
           Write-Host $certificatePath
           Remove-Item -path $certificatePath
         working-directory: ..\..\src

--- a/.github/workflows/samples-Calculator-ci-upgrade.yml
+++ b/.github/workflows/samples-Calculator-ci-upgrade.yml
@@ -47,19 +47,19 @@ jobs:
       - name: Decode the pfx
         run: |
           $PfxBytes = [System.Convert]::FromBase64String("${{ secrets.SAMPLES_BASE64_ENCODED_PFX }}")
-          $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path "windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx) )
+          $PfxPath = [System.IO.Path]::GetFullPath(GitHubActionsWorkflow.pfx)
           Write-Host $PfxPath
           [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
         working-directory: ..\..\src
 
       - name: Run react-native run-windows
         if: ${{ steps.upgrade.outcome == 'success' }}
-        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=[System.IO.Path]::GetFullPath(windows\${{ matrix.sample }}\GitHubActionsWorkflow.pfx)
+        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=GitHubActionsWorkflow.pfx
         working-directory: ..\..\src
 
       - name: Remove the pfx
         run: |
-          $certificatePath = Join-Path -Path "windows\${{ matrix.sample }}" -ChildPath GitHubActionsWorkflow.pfx
+          $certificatePath = GitHubActionsWorkflow.pfx
           Write-Host $certificatePath
           Remove-Item -path $certificatePath
         working-directory: ..\..\src


### PR DESCRIPTION
## Description
Removes pathing in general for certificate to just use the working directory.

### Why
Fix Calculator CI


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/595)