### PR TITLE
(macOS) Project name error to 0.64

### DIFF
--- a/website/versioned_docs/version-0.64/rnm-getting-started.md
+++ b/website/versioned_docs/version-0.64/rnm-getting-started.md
@@ -49,3 +49,6 @@ npx react-native-macos-init
   Open macos\test.xcworkspace in Xcode or run `xed -b macos`; `yarn start:macos`. Hit the Run button.
 
 A new Command Prompt window will open with the React packager as well as a `react-native-macos` app. This step may take a while during first run since it involves building the entire project and all dependencies. You can now start developing! 🎉
+
+### `ProjectName` has not been registered
+There is an existing bug where the casing of the project name affects it's ability to register properly. If you see this error, you can workaround it by navigating to your `app.json` and lowercasing the `name` field.


### PR DESCRIPTION
## Description
We had this error in our 0.63 docs but at some point it got omitted in our 0.64 docs. This change adds it back.

### Why
Someone in the OSS community reached out having hit this error. We should at least cover it in our documentation for now until a proper fix to the CLI tools is made.

Resolves [ProjectName not found error]

I validated it shows up as expected on my localhost.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/616)