### PR TITLE
Updated stale reference from 0.64 to 0.68

### DIFF
--- a/docs/rnm-getting-started.md
+++ b/docs/rnm-getting-started.md
@@ -5,8 +5,8 @@ title: Get Started with macOS
 
 This guide will help you get started on setting up your very first React Native for macOS app.
 
->** Latest stable version available for React Native for macOS is 0.64**
-Please visit the [0.64 version of the Getting Started guide](https://microsoft.github.io/react-native-windows/docs/0.64/rnm-getting-started) to build React Native for macOS apps.
+>** Latest stable version available for React Native for macOS is 0.68**
+Please visit the [0.68 version of the Getting Started guide](https://microsoft.github.io/react-native-windows/docs/0.68/rnm-getting-started) to build React Native for macOS apps.
 
 For information around how to set up:
 - React Native for iOS and Android: See [React Native Getting Started Guide](https://reactnative.dev/docs/getting-started)


### PR DESCRIPTION
## Updated stale reference from 0.64 to 0.68

### Why
The doc was stale and pointing visitors to the old stable page

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/778)