### PR TITLE
Removes Calculator AppxPackageSigningEnabled and Updates Workflow

### DIFF
--- a/.github/workflows/samples-Calculator-ci-upgrade.yml
+++ b/.github/workflows/samples-Calculator-ci-upgrade.yml
@@ -47,19 +47,19 @@ jobs:
       - name: Decode the pfx
         run: |
           $PfxBytes = [System.Convert]::FromBase64String("${{ secrets.SAMPLES_BASE64_ENCODED_PFX }}")
-          $PfxPath = [System.IO.Path]::GetFullPath(GitHubActionsWorkflow.pfx)
+          $PfxPath = [System.IO.Path]::GetFullPath("${{github.workspace}}\GitHubActionsWorkflow.pfx")
           Write-Host $PfxPath
           [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
         working-directory: ..\..\src
 
       - name: Run react-native run-windows
         if: ${{ steps.upgrade.outcome == 'success' }}
-        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=GitHubActionsWorkflow.pfx
+        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=[System.IO.Path]::GetFullPath("${{github.workspace}}\GitHubActionsWorkflow.pfx")
         working-directory: ..\..\src
 
       - name: Remove the pfx
         run: |
-          $certificatePath = GitHubActionsWorkflow.pfx
+          $certificatePath = [System.IO.Path]::GetFullPath("${{github.workspace}}\GitHubActionsWorkflow.pfx")
           Write-Host $certificatePath
           Remove-Item -path $certificatePath
         working-directory: ..\..\src

--- a/.github/workflows/samples-Calculator-ci-upgrade.yml
+++ b/.github/workflows/samples-Calculator-ci-upgrade.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run react-native run-windows
         if: ${{ steps.upgrade.outcome == 'success' }}
-        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=[System.IO.Path]::GetFullPath("${{github.workspace}}\GitHubActionsWorkflow.pfx")
+        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=${{github.workspace}}\GitHubActionsWorkflow.pfx
         working-directory: ..\..\src
 
       - name: Remove the pfx

--- a/samples/Calculator/windows/Calculator/Calculator.vcxproj
+++ b/samples/Calculator/windows/Calculator/Calculator.vcxproj
@@ -74,7 +74,6 @@
     <Import Project="..\packages\$(WinUIPackageProps)" Condition="'$(WinUIPackageProps)'!='' And Exists('..\packages\$(WinUIPackageProps)')" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
-    <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/samples/Calculator/windows/Calculator/Calculator.vcxproj
+++ b/samples/Calculator/windows/Calculator/Calculator.vcxproj
@@ -74,7 +74,7 @@
     <Import Project="..\packages\$(WinUIPackageProps)" Condition="'$(WinUIPackageProps)'!='' And Exists('..\packages\$(WinUIPackageProps)')" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
-    <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
+    <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>


### PR DESCRIPTION
## Description
This should fix the Calculator Workflow, tested locally and works. AppxPackageSigningEnabled needed to be removed and pathing fixed for Calculator Upgrade Workflow :)
### Why
To Fix Calculator Workflow broken by removing certificates



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/597)