### PR TITLE
Support zsh when creating a react-native application

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ For information around how to set up React Native, see the [React Native Getting
 Remember to call `react-native init` from the place you want your project directory to live.
 
 ```bat
-npx react-native init <projectName> --template react-native@^0.71.0
+npx react-native init <projectName> --template "react-native@^0.71.0"
 ```
 
 > To create TypeScript template, run `npx react-native init <projectName> --template react-native-template-typescript`.<br><br>


### PR DESCRIPTION

## Description

If you paste the example into zsh without quoting the version you get:
```
npx react-native init foobar --template react-native@^0.71.0
zsh: no matches found: react-native@^0.71.0
```

### Why

You support more shells from the docs.

## Screenshots
<img width="520" alt="CleanShot 2023-02-17 at 10 13 01@2x" src="https://user-images.githubusercontent.com/49578/219616707-32c12043-0d18-43eb-a9ea-b6da44566108.png">


 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/780)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/780)