### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ npx react-native init <projectName> --template react-native@^0.71.0
 ```
 
 > To create TypeScript template, run `npx react-native init <projectName> --template react-native-template-typescript`.<br><br>
-> Starting from React Native v0.71 TypeScript is used by default
+> Starting from React Native version 0.71 TypeScript is used by default
 
 ### Navigate into this newly created directory
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,6 +18,7 @@ npx react-native init <projectName> --template react-native@^0.71.0
 ```
 
 > To create TypeScript template, run `npx react-native init <projectName> --template react-native-template-typescript`.<br><br>
+> Starting from React Native v0.71 TypeScript is used by default
 
 ### Navigate into this newly created directory
 


### PR DESCRIPTION
Starting from React Native v0.71 TypeScript is used by default

## Description
Adds a quick comment regarding the use of typescript by default after version 0.71

### Why
The use of the typescript templates is no longer necessary and we still recommend it in the documentation without specifying when it is needed.

## Screenshots
![image](https://user-images.githubusercontent.com/1152056/225109450-f2f951b5-3a5d-4ff7-a1c6-33531eaa51c0.png)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/798)