### PR TITLE
Document mixed `PackageReference` and `packages.config` projects

### DIFF
--- a/docs/customizing-SDK-versions.md
+++ b/docs/customizing-SDK-versions.md
@@ -46,8 +46,6 @@ When you create a C# or C++ React Native for Windows app, it is written in such 
 
 For C++ apps, in addition to setting the property value, you will also need to modify the `packages.config` file which can be found next to the app project `.vcxproj` file, to point to the updated package version.
 
-<!--DOCUSAURUS_CODE_TABS-->
-<!--C# app-->
 
 #### `windows\ExperimentalFlags.props`
 
@@ -57,40 +55,3 @@ For C++ apps, in addition to setting the property value, you will also need to m
   <WinUI2xVersion>2.6.0</WinUI2xPackageVersion>
 </PropertyGroup>
 ```
-
-#### `node_modules\react-native-windows\Microsoft.ReactNative\packages.config`
-
-```diff
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.200615.7" targetFramework="native" />
-  <!-- more packages -->
--  <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />
-+  <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native" />
-</packages>
-```
-
-
-<!--C++ app-->
-
-#### `windows\ExperimentalFlags.props`
-
-```xml
-<PropertyGroup>
-  <!-- other properties -->
-  <WinUI2xVersion>2.6.0</WinUI2xPackageVersion>
-</PropertyGroup>
-```
-
-#### `windows\MyApp\packages.config`
-
-```diff
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.200615.7" targetFramework="native" />
--  <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />
-+  <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native" />
-</packages>
-```
-
-<!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/managing-cpp-deps.md
+++ b/docs/managing-cpp-deps.md
@@ -1,0 +1,48 @@
+---
+id: managing-cpp-deps
+title: Managing C++ dependencies
+---
+
+Details to consider when consuming a Visual C++ project as a source dependency of your app.
+
+### Details
+
+Applications with native code, either written on `C#` or `C++`, may add source dependencies on native Visual C++ (`.vcxproj`) projects.\
+Meaning, such dependencies will be built as part of the application.
+
+Starting with version `0.68`, React Native for Windows apps use the [`PackageReference`](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files) restore project style for native `C++` NuGet dependencies.\
+The main change consists in NuGet packages being directly loaded from the user account's `globalPackagesFolder` cache instead of also copying them into a local folder relative to the Visual Studio Solution location (see [repositoryPath](https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file)).
+
+This may conflict with Node/Visual C++ dependencies that use the more common [`packages.config`](https://docs.microsoft.com/en-us/nuget/reference/packages-config) project style (i.e. [React Native Picker](https://github.com/react-native-picker/picker#react-native-pickerpicker)).
+
+## Updating your app
+
+### Add the React Native Windows C++ Dependency (i.e. RN Picker)
+
+```
+yarn add @react-native-picker/picker
+```
+
+### Add a `packages.config` file to your app's project directory
+
+The React Native Windows build system will try to build the dependency from source.\
+Because it uses the `packages.config` restore style, it will most likely expect its own NuGet dependencies to be restored at `$(SolutionDir)packages\`.
+
+#### See [node_modules\@react-native-picker\picker\windows\ReactNativePicker\ReactNativePicker.vcxproj](https://github.com/react-native-picker/picker/blob/v2.2.1/windows/ReactNativePicker/ReactNativePicker.vcxproj#L156)
+
+```xml title="ReactNativePicker.vcxproj"
+<Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
+<Import Project="$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
+```
+
+#### `windows\<C++ or C# app directory>\packages.config`
+
+```xml title="packages.config"
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
+  <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />
+</packages>
+```
+
+This way, your React Native Windows app will restore the external NuGet dependencies into the expected location.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -29,7 +29,8 @@
       "native-modules-jsvalue",
       "native-modules-csharp-codegen",
       "win10-vm",
-      "customizing-sdk-versions"
+      "customizing-sdk-versions",
+      "managing-cpp-deps"
     ],
     "The Basics (MacOS)": [
       "rnm-getting-started",


### PR DESCRIPTION
## Description

See https://github.com/microsoft/react-native-windows/pull/8195

Adds entry with guidance for mixed `PackageReference`/`packages.config` projects.

### Why

After introducing `PackageReference` as MSRN's native NuGet dependency mechanism, source dependencies that use `packages.config` will still expect their own NuGet deps to be located in `$(SolutionDir)packages\`.

Resolves #621

