### PR TITLE
API Parity Page Rename

### DIFF
--- a/docs/parity-status.md
+++ b/docs/parity-status.md
@@ -1,6 +1,6 @@
 ---
 id: parity-status
-title: API Parity
+title: React Native Windows Components and APIs
 ---
 
 ## Core APIs and Components

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -37,7 +37,7 @@ class Footer extends React.Component {
               <a href={this.props.config.baseUrl + "docs/rnm-getting-started"}> Get Started with macOS</a>
             </div>
             <a href={this.props.config.baseUrl + "docs/parity-status"}>
-              API parity with React Native
+              React Native Windows Components and APIs
             </a>
             <a href={this.props.config.baseUrl + "docs/native-modules"}>
               Native Modules

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -61,7 +61,7 @@ Coming soon!
   - [Get started] developing a React Native for Windows app
   - Learn the **basics of React Native** using the [React Native Tutorial]
   - Learn about the core [React Native Components and APIs]
-  - Check out the [API Parity status] doc for updates on what we support from core
+  - Check out the [React Native Windows Components and APIs] doc for updates on what we support from React Native core
   - For new **Windows specific APIs** [check out our list here]
   - Learn how to **extend React Native for Windows** through [Native modules] and [Native UI components]
 
@@ -82,7 +82,7 @@ If you're curious about the **sample apps** we have published for inspiration:
 [React Native for macOS]: https://github.com/microsoft/react-native-macos
 [React Native Tutorial]: https://reactnative.dev/docs/tutorial
 [React Native Components and APIs]: https://reactnative.dev/docs/components-and-apis
-[API Parity status]: docs/parity-status
+[React Native Windows Components and APIs]: docs/parity-status
 [Windows Brushes and Themes]: docs/windowsbrush-and-theme
 [check out our list here]: docs/flyout-component
 [Native modules]: docs/native-modules


### PR DESCRIPTION
### Why
I think the term "API Parity" is not super intuitive for people outside the team/Microsoft. Renaming the tab to include "Components and APIs" might make more sense given the content of that page and since we rely on the RN Core documentation linked there for our non-windows-specific API documentation. 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/611)