### PR TITLE
Outdated typescript instructions

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,8 +17,6 @@ Remember to call `react-native init` from the place you want your project direct
 npx react-native init <projectName> --template react-native@^0.71.0
 ```
 
-> To create TypeScript template, run `npx react-native init <projectName> --template react-native-template-typescript`.<br><br>
-
 ### Navigate into this newly created directory
 
 Once your project has been initialized, React Native will have created a new sub directory where all your generated files live.

--- a/website/versioned_docs/version-0.71/getting-started.md
+++ b/website/versioned_docs/version-0.71/getting-started.md
@@ -18,8 +18,6 @@ Remember to call `react-native init` from the place you want your project direct
 npx react-native init <projectName> --template react-native@^0.71.0
 ```
 
-> To create TypeScript template, run `npx react-native init <projectName> --template react-native-template-typescript`.<br><br>
-
 ### Navigate into this newly created directory
 
 Once your project has been initialized, React Native will have created a new sub directory where all your generated files live.


### PR DESCRIPTION
Remove reference to `react-native-template-typescript` template which has been deprecated since React Native added first-class support for Typescript in version 0.71
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/796)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/796)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/796)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/796)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/796)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/796)