### PR TITLE
Update RNW dependency on VS 2022

### DIFF
--- a/docs/rnw-dependencies.md
+++ b/docs/rnw-dependencies.md
@@ -12,14 +12,14 @@ You can run React Native for Windows apps only on:
 To develop React-Native for Windows apps, you need to install several dependencies.
 
 ## Install the development dependencies
-To check or install dependencies, run the script [`rnw-dependencies.ps1`](https://aka.ms/rnw-deps.ps1) in an elevated PowerShell window.
+To check or install dependencies, run the script [`rnw-dependencies.ps1`](https://aka.ms/rnw-vs2022-deps.ps1) in an elevated PowerShell window.
 
 **Run this command:**
 Start an **elevated** PowerShell window and run:
 
 ```powershell
 Set-ExecutionPolicy Unrestricted -Scope Process -Force;
-iex (New-Object System.Net.WebClient).DownloadString('https://aka.ms/rnw-deps.ps1')
+iex (New-Object System.Net.WebClient).DownloadString('https://aka.ms/rnw-vs2022-deps.ps1')
 ```
 
 <details>
@@ -30,7 +30,7 @@ iex (New-Object System.Net.WebClient).DownloadString('https://aka.ms/rnw-deps.ps
 Alternatively, you can setup your environment manually:
 - Ensure Developer Mode is turned ON in Windows Settings App.
 - It is _highly_ recommended to update the Windows system.
-- Install a recent version of [Visual Studio 2019](https://www.visualstudio.com/downloads) **with the following options checked**:
+- Install a recent version of [Visual Studio 2022](https://www.visualstudio.com/downloads) **with the following options checked**:
   - **Workloads**
     - Node.js development, or one of the following alternatives:
       - Install from **Individual Components**:
@@ -40,7 +40,7 @@ Alternatively, you can setup your environment manually:
     - .NET Desktop development
     - Desktop development with C++
     - Universal Windows Platform development
-      - Include `C++ (v142) Universal Windows Platform tools` (under 'Optional')
+      - Include `C++ (v143) Universal Windows Platform tools` (under 'Optional')
       - Older Windows 10 SDK version may be needed at this point.
 - Ensure that long path support is enabled.
 

--- a/website/versioned_docs/version-0.62/rnw-dependencies.md
+++ b/website/versioned_docs/version-0.62/rnw-dependencies.md
@@ -10,10 +10,10 @@ You can run React-Native for Windows apps only on Windows 10 devices with Window
 To develop React-Native for Windows apps, you need to install several dependencies.
 
 ### Script to check and install all dependencies
-To check or install dependencies, run the script [rnw-dependencies.ps1](https://github.com/microsoft/react-native-windows/blob/main/vnext/Scripts/rnw-dependencies.ps1) in an elevated PowerShell window.
+To check or install dependencies, run the script [rnw-dependencies.ps1](https://aka.ms/rnw-vs2019-deps.ps1) in an elevated PowerShell window.
 
 **Run this command:**
-`Start-Process -Verb RunAs powershell -ArgumentList @("-command", "iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/microsoft/react-native-windows/master/vnext/Scripts/rnw-dependencies.ps1'))")`
+`Start-Process -Verb RunAs powershell -ArgumentList @("-command", "iex ((New-Object System.Net.WebClient).DownloadString('https://aka.ms/rnw-vs2019-deps.ps1'))")`
 
 ### Manual setup
 Alternatively, you can setup your environment manually:

--- a/website/versioned_docs/version-0.63/rnw-dependencies.md
+++ b/website/versioned_docs/version-0.63/rnw-dependencies.md
@@ -9,14 +9,14 @@ You can run React-Native for Windows apps only on Windows 10 devices with Window
 To develop React-Native for Windows apps, you need to install several dependencies.
 
 ## Install the development dependencies
-To check or install dependencies, run the script [`rnw-dependencies.ps1`](https://github.com/microsoft/react-native-windows/blob/main/vnext/Scripts/rnw-dependencies.ps1) in an elevated PowerShell window.
+To check or install dependencies, run the script [`rnw-dependencies.ps1`](https://aka.ms/rnw-vs2019-deps.ps1) in an elevated PowerShell window.
 
 **Run this command:**
 Start an **elevated** PowerShell window and run:
 <html>
 <body>
   <div>
-    <div style="padding: 10px; font-family: monospace; font-size: 9pt; display: inline-block; width: 90%; background: #dddddd; border-radius: 6px;" id="rnwdepCmd">Set-ExecutionPolicy Unrestricted -Scope Process -Force; iex (New-Object System.Net.WebClient).DownloadString('<font color="#2020cc">https://raw.githubusercontent.com/microsoft/react-native-windows/master/vnext/Scripts/rnw-dependencies.ps1</font>')</div>
+    <div style="padding: 10px; font-family: monospace; font-size: 9pt; display: inline-block; width: 90%; background: #dddddd; border-radius: 6px;" id="rnwdepCmd">Set-ExecutionPolicy Unrestricted -Scope Process -Force; iex (New-Object System.Net.WebClient).DownloadString('<font color="#2020cc">https://aka.ms/rnw-vs2019-deps.ps1</font>')</div>
     <inline style="font-size: 24pt; cursor: pointer" onClick="javascript:navigator.clipboard.writeText(document.getElementById('rnwdepCmd').innerText)">📋</inline>
   </div>
 </body>

--- a/website/versioned_docs/version-0.64/rnw-dependencies.md
+++ b/website/versioned_docs/version-0.64/rnw-dependencies.md
@@ -9,14 +9,14 @@ You can run React-Native for Windows apps only on Windows 10 devices with Window
 To develop React-Native for Windows apps, you need to install several dependencies.
 
 ## Install the development dependencies
-To check or install dependencies, run the script [`rnw-dependencies.ps1`](https://aka.ms/rnw-deps.ps1) in an elevated PowerShell window.
+To check or install dependencies, run the script [`rnw-dependencies.ps1`](https://aka.ms/rnw-vs2019-deps.ps1) in an elevated PowerShell window.
 
 **Run this command:**
 Start an **elevated** PowerShell window and run:
 
 ```powershell
 Set-ExecutionPolicy Unrestricted -Scope Process -Force;
-iex (New-Object System.Net.WebClient).DownloadString('https://aka.ms/rnw-deps.ps1')
+iex (New-Object System.Net.WebClient).DownloadString('https://aka.ms/rnw-vs2019-deps.ps1')
 ```
 
 <details>

--- a/website/versioned_docs/version-0.65/rnw-dependencies.md
+++ b/website/versioned_docs/version-0.65/rnw-dependencies.md
@@ -13,14 +13,14 @@ You can run React Native for Windows apps only on:
 To develop React-Native for Windows apps, you need to install several dependencies.
 
 ## Install the development dependencies
-To check or install dependencies, run the script [`rnw-dependencies.ps1`](https://aka.ms/rnw-deps.ps1) in an elevated PowerShell window.
+To check or install dependencies, run the script [`rnw-dependencies.ps1`](https://aka.ms/rnw-vs2019-deps.ps1) in an elevated PowerShell window.
 
 **Run this command:**
 Start an **elevated** PowerShell window and run:
 
 ```powershell
 Set-ExecutionPolicy Unrestricted -Scope Process -Force;
-iex (New-Object System.Net.WebClient).DownloadString('https://aka.ms/rnw-deps.ps1')
+iex (New-Object System.Net.WebClient).DownloadString('https://aka.ms/rnw-vs2019-deps.ps1')
 ```
 
 <details>

--- a/website/versioned_docs/version-0.66/rnw-dependencies.md
+++ b/website/versioned_docs/version-0.66/rnw-dependencies.md
@@ -13,14 +13,14 @@ You can run React Native for Windows apps only on:
 To develop React-Native for Windows apps, you need to install several dependencies.
 
 ## Install the development dependencies
-To check or install dependencies, run the script [`rnw-dependencies.ps1`](https://aka.ms/rnw-deps.ps1) in an elevated PowerShell window.
+To check or install dependencies, run the script [`rnw-dependencies.ps1`](https://aka.ms/rnw-vs2019-deps.ps1) in an elevated PowerShell window.
 
 **Run this command:**
 Start an **elevated** PowerShell window and run:
 
 ```powershell
 Set-ExecutionPolicy Unrestricted -Scope Process -Force;
-iex (New-Object System.Net.WebClient).DownloadString('https://aka.ms/rnw-deps.ps1')
+iex (New-Object System.Net.WebClient).DownloadString('https://aka.ms/rnw-vs2019-deps.ps1')
 ```
 
 <details>


### PR DESCRIPTION
## Description

RNW 0.71 and later will require VS 2022, so the dependency script has changed.

Related https://github.com/microsoft/react-native-windows/pull/9916

### Why

We shouldn't tell people to download the latest script if they're still trying to target RNW <= 0.70.

Closes #736 

## Screenshots
N/A

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/737)