### PR TITLE
Update static js pages with titles and proper site styles

### DIFF
--- a/website/pages/en/init-cli.js
+++ b/website/pages/en/init-cli.js
@@ -13,111 +13,119 @@ class InitCli extends React.Component {
     );
 
     return (
-      <Section background="light">
-        <div style={{marginLeft: 20}}>
-        <h1 style={{ fontSize: 50, fontWeight: 700, marginTop: -35 }}>
-          React Native Windows Init CLI
-        </h1>
-        <p>
-          This guide will give you more information on the React Native Windows
-          CLI.
-        </p>
-        <h2><code>react-native-windows-init</code></h2>
-        <p>
-          <code>react-native-windows-init</code> is a CLI used to bootstrap the addition of
-          the Windows platform to <code>react-native</code> projects.
-        </p>
-        <h3>Usage</h3>
-        <p>
-          Run <code>npx react-native-windows-init --overwrite</code> from an existing <code>react-native</code> project, to install
-          <code>react-native-windows</code> and generate initial project files for Windows.
-        </p>
-        <h3>Options</h3>
-        <MarkdownBlock>Here are the options that `react-native-windows-init` takes: 
-          </MarkdownBlock>
-        <table>
-            <tr>
+      <div className="homepage">
+        <Section background="light">
+          <div className="content">
+            <h1 style={{ fontSize: '60px', marginTop: '-20px', fontWeight: 'bold' }}>
+              React Native Windows Init CLI
+            </h1>
+            <p>
+              This guide will give you more information on the React Native Windows
+              CLI.
+            </p>
+            <h2><code>react-native-windows-init</code></h2>
+            <p>
+              <code>react-native-windows-init</code> is a CLI used to bootstrap the addition of
+              the Windows platform to <code>react-native</code> projects.
+            </p>
+            <h3>Usage</h3>
+            <p>
+              Run <code>npx react-native-windows-init --overwrite</code> from an existing <code>react-native</code> project, to install
+              <code>react-native-windows</code> and generate initial project files for Windows.
+            </p>
+            <h3>Options</h3>
+            <MarkdownBlock>Here are the options that `react-native-windows-init` takes:</MarkdownBlock>
+            <table>
+              <tr>
                 <th>Option</th>
                 <th>Input Type</th>
                 <th>Description</th>
-            </tr>
-            <tr>
+              </tr>
+              <tr>
                 <td><code>--help</code></td>
                 <td>boolean [default: false]</td>
                 <td>Show help.</td>
-            </tr>
-            <tr>
+              </tr>
+              <tr>
                 <td><code>--version</code></td>
                 <td>string</td>
                 <td>The version of react-native-windows to use.</td>
-            </tr>
-            <tr>
+              </tr>
+              <tr>
                 <td><code>--namespace</code></td>
                 <td>string</td>
                 <td>The native project namespace. This should be expressed using dots as separators. i.e. 'Level1.Level2.Level3'. The generator will apply the correct syntax for the target language.</td>
-            </tr>
-            <tr>
+              </tr>
+              <tr>
                 <td><code>--verbose</code></td>
                 <td>boolean [default: false]</td>
                 <td>Enables logging. </td>
-            </tr>
-            <tr>
+              </tr>
+              <tr>
                 <td><code>--language</code></td>
                 <td>string ["cs","cpp"] [default: "cpp"]</td>
                 <td>The language the project is written in.</td>
-            </tr>
-            <tr>
+              </tr>
+              <tr>
                 <td><code>--projectType</code></td>
                 <td>string ["app","lib"] [default: "app"] </td>
                 <td>The type of project to initialize (supported on 0.64+).</td>
-            </tr>
-            <tr>
+              </tr>
+              <tr>
                 <td><code>--overwrite</code></td>
                 <td>boolean [default: false]</td>
                 <td>Overwrite any existing files without prompting.</td>
-            </tr>
-            <tr>
+              </tr>
+              <tr>
                 <td><code>--useWinUI3</code></td>
                 <td>boolean [default: false]</td>
                 <td>[Experimental] Targets WinUI 3.0 (Preview) instead of UWP XAML.</td>
-            </tr>
-            <tr>
+              </tr>
+              <tr>
                 <td><code>--useHermes</code></td>
                 <td>boolean [default: false]</td>
                 <td>[Experimental] Use Hermes instead of Chakra as the JS engine (supported on 0.64+ for C++ projects).</td>
-            </tr>
-            <tr>
+              </tr>
+              <tr>
                 <td><code>--experimentalNuGetDependency</code></td>
                 <td>boolean [default: false]</td>
                 <td>[Experimental] change to start consuming a NuGet containing a pre-built dll version of Microsoft.ReactNative.</td>
-            </tr>
-            <tr>
+              </tr>
+              <tr>
                 <td><code>--telemetry</code></td>
                 <td>boolean [default: false]</td>
                 <td>Controls sending telemetry that allows analysis of usage and failures of the react-native-windows CLI.</td>
-            </tr>
-        </table>
-        <p>
-          This sends telemetry to Microsoft by default. You can prevent the
-          telemetry from being sent by using the <code>--no-telemetry</code> command line
-          option. See below for more details.
-        </p>
-        <p>
-        The software may collect information about you and your use of the software and send 
-        it to Microsoft. Microsoft may use this information to provide services and improve 
-        our products and services. You may turn off the telemetry as described in the repository. 
-        There are also some features in the software that may enable you and Microsoft to collect 
-        data from users of your applications. If you use these features, you must comply with 
-        applicable law, including providing appropriate notices to users of your applications 
-        together with a copy of Microsoft's privacy statement. Our privacy statement is located
-        at https://go.microsoft.com/fwlink/?LinkID=824704. You can learn more about data collection
-        and use in the help documentation and our privacy statement. Your use of the software operates
-        as your consent to these practices. This data collection notice only applies to the process 
-        of creating a new React Native for Windows app with the CLI.
-        </p>
-        </div>
-      </Section>
+              </tr>
+            </table>
+            <p>
+              This sends telemetry to Microsoft by default. You can prevent the
+              telemetry from being sent by using the <code>--no-telemetry</code> command line
+              option. See below for more details.
+            </p>
+            <h3>Data Collection</h3>
+            <p>
+              The software may collect information about you and your use of the software and send 
+              it to Microsoft. Microsoft may use this information to provide services and improve 
+              our products and services. You may turn off the telemetry as described in the repository. 
+              There are also some features in the software that may enable you and Microsoft to collect 
+              data from users of your applications. If you use these features, you must comply with 
+              applicable law, including providing appropriate notices to users of your applications 
+              together with a copy of Microsoft's privacy statement. Our privacy statement is located
+              at <a href="https://go.microsoft.com/fwlink/?LinkID=824704">https://go.microsoft.com/fwlink/?LinkID=824704</a>.
+              You can learn more about data collection and use in the help documentation and our privacy
+              statement. Your use of the software operates as your consent to these practices.
+            </p>
+            <p>
+              This data collection notice only applies to the process of <b>creating</b> a new React Native
+              for Windows app with the CLI.
+            </p>
+          </div>
+        </Section>
+      </div>
     );
   }
 }
+
+InitCli.title = "React Native Windows Init CLI";
+
 module.exports = InitCli;

--- a/website/pages/en/resources-news-social.js
+++ b/website/pages/en/resources-news-social.js
@@ -133,7 +133,7 @@ class Resources extends React.Component {
                 <a href="./resources" className='resourcesSideNavLink'>Repos</a>
               </div>
               <div className="resourcesPageSideNavOptions">
-                <a className="resourcesSideNavLink selected" >News & Social</a>
+                <a className="resourcesSideNavLink selected" >News &amp; Social</a>
               </div>
               <div className="resourcesPageSideNavOptions">
                 <a href="./resources-videos" className="resourcesSideNavLink" >Videos</a>
@@ -155,5 +155,7 @@ class Resources extends React.Component {
     );
   }
 }
+
+Resources.title = "Resources - News & Social";
 
 module.exports = Resources;

--- a/website/pages/en/resources-showcase.js
+++ b/website/pages/en/resources-showcase.js
@@ -186,7 +186,7 @@ class Resources extends React.Component {
                 <a className='resourcesSideNavLink' href="./resources">Repos</a>
               </div>
               <div className="resourcesPageSideNavOptions">
-                <a href="./resources-news-social" className="resourcesSideNavLink">News & Social</a>
+                <a href="./resources-news-social" className="resourcesSideNavLink">News &amp; Social</a>
               </div>
               <div className="resourcesPageSideNavOptions">
                 <a href="./resources-videos" className="resourcesSideNavLink" >Videos</a>
@@ -208,6 +208,8 @@ class Resources extends React.Component {
     );
   }
 }
+
+Resources.title = "Resources - Showcase";
 
 module.exports = Resources;
 function renderDescription(app) {

--- a/website/pages/en/resources-videos.js
+++ b/website/pages/en/resources-videos.js
@@ -105,7 +105,7 @@ class Resources extends React.Component {
         <div className="content">
           {videoUrls.map(video => <iframe style={{ width: 560, height: 315, marginBottom: 16 }} src={`https://www.youtube.com/embed/${video.yt}`}
             title={video.title} frameborder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen />)}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen />)}
         </div>
       </Section>
     );
@@ -120,7 +120,7 @@ class Resources extends React.Component {
                 <a href="./resources" className={'resourcesSideNavLink '}>Repos</a>
               </div>
               <div className="resourcesPageSideNavOptions">
-                <a href="./resources-news-social" className="resourcesSideNavLink" >News & Social</a>
+                <a href="./resources-news-social" className="resourcesSideNavLink" >News &amp; Social</a>
               </div>
               <div className="resourcesPageSideNavOptions">
                 <a className="resourcesSideNavLink selected" >Videos</a>
@@ -142,5 +142,7 @@ class Resources extends React.Component {
     );
   }
 }
+
+Resources.title = "Resources - Videos";
 
 module.exports = Resources;

--- a/website/pages/en/resources.js
+++ b/website/pages/en/resources.js
@@ -179,7 +179,7 @@ class Resources extends React.Component {
                 <a className={'resourcesSideNavLink selected'}>Repos</a>
               </div>
               <div className="resourcesPageSideNavOptions">
-                <a href="./resources-news-social" className="resourcesSideNavLink" >News & Social</a>
+                <a href="./resources-news-social" className="resourcesSideNavLink" >News &amp; Social</a>
               </div>
               <div className="resourcesPageSideNavOptions">
                 <a href="./resources-videos" className="resourcesSideNavLink" >Videos</a>
@@ -201,5 +201,7 @@ class Resources extends React.Component {
     );
   }
 }
+
+Resources.title = "Resources - Repos";
 
 module.exports = Resources;

--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -113,4 +113,6 @@ class Versions extends React.Component {
   }
 }
 
+Versions.title = "Versions";
+
 module.exports = Versions;


### PR DESCRIPTION
This PR adds titles to each of the static js pages (rather than
defaulting the not useful full main site title.

This PR also cleans up the ini-cli page to better align with the styles
of the other static pages.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/708)