### PR TITLE
Add Static Page for react-native-windows-init CLI Page

### DIFF
--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -89,7 +89,7 @@ class InitCli extends React.Component {
             <tr>
                 <td><code>--telemetry</code></td>
                 <td>boolean</td>
-                <td>Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI</td>
+                <td>Controls sending telemetry that allows analysis of usage and failures of the react-native-windows CLI.</td>
             </tr>
         </table>
         <p>

--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -43,7 +43,7 @@ class InitCli extends React.Component {
             </tr>
             <tr>
                 <td><code>--help</code></td>
-                <td>boolean</td>
+                <td>boolean [default: false]</td>
                 <td>Show help.</td>
             </tr>
             <tr>

--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -87,6 +87,11 @@ class InitCli extends React.Component {
                 <td>[Experimental] Use Hermes instead of Chakra as the JS engine (supported on 0.64+ for C++ projects).</td>
             </tr>
             <tr>
+                <td><code>--experimentalNuGetDependency</code></td>
+                <td>boolean [default: false]</td>
+                <td>[Experimental] change to start consuming a NuGet containing a pre-built dll version of Microsoft.ReactNative.</td>
+            </tr>
+            <tr>
                 <td><code>--telemetry</code></td>
                 <td>boolean</td>
                 <td>Controls sending telemetry that allows analysis of usage and failures of the react-native-windows CLI.</td>

--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -87,7 +87,7 @@ class InitCli extends React.Component {
                 <td>[Experimental] Use Hermes instead of Chakra as the JS engine (supported on 0.64+ for C++ projects).</td>
             </tr>
             <tr>
-                <td><code>--no-telemetry</code></td>
+                <td><code>--telemetry</code></td>
                 <td>boolean</td>
                 <td>Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI</td>
             </tr>

--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -84,7 +84,7 @@ class InitCli extends React.Component {
             <tr>
                 <td><code>--useHermes</code></td>
                 <td>boolean</td>
-                <td>Use Hermes instead of Chakra as the JS engine (supported on 0.64+ for C++ projects)</td>
+                <td>[Experimental] Use Hermes instead of Chakra as the JS engine (supported on 0.64+ for C++ projects).</td>
             </tr>
             <tr>
                 <td><code>--no-telemetry</code></td>

--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -64,7 +64,7 @@ class InitCli extends React.Component {
             <tr>
                 <td><code>--language</code></td>
                 <td>string ["cs","cpp"] [default: "cpp"]</td>
-                <td>Which language the app is written in.</td>
+                <td>The language the project is written in.</td>
             </tr>
             <tr>
                 <td><code>--projectType</code></td>

--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -78,7 +78,7 @@ class InitCli extends React.Component {
             </tr>
             <tr>
                 <td><code>--useWinUI3</code></td>
-                <td>boolean</td>
+                <td>boolean [default: false]</td>
                 <td>[Experimental] Targets WinUI 3.0 (Preview) instead of UWP XAML.</td>
             </tr>
             <tr>

--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -58,7 +58,7 @@ class InitCli extends React.Component {
             </tr>
             <tr>
                 <td><code>--verbose</code></td>
-                <td>boolean</td>
+                <td>boolean [default: false]</td>
                 <td>Enables logging. </td>
             </tr>
             <tr>

--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -1,0 +1,105 @@
+const React = require("react");
+
+const CompLibrary = require("../../core/CompLibrary.js");
+
+const MarkdownBlock = CompLibrary.MarkdownBlock; /* Used to read markdown */
+
+class InitCli extends React.Component {
+  render() {
+    const Section = ({ children, className, background = "light" }) => (
+      <section className={`Section ${className} ${background}`}>
+        {children}
+      </section>
+    );
+
+    return (
+      <Section background="light">
+        <div style={{marginLeft: 20}}>
+        <h1 style={{ fontSize: 50, fontWeight: 700, marginTop: -35 }}>
+          React Native Windows Init CLI
+        </h1>
+        <p>
+          This guide will give you more information on the React Native Windows
+          CLI.
+        </p>
+        <h2><code>react-native-windows-init</code></h2>
+        <p>
+          <code>react-native-windows-init</code> is a CLI used to bootstrap the addition of
+          the Windows platform to <code>react-native</code> projects.
+        </p>
+        <h3>Usage</h3>
+        <p>
+          Run <code>npx react-native-windows-init --overwrite</code> from an existing <code>react-native</code> project, to install
+          <code>react-native-windows</code> and generate initial project files for Windows.
+        </p>
+        <h3>Options</h3>
+        <MarkdownBlock>Here are the options that `react-native-windows-init` takes: 
+          </MarkdownBlock>
+        <table>
+            <tr>
+                <th>Option</th>
+                <th>Input Type</th>
+                <th>Description</th>
+            </tr>
+            <tr>
+                <td><code>--help</code></td>
+                <td>boolean</td>
+                <td>Show help.</td>
+            </tr>
+            <tr>
+                <td><code>--version</code></td>
+                <td>string</td>
+                <td>The version of react-native-windows to use.</td>
+            </tr>
+            <tr>
+                <td><code>--namespace</code></td>
+                <td>string</td>
+                <td>The native project namespace.</td>
+            </tr>
+            <tr>
+                <td><code>--verbose</code></td>
+                <td>boolean</td>
+                <td>Enables logging. </td>
+            </tr>
+            <tr>
+                <td><code>--language</code></td>
+                <td>string ["cs","cpp"] [default: "cpp"]</td>
+                <td>Which language the app is written in.</td>
+            </tr>
+            <tr>
+                <td><code>--projectType</code></td>
+                <td>string ["app","lib"] [default: "app"] </td>
+                <td>The type of project to initialize.</td>
+            </tr>
+            <tr>
+                <td><code>--overwrite</code></td>
+                <td>boolean</td>
+                <td>Overwrite any existing files without prompting.</td>
+            </tr>
+            <tr>
+                <td><code>--useWinUI3</code></td>
+                <td>boolean</td>
+                <td>Targets WinUI 3.0 (Preview) instead of UWP XAML.</td>
+            </tr>
+            <tr>
+                <td><code>--useHermes</code></td>
+                <td>boolean</td>
+                <td>Use Hermes instead of Chakra as the JS engine (supported on 0.64+ for C++ projects)</td>
+            </tr>
+            <tr>
+                <td><code>--no-telemetry</code></td>
+                <td>boolean</td>
+                <td>Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI</td>
+            </tr>
+        </table>
+        <p>
+          This sends telemetry to Microsoft by default. You can prevent the
+          telemetry from being sent by using the <code>--no-telemetry</code> command line
+          option. See the <code>react-native-windows-init</code> README for more details.
+        </p>
+        </div>
+      </Section>
+    );
+  }
+}
+module.exports = InitCli;

--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -73,7 +73,7 @@ class InitCli extends React.Component {
             </tr>
             <tr>
                 <td><code>--overwrite</code></td>
-                <td>boolean</td>
+                <td>boolean [default: false]</td>
                 <td>Overwrite any existing files without prompting.</td>
             </tr>
             <tr>

--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -100,7 +100,20 @@ class InitCli extends React.Component {
         <p>
           This sends telemetry to Microsoft by default. You can prevent the
           telemetry from being sent by using the <code>--no-telemetry</code> command line
-          option. See the <code>react-native-windows-init</code> README for more details.
+          option. See below for more details.
+        </p>
+        <p>
+        The software may collect information about you and your use of the software and send 
+        it to Microsoft. Microsoft may use this information to provide services and improve 
+        our products and services. You may turn off the telemetry as described in the repository. 
+        There are also some features in the software that may enable you and Microsoft to collect 
+        data from users of your applications. If you use these features, you must comply with 
+        applicable law, including providing appropriate notices to users of your applications 
+        together with a copy of Microsoft's privacy statement. Our privacy statement is located
+        at https://go.microsoft.com/fwlink/?LinkID=824704. You can learn more about data collection
+        and use in the help documentation and our privacy statement. Your use of the software operates
+        as your consent to these practices. This data collection notice only applies to the process 
+        of creating a new React Native for Windows app with the CLI.
         </p>
         </div>
       </Section>

--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -54,7 +54,7 @@ class InitCli extends React.Component {
             <tr>
                 <td><code>--namespace</code></td>
                 <td>string</td>
-                <td>The native project namespace.</td>
+                <td>The native project namespace. This should be expressed using dots as separators. i.e. 'Level1.Level2.Level3'. The generator will apply the correct syntax for the target language.</td>
             </tr>
             <tr>
                 <td><code>--verbose</code></td>

--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -79,7 +79,7 @@ class InitCli extends React.Component {
             <tr>
                 <td><code>--useWinUI3</code></td>
                 <td>boolean</td>
-                <td>Targets WinUI 3.0 (Preview) instead of UWP XAML.</td>
+                <td>[Experimental] Targets WinUI 3.0 (Preview) instead of UWP XAML.</td>
             </tr>
             <tr>
                 <td><code>--useHermes</code></td>

--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -69,7 +69,7 @@ class InitCli extends React.Component {
             <tr>
                 <td><code>--projectType</code></td>
                 <td>string ["app","lib"] [default: "app"] </td>
-                <td>The type of project to initialize.</td>
+                <td>The type of project to initialize (supported on 0.64+).</td>
             </tr>
             <tr>
                 <td><code>--overwrite</code></td>

--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -83,7 +83,7 @@ class InitCli extends React.Component {
             </tr>
             <tr>
                 <td><code>--useHermes</code></td>
-                <td>boolean</td>
+                <td>boolean [default: false]</td>
                 <td>[Experimental] Use Hermes instead of Chakra as the JS engine (supported on 0.64+ for C++ projects).</td>
             </tr>
             <tr>

--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -93,7 +93,7 @@ class InitCli extends React.Component {
             </tr>
             <tr>
                 <td><code>--telemetry</code></td>
-                <td>boolean</td>
+                <td>boolean [default: false]</td>
                 <td>Controls sending telemetry that allows analysis of usage and failures of the react-native-windows CLI.</td>
             </tr>
         </table>


### PR DESCRIPTION
## Description

### Why
Making a separate static page to document react-native-windows-init CLI.

See #607 for page getting linked up to existing pages. 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/638)