### PR TITLE
Update support status for RNW 0.64

### DIFF
--- a/website/pages/en/support.js
+++ b/website/pages/en/support.js
@@ -19,7 +19,7 @@ The React Native for Windows (RNW) Team strives to provide full support for the 
 | [0.67](https://www.npmjs.com/package/react-native-windows/v/v0.67-stable) | [Maintenance](#maintenance-support) | 01/24/2022 | *N/A*[¹](#support-matrix-1)</a> | *N/A*[¹](#support-matrix-1)  | 09/30/2022[²](#support-matrix-2) |
 | [0.66](https://www.npmjs.com/package/react-native-windows/v/v0.66-stable) | [Maintenance](#maintenance-support) | 10/11/2021 | *N/A*[¹](#support-matrix-1) | *N/A*[¹](#support-matrix-1) | 08/31/2022[²](#support-matrix-2) |
 | [0.65](https://www.npmjs.com/package/react-native-windows/v/v0.65-stable) | [Maintenance](#maintenance-support) | 08/23/2021 | *N/A*[¹](#support-matrix-1) | *N/A*[¹](#support-matrix-1) | 07/31/2022[²](#support-matrix-2) |
-| [0.64](https://www.npmjs.com/package/react-native-windows/v/v0.64-stable) | [Maintenance](#maintenance-support) | 03/15/2021 | *N/A*[¹](#support-matrix-1)| *N/A*[¹](#support-matrix-1) | 06/30/2022[²](#support-matrix-2) |
+| [0.64](https://www.npmjs.com/package/react-native-windows/v/v0.64-stable) | [Unsupported](#unsupported) | 03/15/2021 | *N/A*[¹](#support-matrix-1)| *N/A*[¹](#support-matrix-1) | 06/30/2022[²](#support-matrix-2) |
 | [0.63](https://www.npmjs.com/package/react-native-windows/v/v0.63-stable) | [Unsupported](#unsupported) | 08/31/2020 | *N/A*[¹](#support-matrix-1) | *N/A*[¹](#support-matrix-1) | 10/11/2021 |
 
 <div class="footnote">
@@ -30,7 +30,7 @@ The React Native for Windows (RNW) Team strives to provide full support for the 
 ¹: These releases were made prior to the institution of this official support policy document.
 
 <a id="support-matrix-2"></a>
-²: These releases were already receiving [Maintenance](#maintenance-support) equivalent support, and the new "End of Support" dates were set to give users some transition time before they become officially [Unsupported](#unsupported).
+²: These releases were receiving [Maintenance](#maintenance-support) equivalent support at the institution of this document. The "End of Support" dates were set to give users some transition time before the releases transition to [Unsupported](#unsupported).
 
 </div>
 


### PR DESCRIPTION
As per the schedule, RNW 0.64 is now unsupported.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/718)