### PR TITLE
Update FancyMath.cs

### DIFF
--- a/samples/NativeModuleSample/csharp/windows/NativeModuleSample/FancyMath.cs
+++ b/samples/NativeModuleSample/csharp/windows/NativeModuleSample/FancyMath.cs
@@ -6,27 +6,24 @@ using Microsoft.ReactNative.Managed;
 
 namespace NativeModuleSample
 {
-    namespace NativeModuleSample
+    [ReactModule]
+    class FancyMath
     {
-        [ReactModule]
-        class FancyMath
+        [ReactConstant]
+        public double E = Math.E;
+
+        [ReactConstant("Pi")]
+        public double PI = Math.PI;
+
+        [ReactMethod("add")]
+        public double Add(double a, double b)
         {
-            [ReactConstant]
-            public double E = Math.E;
-
-            [ReactConstant("Pi")]
-            public double PI = Math.PI;
-
-            [ReactMethod("add")]
-            public double Add(double a, double b)
-            {
-                double result = a + b;
-                AddEvent(result);
-                return result;
-            }
-
-            [ReactEvent]
-            public Action<double> AddEvent { get; set; }
+            double result = a + b;
+            AddEvent(result);
+            return result;
         }
+
+        [ReactEvent]
+        public Action<double> AddEvent { get; set; }
     }
 }


### PR DESCRIPTION
## Description
Namespace is written twice. This would not compile if copied to Visual Studio.

### Why
Typo in the documentation.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/614)