### PR TITLE
Update Experimental NuGet documentation

### DIFF
--- a/docs/managing-cpp-deps.md
+++ b/docs/managing-cpp-deps.md
@@ -7,11 +7,9 @@ Details to consider when consuming community modules or other Visual C++ project
 
 ### Details
 
-Applications with native code, either written on `C#` or `C++`, may add source dependencies on native Visual C++ (`.vcxproj`) projects.\
-Meaning, such dependencies will be built as part of the application.
+Applications with native code, either written on `C#` or `C++`, may add source dependencies on native Visual C++ (`.vcxproj`) projects. Meaning, such dependencies will be built as part of the application.
 
-Starting with version `0.68`, React Native for Windows apps use the [`PackageReference`](https://docs.microsoft.com/nuget/consume-packages/package-references-in-project-files) restore project style for native `C++` NuGet dependencies.\
-The main change consists of NuGet packages being placed directly in the user account's `globalPackagesFolder` cache instead of also copying them into a local folder relative to the Visual Studio Solution location (see [`repositoryPath`](https://docs.microsoft.com/nuget/reference/nuget-config-file)).
+Starting with version `0.68`, React Native for Windows apps use the [`PackageReference`](https://docs.microsoft.com/nuget/consume-packages/package-references-in-project-files) restore project style for native `C++` NuGet dependencies. The main change consists of NuGet packages being placed directly in the user account's `globalPackagesFolder` cache instead of also copying them into a local folder relative to the Visual Studio Solution location (see [`repositoryPath`](https://docs.microsoft.com/nuget/reference/nuget-config-file)).
 
 This may conflict with C++ dependencies that use the more common [`packages.config`](https://docs.microsoft.com/nuget/reference/packages-config) project style, including community modules generated targeting versions older than 0.68.
 
@@ -25,8 +23,7 @@ yarn add @react-native-picker/picker
 
 ### Add a `packages.config` file to your app's project directory
 
-The React Native Windows build system will try to build the dependency from source.\
-Because it uses the `packages.config` restore style, it will most likely expect its own NuGet dependencies to be restored at `$(SolutionDir)packages\`.
+The React Native Windows build system will try to build the dependency from source. Because it uses the `packages.config` restore style, it will most likely expect its own NuGet dependencies to be restored at `$(SolutionDir)packages\`.
 
 #### See [`node_modules\@react-native-picker\picker\windows\ReactNativePicker\ReactNativePicker.vcxproj`](https://github.com/react-native-picker/picker/blob/v2.2.1/windows/ReactNativePicker/ReactNativePicker.vcxproj#L156)
 

--- a/website/.unbroken_exclusions
+++ b/website/.unbroken_exclusions
@@ -35,6 +35,11 @@ File not found native-modules-async.md while parsing versioned_docs/version-0.68
 File not found native-modules-jsvalue.md while parsing versioned_docs/version-0.68/native-modules.md
 File not found view-managers.md while parsing versioned_docs/version-0.68/native-modules.md
 File not found native-code-language-choice.md while parsing versioned_docs/version-0.68/native-modules.md
+File not found supported-community-modules.md while parsing versioned_docs/version-0.68/nuget.md
+File not found upgrade-app.md while parsing versioned_docs/version-0.68/nuget.md
+File not found winui3.md while parsing versioned_docs/version-0.68/nuget.md
+File not found native-modules-csharp-codegen.md while parsing versioned_docs/version-0.68/nuget.md
+File not found nuget-update.md while parsing versioned_docs/version-0.68/nuget.md
 File not found hermes.md while parsing versioned_docs/version-0.67/customizing-SDK-versions.md
 File not found rnw-dependencies.md while parsing versioned_docs/version-0.67/getting-started.md
 File not found native-modules.md while parsing versioned_docs/version-0.67/getting-started.md

--- a/website/versioned_docs/version-0.64/nuget-update.md
+++ b/website/versioned_docs/version-0.64/nuget-update.md
@@ -16,11 +16,11 @@ You can find the npm version by opening `package.json` at the root of your proje
   ...
   "dependencies": {
     ...
-    "react-native-windows": "0.63.0"
+    "react-native-windows": "0.64.0"
   },
   ...
 ```
-In this example the npm version for `react-native-windows` is `0.63.0`.  Note that if you use preview, Your version might include a preview marker like `0.64.0-preview.3`. 
+In this example the npm version for `react-native-windows` is `0.64.0`.  Note that if you use preview, Your version might include a preview marker like `0.65.0-preview.1`. 
 
 # Determine and update the NuGet version
 For Windows there are two project types: C++ and C#. If you don't know which one you can look in the `windows/MyProject` folder. 
@@ -43,7 +43,7 @@ If you use [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/), 
 1. Find the Package reference section:
    ```xml
     <PackageReference Include="Microsoft.ReactNative.Managed">
-      <Version>0.63.0</Version>
+      <Version>0.64.0</Version>
     </PackageReference>
     ```
 1. Change the version element.
@@ -70,8 +70,8 @@ If you use [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/), 
 1. Update the version attributes of both `Microsoft.ReactNative` and `Microsoft.ReactNative.Cxx` packages
 1. Open `windows/MyProject/MyProject.vcxproj` in a text editor.
 1. Perform a search and replace for: 
-   * `packages\Microsoft.ReactNative.0.63.0`
-   * `packages\Microsoft.ReactNative.Cxx.0.63.0`
+   * `packages\Microsoft.ReactNative.0.64.0`
+   * `packages\Microsoft.ReactNative.Cxx.0.64.0`
    and replace it with the the version number of the npm package.
    There should be multiple strings to replace.
 

--- a/website/versioned_docs/version-0.64/nuget.md
+++ b/website/versioned_docs/version-0.64/nuget.md
@@ -8,7 +8,7 @@ original_id: NuGet
 
 The default for react-native-windows has been to build all code from source. This includes building all the code shipped by the react-native-windows team in the npm package from source. This code can be quite large and take a long time to build as well as require a high-performance computer. Some configurations have problems building this code with only 8 GB of memory. Especially if you are used to working only with managed code, this can be a big surprise.
 
-Starting with version 0.63 the team offers experimental NuGet packages that can be used as a replacement of compiling the sources.
+Starting with version 0.64 the team offers experimental NuGet packages that can be used as a replacement of compiling the sources.
 
 > Disclaimer: There are known compatibility issues with [community modules](supported-community-modules.md), as they still rely on building the shared code from source. So the solution still needs to have all the source projects which puts all the build performance problems back.
 
@@ -17,8 +17,6 @@ Starting with version 0.63 the team offers experimental NuGet packages that can 
 The benefit of using NuGet packages is that you get improved compilation times for your Windows project and can develop on a less powerful computer.
 
 The other benefit will be that it will be easier to update your projects to future versions or react-native-windows.
-
-We are working on getting the packages on [`NuGet.org`](https://NuGet.org). Until that time the packages will be available on the [react-native-public feed](https://dev.azure.com/ms/react-native/_packaging?_a=feed&feed=react-native-public) on Azure DevOps.
 
 # How to enable on new projects
 When you enable react-native-windows on your new project, you can pass `--experimentalNuGetDependency true`:
@@ -31,19 +29,6 @@ Of course all the other flags still work.
 
 # How to update a previously created project
 ## C# projects
-1. Add a NuGet configuration file `NuGet.config` in the `windows` folder next to the `.sln` file
-   ```xml
-   <?xml version="1.0" encoding="utf-8"?>
-    <configuration>
-    <config>
-      <add key="repositoryPath" value="packages" />
-    </config>
-    <packageSources>
-      <add key="NuGet.org" value="https://api.NuGet.org/v3/index.json" />
-      <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/NuGet/v3/index.json" />
-     </packageSources>
-   </configuration>
-   ```
 1. Update the solution file `windows\<projectName>.sln`:
    1. Open the project in Visual Studio
    1. Remove all projects except your own app project
@@ -53,7 +38,7 @@ Of course all the other flags still work.
       +   <UseExperimentalNuGet>true</UseExperimentalNuGet>
         </PropertyGroup>
       ```
-   1. If you have a project that was created before 0.63, you should remove all references to `Microsoft.ReactNative.*` projects.
+   1. Remove any `<ProjectReference>` references for `Microsoft.ReactNative.*` projects.
    1. Add a NuGet reference to `Microsoft.ReactNative.Managed`.
       You can do this either through Visual Studio's UI or by adding:
       ```xml
@@ -79,6 +64,7 @@ Of course all the other flags still work.
       +   <UseExperimentalNuGet>true</UseExperimentalNuGet>
         </PropertyGroup>
       ```
+   1. Remove any `<ProjectReference>` references for `Microsoft.ReactNative.*` projects.
    1. Add NuGet references to the following NuGet packages:
       * `Microsoft.ReactNative`
       * `Microsoft.ReactNative.Cxx`

--- a/website/versioned_docs/version-0.65/nuget.md
+++ b/website/versioned_docs/version-0.65/nuget.md
@@ -8,7 +8,7 @@ original_id: NuGet
 
 The default for react-native-windows has been to build all code from source. This includes building all the code shipped by the react-native-windows team in the npm package from source. This code can be quite large and take a long time to build as well as require a high-performance computer. Some configurations have problems building this code with only 8 GB of memory. Especially if you are used to working only with managed code, this can be a big surprise.
 
-Starting with version 0.63 the team offers experimental NuGet packages that can be used as a replacement of compiling the sources.
+Starting with version 0.64 the team offers experimental NuGet packages that can be used as a replacement of compiling the sources.
 
 > Disclaimer: There are known compatibility issues with [community modules](supported-community-modules.md), as they still rely on building the shared code from source. So the solution still needs to have all the source projects which puts all the build performance problems back.
 
@@ -17,8 +17,6 @@ Starting with version 0.63 the team offers experimental NuGet packages that can 
 The benefit of using NuGet packages is that you get improved compilation times for your Windows project and can develop on a less powerful computer.
 
 The other benefit will be that it will be easier to update your projects to future versions or react-native-windows.
-
-We are working on getting the packages on [`NuGet.org`](https://NuGet.org). Until that time the packages will be available on the [react-native-public feed](https://dev.azure.com/ms/react-native/_packaging?_a=feed&feed=react-native-public) on Azure DevOps.
 
 # How to enable on new projects
 When you enable react-native-windows on your new project, you can pass `--experimentalNuGetDependency true`:
@@ -33,19 +31,6 @@ Of course all the other flags still work.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--C# projects-->
-1. Add a NuGet configuration file `NuGet.config` in the `windows` folder next to the `.sln` file
-   ```xml
-   <?xml version="1.0" encoding="utf-8"?>
-    <configuration>
-    <config>
-      <add key="repositoryPath" value="packages" />
-    </config>
-    <packageSources>
-      <add key="NuGet.org" value="https://api.NuGet.org/v3/index.json" />
-      <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/NuGet/v3/index.json" />
-     </packageSources>
-   </configuration>
-   ```
 1. Update the solution file `windows\<projectName>.sln`:
    1. Open the project in Visual Studio
    1. Remove all projects except your own app project
@@ -55,7 +40,7 @@ Of course all the other flags still work.
       +   <UseExperimentalNuGet>true</UseExperimentalNuGet>
         </PropertyGroup>
       ```
-   1. If you have a project that was created before 0.63, you should remove all references to `Microsoft.ReactNative.*` projects.
+   1. Remove any `<ProjectReference>` references for `Microsoft.ReactNative.*` projects.
    1. Add a NuGet reference to `Microsoft.ReactNative.Managed`.
       You can do this either through Visual Studio's UI or by adding:
       ```xml
@@ -74,6 +59,7 @@ Of course all the other flags still work.
    1. Open the project in Visual Studio
    1. Remove all projects that are not your project
 1. Edit the project file `windows\<projectName>\<projectName.vcxproj>`
+   1. Remove any `<ProjectReference>` references for `Microsoft.ReactNative.*` projects.
    1. Add the the NuGet flag to the first property group
       ```diff
         <PropertyGroup Label="ReactNativeWindowsProps">

--- a/website/versioned_docs/version-0.66/nuget.md
+++ b/website/versioned_docs/version-0.66/nuget.md
@@ -8,7 +8,7 @@ original_id: NuGet
 
 The default for react-native-windows has been to build all code from source. This includes building all the code shipped by the react-native-windows team in the npm package from source. This code can be quite large and take a long time to build as well as require a high-performance computer. Some configurations have problems building this code with only 8 GB of memory. Especially if you are used to working only with managed code, this can be a big surprise.
 
-Starting with version 0.63 the team offers experimental NuGet packages that can be used as a replacement of compiling the sources.
+Starting with version 0.64 the team offers experimental NuGet packages that can be used as a replacement of compiling the sources.
 
 > Disclaimer: There are known compatibility issues with [community modules](supported-community-modules.md), as they still rely on building the shared code from source. So the solution still needs to have all the source projects which puts all the build performance problems back.
 
@@ -17,8 +17,6 @@ Starting with version 0.63 the team offers experimental NuGet packages that can 
 The benefit of using NuGet packages is that you get improved compilation times for your Windows project and can develop on a less powerful computer.
 
 The other benefit will be that it will be easier to update your projects to future versions or react-native-windows.
-
-We are working on getting the packages on [`NuGet.org`](https://NuGet.org). Until that time the packages will be available on the [react-native-public feed](https://dev.azure.com/ms/react-native/_packaging?_a=feed&feed=react-native-public) on Azure DevOps.
 
 # How to enable on new projects
 When you enable react-native-windows on your new project, you can pass `--experimentalNuGetDependency true`:
@@ -33,19 +31,6 @@ Of course all the other flags still work.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--C# projects-->
-1. Add a NuGet configuration file `NuGet.config` in the `windows` folder next to the `.sln` file
-   ```xml
-   <?xml version="1.0" encoding="utf-8"?>
-    <configuration>
-    <config>
-      <add key="repositoryPath" value="packages" />
-    </config>
-    <packageSources>
-      <add key="NuGet.org" value="https://api.NuGet.org/v3/index.json" />
-      <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/NuGet/v3/index.json" />
-     </packageSources>
-   </configuration>
-   ```
 1. Update the solution file `windows\<projectName>.sln`:
    1. Open the project in Visual Studio
    1. Remove all projects except your own app project
@@ -54,13 +39,14 @@ Of course all the other flags still work.
       ```xml
       <UseExperimentalNuGet>true</UseExperimentalNuGet>
       ```
-   1. If you have a project that was created before 0.63, you should remove all references to `Microsoft.ReactNative.*` projects.
+1. Edit the project file `windows\<projectName>\<projectName.csproj>`
+   1. Remove any `<ProjectReference>` references for `Microsoft.ReactNative.*` projects.
    1. Add a NuGet reference to `Microsoft.ReactNative.Managed`.
       You can do this either through Visual Studio's UI or by adding:
       ```xml
       <ItemGroup>
         <PackageReference Include="Microsoft.ReactNative.Managed">
-          <Version>0.65.0</Version>
+          <Version>0.66.0</Version>
         </PackageReference>
       </ItemGroup>
       ```
@@ -77,6 +63,8 @@ Of course all the other flags still work.
       ```xml
       <UseExperimentalNuGet>true</UseExperimentalNuGet>
       ```
+1. Edit the project file `windows\<projectName>\<projectName.vcxproj>`
+   1. Remove any `<ProjectReference>` references for `Microsoft.ReactNative.*` projects.
    1. Add NuGet references to the following NuGet packages:
       * `Microsoft.ReactNative`
       * `Microsoft.ReactNative.Cxx`

--- a/website/versioned_docs/version-0.68/managing-cpp-deps.md
+++ b/website/versioned_docs/version-0.68/managing-cpp-deps.md
@@ -8,11 +8,9 @@ Details to consider when consuming community modules or other Visual C++ project
 
 ### Details
 
-Applications with native code, either written on `C#` or `C++`, may add source dependencies on native Visual C++ (`.vcxproj`) projects.\
-Meaning, such dependencies will be built as part of the application.
+Applications with native code, either written on `C#` or `C++`, may add source dependencies on native Visual C++ (`.vcxproj`) projects. Meaning, such dependencies will be built as part of the application.
 
-Starting with version `0.68`, React Native for Windows apps use the [`PackageReference`](https://docs.microsoft.com/nuget/consume-packages/package-references-in-project-files) restore project style for native `C++` NuGet dependencies.\
-The main change consists of NuGet packages being placed directly in the user account's `globalPackagesFolder` cache instead of also copying them into a local folder relative to the Visual Studio Solution location (see [`repositoryPath`](https://docs.microsoft.com/nuget/reference/nuget-config-file)).
+Starting with version `0.68`, React Native for Windows apps use the [`PackageReference`](https://docs.microsoft.com/nuget/consume-packages/package-references-in-project-files) restore project style for native `C++` NuGet dependencies. The main change consists of NuGet packages being placed directly in the user account's `globalPackagesFolder` cache instead of also copying them into a local folder relative to the Visual Studio Solution location (see [`repositoryPath`](https://docs.microsoft.com/nuget/reference/nuget-config-file)).
 
 This may conflict with C++ dependencies that use the more common [`packages.config`](https://docs.microsoft.com/nuget/reference/packages-config) project style, including community modules generated targeting versions older than 0.68.
 
@@ -26,8 +24,7 @@ yarn add @react-native-picker/picker
 
 ### Add a `packages.config` file to your app's project directory
 
-The React Native Windows build system will try to build the dependency from source.\
-Because it uses the `packages.config` restore style, it will most likely expect its own NuGet dependencies to be restored at `$(SolutionDir)packages\`.
+The React Native Windows build system will try to build the dependency from source. Because it uses the `packages.config` restore style, it will most likely expect its own NuGet dependencies to be restored at `$(SolutionDir)packages\`.
 
 #### See [`node_modules\@react-native-picker\picker\windows\ReactNativePicker\ReactNativePicker.vcxproj`](https://github.com/react-native-picker/picker/blob/v2.2.1/windows/ReactNativePicker/ReactNativePicker.vcxproj#L156)
 

--- a/website/versioned_docs/version-0.68/nuget.md
+++ b/website/versioned_docs/version-0.68/nuget.md
@@ -1,6 +1,7 @@
 ---
-id: NuGet
+id: version-0.68-NuGet
 title: Using react-native-windows NuGet packages
+original_id: NuGet
 ---
 
 >**This documentation and the underlying platform code is a work in progress.**


### PR DESCRIPTION
Changes were made starting with RNW 0.68 to make switching between
building from RNW source and nugets easier.

This PR updates the docs to reflect these easier steps for RNW >= 0.68
and also to clarify the correct steps for earlier versions.

Addressing the confusion from the older steps asking for unnecessary
changes. See https://github.com/microsoft/react-native-windows/issues/9937

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/696)