### PR TITLE
fix typos

### DIFF
--- a/docs/view-managers.md
+++ b/docs/view-managers.md
@@ -142,7 +142,7 @@ namespace ViewManagerSample
     internal class CustomUserControlViewManager : AttributedViewManager<CustomUserControl>
     {
         [ViewManagerProperty("label")]
-        public void SetLabel(CustomUserControl view, view, string value)
+        public void SetLabel(CustomUserControl view, string value)
         {
             if (null != value)
             {
@@ -181,7 +181,7 @@ namespace ViewManagerSample
         }
 
         [ViewManagerCommand]
-        public void CustomCommand(CustomUserControl view, IReadonlyList<object> commandArgs)
+        public void CustomCommand(CustomUserControl view, IReadOnlyList<object> commandArgs)
         {
             // Execute command
         }

--- a/website/versioned_docs/version-0.60/view-managers.md
+++ b/website/versioned_docs/version-0.60/view-managers.md
@@ -132,7 +132,7 @@ namespace ViewManagerSample
     internal class CustomUserControlViewManager : AttributedViewManager<CustomUserControlCS>
     {
         [ViewManagerProperty("label")]
-        public void SetLabel(CustomUserControl view, view, string value)
+        public void SetLabel(CustomUserControl view, string value)
         {
             if (null != value)
             {
@@ -171,7 +171,7 @@ namespace ViewManagerSample
         }
 
         [ViewManagerCommand]
-        public void CustomCommand(CustomUserControl view, IReadonlyList<object> commandArgs)
+        public void CustomCommand(CustomUserControl view, IReadOnlyList<object> commandArgs)
         {
             // Execute command
         }

--- a/website/versioned_docs/version-0.61/view-managers.md
+++ b/website/versioned_docs/version-0.61/view-managers.md
@@ -133,7 +133,7 @@ namespace ViewManagerSample
     internal class CustomUserControlViewManager : AttributedViewManager<CustomUserControlCS>
     {
         [ViewManagerProperty("label")]
-        public void SetLabel(CustomUserControl view, view, string value)
+        public void SetLabel(CustomUserControl view, string value)
         {
             if (null != value)
             {
@@ -172,7 +172,7 @@ namespace ViewManagerSample
         }
 
         [ViewManagerCommand]
-        public void CustomCommand(CustomUserControl view, IReadonlyList<object> commandArgs)
+        public void CustomCommand(CustomUserControl view, IReadOnlyList<object> commandArgs)
         {
             // Execute command
         }

--- a/website/versioned_docs/version-0.62/view-managers.md
+++ b/website/versioned_docs/version-0.62/view-managers.md
@@ -133,7 +133,7 @@ namespace ViewManagerSample
     internal class CustomUserControlViewManager : AttributedViewManager<CustomUserControlCS>
     {
         [ViewManagerProperty("label")]
-        public void SetLabel(CustomUserControl view, view, string value)
+        public void SetLabel(CustomUserControl view, string value)
         {
             if (null != value)
             {
@@ -172,7 +172,7 @@ namespace ViewManagerSample
         }
 
         [ViewManagerCommand]
-        public void CustomCommand(CustomUserControl view, IReadonlyList<object> commandArgs)
+        public void CustomCommand(CustomUserControl view, IReadOnlyList<object> commandArgs)
         {
             // Execute command
         }

--- a/website/versioned_docs/version-0.63/view-managers.md
+++ b/website/versioned_docs/version-0.63/view-managers.md
@@ -140,7 +140,7 @@ namespace ViewManagerSample
     internal class CustomUserControlViewManager : AttributedViewManager<CustomUserControlCS>
     {
         [ViewManagerProperty("label")]
-        public void SetLabel(CustomUserControl view, view, string value)
+        public void SetLabel(CustomUserControl view, string value)
         {
             if (null != value)
             {
@@ -179,7 +179,7 @@ namespace ViewManagerSample
         }
 
         [ViewManagerCommand]
-        public void CustomCommand(CustomUserControl view, IReadonlyList<object> commandArgs)
+        public void CustomCommand(CustomUserControl view, IReadOnlyList<object> commandArgs)
         {
             // Execute command
         }

--- a/website/versioned_docs/version-0.64/view-managers.md
+++ b/website/versioned_docs/version-0.64/view-managers.md
@@ -140,7 +140,7 @@ namespace ViewManagerSample
     internal class CustomUserControlViewManager : AttributedViewManager<CustomUserControl>
     {
         [ViewManagerProperty("label")]
-        public void SetLabel(CustomUserControl view, view, string value)
+        public void SetLabel(CustomUserControl view, string value)
         {
             if (null != value)
             {
@@ -179,7 +179,7 @@ namespace ViewManagerSample
         }
 
         [ViewManagerCommand]
-        public void CustomCommand(CustomUserControl view, IReadonlyList<object> commandArgs)
+        public void CustomCommand(CustomUserControl view, IReadOnlyList<object> commandArgs)
         {
             // Execute command
         }

--- a/website/versioned_docs/version-0.65/view-managers.md
+++ b/website/versioned_docs/version-0.65/view-managers.md
@@ -143,7 +143,7 @@ namespace ViewManagerSample
     internal class CustomUserControlViewManager : AttributedViewManager<CustomUserControl>
     {
         [ViewManagerProperty("label")]
-        public void SetLabel(CustomUserControl view, view, string value)
+        public void SetLabel(CustomUserControl view, string value)
         {
             if (null != value)
             {
@@ -182,7 +182,7 @@ namespace ViewManagerSample
         }
 
         [ViewManagerCommand]
-        public void CustomCommand(CustomUserControl view, IReadonlyList<object> commandArgs)
+        public void CustomCommand(CustomUserControl view, IReadOnlyList<object> commandArgs)
         {
             // Execute command
         }


### PR DESCRIPTION
## Description
Just fixing a few typos I noticed while following the code on the website:

* `IReadonlyList` -> `IReadOnlyList`
* `SetLabel(CustomUserControl view, view, string value)` has an extra `view` argument that shouldn't be there.







###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/725)