### PR TITLE
Removes Certificate and Updates Workflow for RSSReader

### DIFF
--- a/.github/workflows/samples-RssReader-CI.yml
+++ b/.github/workflows/samples-RssReader-CI.yml
@@ -37,8 +37,23 @@ jobs:
         run: yarn install --frozen-lockfile
         working-directory: ..\..\src
 
+      - name: Decode the pfx
+        run: |
+          $PfxBytes = [System.Convert]::FromBase64String("${{ secrets.SAMPLES_BASE64_ENCODED_PFX }}")
+          $PfxPath = [System.IO.Path]::GetFullPath("${{github.workspace}}\GitHubActionsWorkflow.pfx")
+          Write-Host $PfxPath
+          [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
+        working-directory: ..\..\src
+
       - name: Run react-native run-windows
-        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }}
+        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=${{github.workspace}}\GitHubActionsWorkflow.pfx
+        working-directory: ..\..\src
+
+      - name: Remove the pfx
+        run: |
+          $certificatePath = [System.IO.Path]::GetFullPath("${{github.workspace}}\GitHubActionsWorkflow.pfx")
+          Write-Host $certificatePath
+          Remove-Item -path $certificatePath
         working-directory: ..\..\src
 
       - name: Get final folder size

--- a/.github/workflows/samples-RssReader-ci-upgrade.yml
+++ b/.github/workflows/samples-RssReader-ci-upgrade.yml
@@ -44,7 +44,22 @@ jobs:
         run: npx react-native-windows-init --overwrite --version ${{ matrix.reactNativeWindowsVersion }}
         working-directory: ..\..\src
 
+      - name: Decode the pfx
+        run: |
+          $PfxBytes = [System.Convert]::FromBase64String("${{ secrets.SAMPLES_BASE64_ENCODED_PFX }}")
+          $PfxPath = [System.IO.Path]::GetFullPath("${{github.workspace}}\GitHubActionsWorkflow.pfx")
+          Write-Host $PfxPath
+          [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
+        working-directory: ..\..\src
+
       - name: Run react-native run-windows
         if: ${{ steps.upgrade.outcome == 'success' }}
-        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }}
+        run: npx react-native run-windows --logging --no-packager --no-launch --arch ${{ matrix.architecture }} ${{ startsWith(matrix.architecture, 'ARM') && '--no-deploy' || '' }} ${{ matrix.configuration == 'Release' && '--release' || '' }} --msbuildprops PackageCertificateKeyFile=${{github.workspace}}\GitHubActionsWorkflow.pfx
+        working-directory: ..\..\src
+
+      - name: Remove the pfx
+        run: |
+          $certificatePath = [System.IO.Path]::GetFullPath("${{github.workspace}}\GitHubActionsWorkflow.pfx")
+          Write-Host $certificatePath
+          Remove-Item -path $certificatePath
         working-directory: ..\..\src

--- a/samples/rssreader/windows/rssreader/rssreader.vcxproj
+++ b/samples/rssreader/windows/rssreader/rssreader.vcxproj
@@ -15,7 +15,6 @@
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
-    <PackageCertificateThumbprint>33C46DDC74B6BD71CE5E0FFCED72368FC413B780</PackageCertificateThumbprint>
     <USE_HERMES>true</USE_HERMES>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -185,7 +184,6 @@
   <ItemGroup>
     <None Include="packages.config" />
     <None Include="PropertySheet.props" />
-    <None Include="rssreader_TemporaryKey.pfx" />
     <Text Include="readme.txt">
       <DeploymentContent>false</DeploymentContent>
     </Text>
@@ -198,8 +196,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <PropertyGroup Label="ReactNativeWindowsNodeProps">
     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
-    <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
-    <PackageCertificateKeyFile>rssreader_TemporaryKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
   <ImportGroup Label="ReactNativeWindowsNodeTargets">
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props')" />


### PR DESCRIPTION
## Description
Removes certificate for RSSReader sample app. Thus the corresponding workflow has to be changed to use the new secret certificate.

### Why
#527. Supports movement to remove temporary certificates from RNW repos. The current CI for rssreader also fails since the current temporary certificate is expired.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/600)