### PR TITLE
Fix module builder bugs in "Native Modules (Advanced)" page

### DIFF
--- a/docs/native-modules-advanced.md
+++ b/docs/native-modules-advanced.md
@@ -61,7 +61,6 @@ namespace NativeModuleSample
     {
       packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
         var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
         moduleBuilder.AddConstantProvider((IJSValueWriter writer) => {
           writer.WritePropertyName("E");
           writer.WriteDouble(module.E);
@@ -76,8 +75,10 @@ namespace NativeModuleSample
             double a = inputReader.GetNextArrayItem() ? inputReader.GetDouble() : throw new Exception();
             double b = inputReader.GetNextArrayItem() ? inputReader.GetDouble() : throw new Exception();
             double result = module.Add(a, b);
+            outputWriter.WriteArrayBegin();
             outputWriter.WriteDouble(result);
-          resolve(outputWriter);
+            outputWriter.WriteArrayEnd();
+            resolve(outputWriter);
           });
         return module;
       });
@@ -99,7 +100,6 @@ namespace NativeModuleSample
     {
       packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
         var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
         moduleBuilder.AddConstantProvider((IJSValueWriter writer) => {
           writer.WriteProperty("E", module.E);
           writer.WriteProperty("Pi", module.PI);
@@ -109,11 +109,11 @@ namespace NativeModuleSample
           IJSValueWriter outputWriter,
           MethodResultCallback resolve,
           MethodResultCallback reject) => {
-           double[] args;
-           inputReader.ReadArgs(out args[0], out args[1]);
-           double result = module.Add(args[0], args[1]);
-           outputWriter.WriteDouble(result);
-           resolve(outputWriter);
+            double[] args;
+            inputReader.ReadArgs(out args[0], out args[1]);
+            double result = module.Add(args[0], args[1]);
+            outputWriter.WriteArgs(result);
+            resolve(outputWriter);
           });
         return module;
       });
@@ -135,7 +135,6 @@ namespace NativeModuleSample
     {
       packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
         var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
         moduleBuilder.AddConstantProvider(() => new Dictionary<string, object> {
           ["E"] = module.E,
           ["Pi"] = module.PI

--- a/website/versioned_docs/version-0.60/native-modules-advanced.md
+++ b/website/versioned_docs/version-0.60/native-modules-advanced.md
@@ -62,7 +62,6 @@ namespace NativeModuleSample
     {
       packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
         var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
         moduleBuilder.AddConstantProvider((IJSValueWriter writer) => {
           writer.WritePropertyName("E");
           writer.WriteDouble(module.E);
@@ -77,8 +76,10 @@ namespace NativeModuleSample
             double a = inputReader.GetNextArrayItem() ? inputReader.GetDouble() : throw new Exception();
             double b = inputReader.GetNextArrayItem() ? inputReader.GetDouble() : throw new Exception();
             double result = module.Add(a, b);
+            outputWriter.WriteArrayBegin();
             outputWriter.WriteDouble(result);
-          resolve(outputWriter);
+            outputWriter.WriteArrayEnd();
+            resolve(outputWriter);
           });
         return module;
       });
@@ -100,7 +101,6 @@ namespace NativeModuleSample
     {
       packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
         var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
         moduleBuilder.AddConstantProvider((IJSValueWriter writer) => {
           writer.WriteProperty("E", module.E);
           writer.WriteProperty("Pi", module.PI);
@@ -110,11 +110,11 @@ namespace NativeModuleSample
           IJSValueWriter outputWriter,
           MethodResultCallback resolve,
           MethodResultCallback reject) => {
-           double[] args;
-           inputReader.ReadArgs(out args[0], out args[1]);
-           double result = module.Add(args[0], args[1]);
-           outputWriter.WriteDouble(result);
-           resolve(outputWriter);
+            double[] args;
+            inputReader.ReadArgs(out args[0], out args[1]);
+            double result = module.Add(args[0], args[1]);
+            outputWriter.WriteArgs(result);
+            resolve(outputWriter);
           });
         return module;
       });
@@ -136,7 +136,6 @@ namespace NativeModuleSample
     {
       packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
         var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
         moduleBuilder.AddConstantProvider(() => new Dictionary<string, object> {
           ["E"] = module.E,
           ["Pi"] = module.PI

--- a/website/versioned_docs/version-0.62/native-modules-advanced.md
+++ b/website/versioned_docs/version-0.62/native-modules-advanced.md
@@ -62,7 +62,6 @@ namespace NativeModuleSample
     {
       packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
         var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
         moduleBuilder.AddConstantProvider((IJSValueWriter writer) => {
           writer.WritePropertyName("E");
           writer.WriteDouble(module.E);
@@ -77,8 +76,10 @@ namespace NativeModuleSample
             double a = inputReader.GetNextArrayItem() ? inputReader.GetDouble() : throw new Exception();
             double b = inputReader.GetNextArrayItem() ? inputReader.GetDouble() : throw new Exception();
             double result = module.Add(a, b);
+            outputWriter.WriteArrayBegin();
             outputWriter.WriteDouble(result);
-          resolve(outputWriter);
+            outputWriter.WriteArrayEnd();
+            resolve(outputWriter);
           });
         return module;
       });
@@ -100,7 +101,6 @@ namespace NativeModuleSample
     {
       packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
         var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
         moduleBuilder.AddConstantProvider((IJSValueWriter writer) => {
           writer.WriteProperty("E", module.E);
           writer.WriteProperty("Pi", module.PI);
@@ -110,11 +110,11 @@ namespace NativeModuleSample
           IJSValueWriter outputWriter,
           MethodResultCallback resolve,
           MethodResultCallback reject) => {
-           double[] args;
-           inputReader.ReadArgs(out args[0], out args[1]);
-           double result = module.Add(args[0], args[1]);
-           outputWriter.WriteDouble(result);
-           resolve(outputWriter);
+            double[] args;
+            inputReader.ReadArgs(out args[0], out args[1]);
+            double result = module.Add(args[0], args[1]);
+            outputWriter.WriteArgs(result);
+            resolve(outputWriter);
           });
         return module;
       });
@@ -136,7 +136,6 @@ namespace NativeModuleSample
     {
       packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
         var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
         moduleBuilder.AddConstantProvider(() => new Dictionary<string, object> {
           ["E"] = module.E,
           ["Pi"] = module.PI

--- a/website/versioned_docs/version-0.64/native-modules-advanced.md
+++ b/website/versioned_docs/version-0.64/native-modules-advanced.md
@@ -62,7 +62,6 @@ namespace NativeModuleSample
     {
       packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
         var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
         moduleBuilder.AddConstantProvider((IJSValueWriter writer) => {
           writer.WritePropertyName("E");
           writer.WriteDouble(module.E);
@@ -77,8 +76,10 @@ namespace NativeModuleSample
             double a = inputReader.GetNextArrayItem() ? inputReader.GetDouble() : throw new Exception();
             double b = inputReader.GetNextArrayItem() ? inputReader.GetDouble() : throw new Exception();
             double result = module.Add(a, b);
+            outputWriter.WriteArrayBegin();
             outputWriter.WriteDouble(result);
-          resolve(outputWriter);
+            outputWriter.WriteArrayEnd();
+            resolve(outputWriter);
           });
         return module;
       });
@@ -100,7 +101,6 @@ namespace NativeModuleSample
     {
       packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
         var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
         moduleBuilder.AddConstantProvider((IJSValueWriter writer) => {
           writer.WriteProperty("E", module.E);
           writer.WriteProperty("Pi", module.PI);
@@ -110,11 +110,11 @@ namespace NativeModuleSample
           IJSValueWriter outputWriter,
           MethodResultCallback resolve,
           MethodResultCallback reject) => {
-           double[] args;
-           inputReader.ReadArgs(out args[0], out args[1]);
-           double result = module.Add(args[0], args[1]);
-           outputWriter.WriteDouble(result);
-           resolve(outputWriter);
+            double[] args;
+            inputReader.ReadArgs(out args[0], out args[1]);
+            double result = module.Add(args[0], args[1]);
+            outputWriter.WriteArgs(result);
+            resolve(outputWriter);
           });
         return module;
       });
@@ -136,7 +136,6 @@ namespace NativeModuleSample
     {
       packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
         var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
         moduleBuilder.AddConstantProvider(() => new Dictionary<string, object> {
           ["E"] = module.E,
           ["Pi"] = module.PI

--- a/website/versioned_docs/version-0.65/native-modules-advanced.md
+++ b/website/versioned_docs/version-0.65/native-modules-advanced.md
@@ -62,7 +62,6 @@ namespace NativeModuleSample
     {
       packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
         var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
         moduleBuilder.AddConstantProvider((IJSValueWriter writer) => {
           writer.WritePropertyName("E");
           writer.WriteDouble(module.E);
@@ -77,8 +76,10 @@ namespace NativeModuleSample
             double a = inputReader.GetNextArrayItem() ? inputReader.GetDouble() : throw new Exception();
             double b = inputReader.GetNextArrayItem() ? inputReader.GetDouble() : throw new Exception();
             double result = module.Add(a, b);
+            outputWriter.WriteArrayBegin();
             outputWriter.WriteDouble(result);
-          resolve(outputWriter);
+            outputWriter.WriteArrayEnd();
+            resolve(outputWriter);
           });
         return module;
       });
@@ -100,7 +101,6 @@ namespace NativeModuleSample
     {
       packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
         var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
         moduleBuilder.AddConstantProvider((IJSValueWriter writer) => {
           writer.WriteProperty("E", module.E);
           writer.WriteProperty("Pi", module.PI);
@@ -110,11 +110,11 @@ namespace NativeModuleSample
           IJSValueWriter outputWriter,
           MethodResultCallback resolve,
           MethodResultCallback reject) => {
-           double[] args;
-           inputReader.ReadArgs(out args[0], out args[1]);
-           double result = module.Add(args[0], args[1]);
-           outputWriter.WriteDouble(result);
-           resolve(outputWriter);
+            double[] args;
+            inputReader.ReadArgs(out args[0], out args[1]);
+            double result = module.Add(args[0], args[1]);
+            outputWriter.WriteArgs(result);
+            resolve(outputWriter);
           });
         return module;
       });
@@ -136,7 +136,6 @@ namespace NativeModuleSample
     {
       packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
         var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
         moduleBuilder.AddConstantProvider(() => new Dictionary<string, object> {
           ["E"] = module.E,
           ["Pi"] = module.PI


### PR DESCRIPTION
The sample C# code given in the Native Modules (Advanced) page is incorrect. First, there is no `IReactModuleBuilder.SetName` method (it might be left over from an earlier iteration of the API).

Also, when passing an `IJSValueWriter` to a `MethodResultCallback`, the writer must contain an array of arguments to pass to the callback. Even if the callback has only one argument, it must be wrapped in an array for the (de)serialization to work.

Closes https://github.com/microsoft/react-native-windows/issues/10591

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/731)