### PR TITLE
Adds link to RN Gallery Examples for Popup and Flyout

### DIFF
--- a/docs/flyout-component-windows.md
+++ b/docs/flyout-component-windows.md
@@ -92,3 +92,7 @@ Accepted placements value types are:
 | type | required |
 |:--|:--|
 | type | No |
+
+# Examples
+
+Examples can be found in the [React Native Gallery App](https://github.com/microsoft/react-native-gallery/blob/main/src/examples/FlyoutExamplePage.tsx) avaliable in the [Microsoft Store](http://aka.ms/reactnativegalleryapp)

--- a/docs/flyout-component-windows.md
+++ b/docs/flyout-component-windows.md
@@ -93,6 +93,6 @@ Accepted placements value types are:
 |:--|:--|
 | type | No |
 
-# Examples
+## Examples
 
 Examples can be found in the [React Native Gallery App](https://github.com/microsoft/react-native-gallery/blob/main/src/examples/FlyoutExamplePage.tsx) avaliable in the [Microsoft Store](http://aka.ms/reactnativegalleryapp)

--- a/docs/flyout-component-windows.md
+++ b/docs/flyout-component-windows.md
@@ -95,4 +95,4 @@ Accepted placements value types are:
 
 ## Examples
 
-Examples can be found in the [React Native Gallery App](https://github.com/microsoft/react-native-gallery/blob/main/src/examples/FlyoutExamplePage.tsx) avaliable in the [Microsoft Store](http://aka.ms/reactnativegalleryapp)
+Examples can be found in the [React Native Gallery App](https://github.com/microsoft/react-native-gallery/blob/main/src/examples/FlyoutExamplePage.tsx) available in the [Microsoft Store](http://aka.ms/reactnativegalleryapp)

--- a/docs/popup-component-windows.md
+++ b/docs/popup-component-windows.md
@@ -61,6 +61,6 @@ A component that the `Popup` is attached to and will show from when [`isOpen`](f
 |:--|:--|
 | `React.ReactNode` | Yes |
 
-# Examples
+## Examples
 
 Examples can be found in the [React Native Gallery App](https://github.com/microsoft/react-native-gallery/blob/main/src/examples/PopupExamplePage.tsx) avaliable in the [Microsoft Store](http://aka.ms/reactnativegalleryapp)

--- a/docs/popup-component-windows.md
+++ b/docs/popup-component-windows.md
@@ -60,3 +60,7 @@ A component that the `Popup` is attached to and will show from when [`isOpen`](f
 | type | required |
 |:--|:--|
 | `React.ReactNode` | Yes |
+
+# Examples
+
+Examples can be found in the [React Native Gallery App](https://github.com/microsoft/react-native-gallery/blob/main/src/examples/PopupExamplePage.tsx) avaliable in the [Microsoft Store](http://aka.ms/reactnativegalleryapp)

--- a/docs/popup-component-windows.md
+++ b/docs/popup-component-windows.md
@@ -63,4 +63,4 @@ A component that the `Popup` is attached to and will show from when [`isOpen`](f
 
 ## Examples
 
-Examples can be found in the [React Native Gallery App](https://github.com/microsoft/react-native-gallery/blob/main/src/examples/PopupExamplePage.tsx) avaliable in the [Microsoft Store](http://aka.ms/reactnativegalleryapp)
+Examples can be found in the [React Native Gallery App](https://github.com/microsoft/react-native-gallery/blob/main/src/examples/PopupExamplePage.tsx) available in the [Microsoft Store](http://aka.ms/reactnativegalleryapp)


### PR DESCRIPTION
## Description
Add link to React Native Gallery App (http://aka.ms/reactnativegalleryapp) and corresponding example pages (https://github.com/microsoft/react-native-gallery/blob/main/src/examples/FlyoutExamplePage.tsx \ https://github.com/microsoft/react-native-gallery/blob/main/src/examples/PopupExamplePage.tsx) to Popup/Flyout Documentation
### Why
When looking at just the documentation, it's hard to find examples of popup/flyout. This leads the user to Gallery App which has examples of both.
Resolves #29

## Screenshots
Added to bottom of popup/flyout page
![image](https://user-images.githubusercontent.com/42554868/142951867-03d106b0-82b1-4f84-a1a2-b4d09395ddd0.png)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/604)