### PR TITLE
Remove version specification from winui pages

### DIFF
--- a/docs/winui3.md
+++ b/docs/winui3.md
@@ -30,7 +30,7 @@ In order to create a **WinUI 3** enabled C++ or C# app, pass the `--useWinUI3` f
 
 Example:
 ```bat
-npx react-native-windows-init --useWinUI3 --version 0.67-stable --overwrite --language cpp
+npx react-native-windows-init --useWinUI3 --overwrite --language cpp
 ```
 
 ## How it works

--- a/website/versioned_docs/version-0.62/winui3.md
+++ b/website/versioned_docs/version-0.62/winui3.md
@@ -31,7 +31,7 @@ In order to create a **WinUI 3** enabled C++ app, pass the `--useWinUI3` flag wh
 
 Example:
 ```powershell
-npx react-native-windows-init --useWinUI3 --version master --overwrite --language cpp
+npx react-native-windows-init --useWinUI3 --overwrite --language cpp
 ```
 
 Follow overall project status in the [Re-target onto OSS XAML](https://github.com/microsoft/react-native-windows/projects/30) project.

--- a/website/versioned_docs/version-0.63/winui3.md
+++ b/website/versioned_docs/version-0.63/winui3.md
@@ -28,7 +28,7 @@ In order to create a **WinUI 3** enabled C++ or C# app, pass the `--useWinUI3` f
 
 Example:
 ```bat
-npx react-native-windows-init --useWinUI3 --version canary --overwrite --language cpp
+npx react-native-windows-init --useWinUI3 --overwrite --language cpp
 ```
 
 ## How it works

--- a/website/versioned_docs/version-0.64/winui3.md
+++ b/website/versioned_docs/version-0.64/winui3.md
@@ -28,7 +28,7 @@ In order to create a **WinUI 3** enabled C++ or C# app, pass the `--useWinUI3` f
 
 Example:
 ```bat
-npx react-native-windows-init --useWinUI3 --version canary --overwrite --language cpp
+npx react-native-windows-init --useWinUI3 --overwrite --language cpp
 ```
 
 ## How it works

--- a/website/versioned_docs/version-0.67/winui3.md
+++ b/website/versioned_docs/version-0.67/winui3.md
@@ -31,7 +31,7 @@ In order to create a **WinUI 3** enabled C++ or C# app, pass the `--useWinUI3` f
 
 Example:
 ```bat
-npx react-native-windows-init --useWinUI3 --version 0.67-stable --overwrite --language cpp
+npx react-native-windows-init --useWinUI3 --overwrite --language cpp
 ```
 
 ## How it works


### PR DESCRIPTION
There's no need to specify the version as the react-native-windows-init
command will automatically find the right version for the existing
project.

Also, this means one less place we need to bump the version when
snapping docs for a new release.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/631)