### PR TITLE
Fixes Calculator CI (Upgrade)/Csharp by adding --language

### DIFF
--- a/.github/workflows/samples-Calculator-ci-upgrade.yml
+++ b/.github/workflows/samples-Calculator-ci-upgrade.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Run react-native-windows-init
         if: ${{ steps.upgrade.outcome == 'success' }}
-        run: npx react-native-windows-init --overwrite --version ${{ matrix.reactNativeWindowsVersion }}
+        run: npx react-native-windows-init --overwrite --version ${{ matrix.reactNativeWindowsVersion }} --language ${{ endsWith(matrix.sample, 'cppwinrt') && 'cpp' || 'cs' }}
         working-directory: ..\..\src
 
       - name: Decode the pfx


### PR DESCRIPTION
## Description
Fixes Calculator CI (Upgrade)/Csharp added in #606 by adding `--language` option to `react-native-windows-init`. Previously, it was installing the CppWinrt version. 

### Why
Workflow is currently broken for Calculator CI (Upgrade)/Csharp


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/618)