### PR TITLE
Add mention of autolinking to Using Community Native Modules doc

### DIFF
--- a/docs/native-modules-using.md
+++ b/docs/native-modules-using.md
@@ -13,7 +13,7 @@ This document outlines the general steps to manually link a module (`react-nativ
 
 > Note that individual modules may have different or specific steps for linking to Windows. The steps outlined in this doc are useful if the module repo doesn't outline how to use the module on Windows.
 
-> For more information on how autolinking works, see [Autolinking Native Modules](native-modules-autolinking).
+> For more information on how autolinking works, see [Autolinking Native Modules](native-modules-autolinking.md).
 
 ## Step 1: Update the solution file
 

--- a/docs/native-modules-using.md
+++ b/docs/native-modules-using.md
@@ -7,7 +7,7 @@ Community native modules are usually distributed as npm packages. To understand 
 
 Consuming native modules requires updating your app's native build files to depend on the module's native build files, called "linking". Many modules support "autolinking", where these updates are done automatically when running `npx react-native run-windows`. Others may require you to link the module manually.
 
-This document outlines the general steps to manually link a module (`react-native-foo`) to your project. 
+This document outlines the general steps to manually link a module (`react-native-foo`) to your project.
 
 > Not all community modules have been updated to work with Windows. If you find a module that doesn't work with Windows, please file an [issue on GitHub](https://github.com/microsoft/react-native-windows/issues/new/choose). We're tracking the list of incompatible modules that we're working to add support for [on GitHub](https://github.com/microsoft/react-native-windows/projects/23). 
 

--- a/docs/native-modules-using.md
+++ b/docs/native-modules-using.md
@@ -5,7 +5,7 @@ title: Using Community Native Modules
 
 Community native modules are usually distributed as npm packages. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry) useful.
 
-Consuming native modules requires updating your app's native build files to depend on the module's native build files, called "linking". Many modules supporting "autolinking", where these updates are done automatically when running `npx react-native run-windows`.
+Consuming native modules requires updating your app's native build files to depend on the module's native build files, called "linking". Many modules support "autolinking", where these updates are done automatically when running `npx react-native run-windows`. Others may require you to link the module manually.
 
 This document outlines the general steps to manually link a module (`react-native-foo`) to your project. 
 

--- a/website/.unbroken_exclusions
+++ b/website/.unbroken_exclusions
@@ -63,6 +63,7 @@ File not found rnw-dependencies.md while parsing versioned_docs/version-0.67/nat
 File not found view-managers.md while parsing versioned_docs/version-0.67/native-modules-setup.md
 File not found getting-started.md while parsing versioned_docs/version-0.67/native-modules-setup.md
 File not found native-modules-autolinking.md while parsing versioned_docs/version-0.67/native-modules-setup.md
+File not found native-modules-using.md while parsing versioned_docs/version-0.67/native-modules-setup.md
 File not found native-modules.md while parsing versioned_docs/version-0.67/native-modules-setup.md
 File not found rnw-dependencies.md while parsing versioned_docs/version-0.67/native-modules-setup.md
 File not found view-managers.md while parsing versioned_docs/version-0.67/native-modules-setup.md
@@ -176,6 +177,7 @@ File not found rnw-dependencies.md while parsing versioned_docs/version-0.65/nat
 File not found view-managers.md while parsing versioned_docs/version-0.65/native-modules-setup.md
 File not found getting-started.md while parsing versioned_docs/version-0.65/native-modules-setup.md
 File not found native-modules-autolinking.md while parsing versioned_docs/version-0.65/native-modules-setup.md
+File not found native-modules-using.md while parsing versioned_docs/version-0.65/native-modules-setup.md
 File not found native-modules.md while parsing versioned_docs/version-0.65/native-modules-setup.md
 File not found rnw-dependencies.md while parsing versioned_docs/version-0.65/native-modules-setup.md
 File not found view-managers.md while parsing versioned_docs/version-0.65/native-modules-setup.md
@@ -288,6 +290,7 @@ File not found native-modules-advanced.md while parsing versioned_docs/version-0
 File not found native-modules.md while parsing versioned_docs/version-0.64/native-modules-marshalling-data.md
 File not found getting-started.md while parsing versioned_docs/version-0.64/native-modules-setup.md
 File not found native-modules-autolinking.md while parsing versioned_docs/version-0.64/native-modules-setup.md
+File not found native-modules-using.md while parsing versioned_docs/version-0.64/native-modules-setup.md
 File not found native-modules.md while parsing versioned_docs/version-0.64/native-modules-setup.md
 File not found rnw-dependencies.md while parsing versioned_docs/version-0.64/native-modules-setup.md
 File not found view-managers.md while parsing versioned_docs/version-0.64/native-modules-setup.md

--- a/website/.unbroken_exclusions
+++ b/website/.unbroken_exclusions
@@ -308,6 +308,7 @@ File not found native-modules.md while parsing versioned_docs/version-0.64/nativ
 File not found rnw-dependencies.md while parsing versioned_docs/version-0.64/native-modules-setup.md
 File not found testing.md while parsing versioned_docs/version-0.64/native-modules-setup.md
 File not found view-managers.md while parsing versioned_docs/version-0.64/native-modules-setup.md
+File not found native-modules-autolinking.md while parsing versioned_docs/version-0.64/native-modules-using.md
 File not found native-modules-async.md while parsing versioned_docs/version-0.64/native-modules.md
 File not found native-modules-jsvalue.md while parsing versioned_docs/version-0.64/native-modules.md
 File not found native-modules-setup.md while parsing versioned_docs/version-0.64/native-modules.md

--- a/website/versioned_docs/version-0.63/native-modules-using.md
+++ b/website/versioned_docs/version-0.63/native-modules-using.md
@@ -14,7 +14,7 @@ This document outlines the general steps to manually link a module (`react-nativ
 
 > Note that individual modules may have different or specific steps for linking to Windows. The steps outlined in this doc are useful if the module repo doesn't outline how to use the module on Windows.
 
-> For more information on how autolinking works, see [Autolinking Native Modules](native-modules-autolinking).
+> For more information on how autolinking works, see [Autolinking Native Modules](native-modules-autolinking.md).
 
 ## Step 1: Update the solution file
 

--- a/website/versioned_docs/version-0.63/native-modules-using.md
+++ b/website/versioned_docs/version-0.63/native-modules-using.md
@@ -6,7 +6,7 @@ original_id: native-modules-using
 
 Community native modules are usually distributed as npm packages. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry) useful.
 
-Consuming native modules requires updating your app's native build files to depend on the module's native build files, called "linking". Many modules supporting "autolinking", where these updates are done automatically when running `npx react-native run-windows`.
+Consuming native modules requires updating your app's native build files to depend on the module's native build files, called "linking". Many modules support "autolinking", where these updates are done automatically when running `npx react-native run-windows`. Others may require you to link the module manually.
 
 This document outlines the general steps to link a module (`react-native-foo`) to your project. 
 

--- a/website/versioned_docs/version-0.63/native-modules-using.md
+++ b/website/versioned_docs/version-0.63/native-modules-using.md
@@ -8,7 +8,7 @@ Community native modules are usually distributed as npm packages. To understand 
 
 Consuming native modules requires updating your app's native build files to depend on the module's native build files, called "linking". Many modules support "autolinking", where these updates are done automatically when running `npx react-native run-windows`. Others may require you to link the module manually.
 
-This document outlines the general steps to link a module (`react-native-foo`) to your project. 
+This document outlines the general steps to manually link a module (`react-native-foo`) to your project.
 
 > Not all community modules have been updated to work with Windows. If you find a module that doesn't work with Windows, please file an [issue on GitHub](https://github.com/microsoft/react-native-windows/issues/new/choose). We're tracking the list of incompatible modules that we're working to add support for [on GitHub](https://github.com/microsoft/react-native-windows/projects/23). 
 

--- a/website/versioned_docs/version-0.63/native-modules-using.md
+++ b/website/versioned_docs/version-0.63/native-modules-using.md
@@ -1,13 +1,14 @@
 ---
-id: native-modules-using
+id: version-0.63-native-modules-using
 title: Using Community Native Modules
+original_id: native-modules-using
 ---
 
 Community native modules are usually distributed as npm packages. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry) useful.
 
 Consuming native modules requires updating your app's native build files to depend on the module's native build files, called "linking". Many modules supporting "autolinking", where these updates are done automatically when running `npx react-native run-windows`.
 
-This document outlines the general steps to manually link a module (`react-native-foo`) to your project. 
+This document outlines the general steps to link a module (`react-native-foo`) to your project. 
 
 > Not all community modules have been updated to work with Windows. If you find a module that doesn't work with Windows, please file an [issue on GitHub](https://github.com/microsoft/react-native-windows/issues/new/choose). We're tracking the list of incompatible modules that we're working to add support for [on GitHub](https://github.com/microsoft/react-native-windows/projects/23). 
 
@@ -31,7 +32,7 @@ Add a reference to `ReactNativeFooCpp` to your main application project. From Vi
 2. Check `ReactNativeFooCpp` from Solution Projects
 
 
-## Step 3: Update the `pch.h` file
+## Step 3: Update the pch.h file
 
 Add `#include "winrt/ReactNativeFooCPP.h"`.
 

--- a/website/versioned_docs/version-0.64/native-modules-using.md
+++ b/website/versioned_docs/version-0.64/native-modules-using.md
@@ -14,7 +14,7 @@ This document outlines the general steps to manually link a module (`react-nativ
 
 > Note that individual modules may have different or specific steps for linking to Windows. The steps outlined in this doc are useful if the module repo doesn't outline how to use the module on Windows.
 
-> For more information on how autolinking works, see [Autolinking Native Modules](native-modules-autolinking).
+> For more information on how autolinking works, see [Autolinking Native Modules](native-modules-autolinking.md).
 
 ## Step 1: Update the solution file
 

--- a/website/versioned_docs/version-0.64/native-modules-using.md
+++ b/website/versioned_docs/version-0.64/native-modules-using.md
@@ -6,7 +6,7 @@ original_id: native-modules-using
 
 Community native modules are usually distributed as npm packages. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry) useful.
 
-Consuming native modules requires updating your app's native build files to depend on the module's native build files, called "linking". Many modules supporting "autolinking", where these updates are done automatically when running `npx react-native run-windows`.
+Consuming native modules requires updating your app's native build files to depend on the module's native build files, called "linking". Many modules support "autolinking", where these updates are done automatically when running `npx react-native run-windows`. Others may require you to link the module manually.
 
 This document outlines the general steps to link a module (`react-native-foo`) to your project.
 

--- a/website/versioned_docs/version-0.64/native-modules-using.md
+++ b/website/versioned_docs/version-0.64/native-modules-using.md
@@ -8,7 +8,7 @@ Community native modules are usually distributed as npm packages. To understand 
 
 Consuming native modules requires updating your app's native build files to depend on the module's native build files, called "linking". Many modules support "autolinking", where these updates are done automatically when running `npx react-native run-windows`. Others may require you to link the module manually.
 
-This document outlines the general steps to link a module (`react-native-foo`) to your project.
+This document outlines the general steps to manually link a module (`react-native-foo`) to your project.
 
 > Not all community modules have been updated to work with Windows. If you find a module that doesn't work with Windows, please file an [issue on GitHub](https://github.com/microsoft/react-native-windows/issues/new/choose). We're tracking the list of incompatible modules that we're working to add support for [on GitHub](https://github.com/microsoft/react-native-windows/projects/23). 
 

--- a/website/versioned_docs/version-0.64/native-modules-using.md
+++ b/website/versioned_docs/version-0.64/native-modules-using.md
@@ -6,11 +6,15 @@ original_id: native-modules-using
 
 Community native modules are usually distributed as npm packages. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry) useful.
 
-This document outlines the general steps to link a module (`react-native-foo`) to your project. 
+Consuming native modules requires updating your app's native build files to depend on the module's native build files, called "linking". Many modules supporting "autolinking", where these updates are done automatically when running `npx react-native run-windows`.
+
+This document outlines the general steps to link a module (`react-native-foo`) to your project.
 
 > Not all community modules have been updated to work with Windows. If you find a module that doesn't work with Windows, please file an [issue on GitHub](https://github.com/microsoft/react-native-windows/issues/new/choose). We're tracking the list of incompatible modules that we're working to add support for [on GitHub](https://github.com/microsoft/react-native-windows/projects/23). 
 
 > Note that individual modules may have different or specific steps for linking to Windows. The steps outlined in this doc are useful if the module repo doesn't outline how to use the module on Windows.
+
+> For more information on how autolinking works, see [Autolinking Native Modules](native-modules-autolinking).
 
 ## Step 1: Update the solution file
 


### PR DESCRIPTION
This PR updates the "Using Community Native Modules" doc to mention
the role of autolinking and link to its page.

Closes #342

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/632)