### PR TITLE
workflow for adding issues to bug board, using rnbot token

### DIFF
--- a/.github/workflows/add-issues-to-bug-board.yml
+++ b/.github/workflows/add-issues-to-bug-board.yml
@@ -1,0 +1,16 @@
+name: Add issues to React Native Bug Board
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/microsoft/projects/235
+          github-token: ${{ secrets.RNBOT_GH_TOKEN }}


### PR DESCRIPTION
## Description
Using a new [GitHub action (beta) ](https://github.com/marketplace/actions/add-to-github-projects-beta)to automatically add new issues into RN Bug Board for easier triage. 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/695)