### PR TITLE
Backport JavaScript Debugging Docs to 0.67

### DIFF
--- a/website/versioned_docs/version-0.67/debugging-javascript.md
+++ b/website/versioned_docs/version-0.67/debugging-javascript.md
@@ -1,5 +1,5 @@
 ---
-id: version-0.71-debugging-javascript
+id: version-0.67-debugging-javascript
 title: JavaScript Debugging
 original_id: debugging-javascript
 ---

--- a/website/versioned_sidebars/version-0.67-sidebars.json
+++ b/website/versioned_sidebars/version-0.67-sidebars.json
@@ -37,6 +37,7 @@
       "version-0.67-rnm-dependencies"
     ],
     "Troubleshooting": [
+      "version-0.67-debugging-javascript",
       "version-0.67-native-modules-troubleshooting",
       "version-0.67-metro-config-out-tree-platforms"
     ],

--- a/website/versioned_sidebars/version-0.68-sidebars.json
+++ b/website/versioned_sidebars/version-0.68-sidebars.json
@@ -38,6 +38,7 @@
       "version-0.68-rnm-dependencies"
     ],
     "Troubleshooting": [
+      "version-0.68-debugging-javascript",
       "version-0.68-native-modules-troubleshooting",
       "version-0.68-metro-config-out-tree-platforms"
     ],

--- a/website/versioned_sidebars/version-0.70-sidebars.json
+++ b/website/versioned_sidebars/version-0.70-sidebars.json
@@ -38,6 +38,7 @@
       "version-0.70-rnm-dependencies"
     ],
     "Troubleshooting": [
+      "version-0.70-debugging-javascript",
       "version-0.70-native-modules-troubleshooting",
       "version-0.70-metro-config-out-tree-platforms"
     ],


### PR DESCRIPTION
I've confirmed that the instructions for JavaScript Debugging that I wrote for RNW 0.71 actually all work as-is for RNW 0.67.

So this PR backports that doc so it's available in RNW >= 0.67.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/783)