### PR TITLE
Update some of the TurboModule documentation

### DIFF
--- a/docs/native-modules-advanced.md
+++ b/docs/native-modules-advanced.md
@@ -196,12 +196,12 @@ import FancyMath from './NativeFancyMath';
 class NativeModuleSample extends Component {
   _onPressHandler() {
     FancyMath.add(
-      /* arg a */ FancyMath.Pi,
-      /* arg b */ FancyMath.E,
+      /* arg a */ FancyMath.getConstants().Pi,
+      /* arg b */ FancyMath.getConstants().E,
       /* callback */ function (result) {
         Alert.alert(
           'FancyMath',
-          `FancyMath says ${FancyMath.Pi} + ${FancyMath.E} = ${result}`,
+          `FancyMath says ${FancyMath.getConstants().Pi} + ${FancyMath.getConstants().E} = ${result}`,
           [{ text: 'OK' }],
           {cancelable: false});
       });
@@ -210,8 +210,8 @@ class NativeModuleSample extends Component {
   render() {
     return (
       <View>
-         <Text>FancyMath says PI = {FancyMath.Pi}</Text>
-         <Text>FancyMath says E = {FancyMath.E}</Text>
+         <Text>FancyMath says PI = {FancyMath.getConstants().Pi}</Text>
+         <Text>FancyMath says E = {FancyMath.getConstants().E}</Text>
          <Button onPress={this._onPressHandler} title="Click me!"/>
       </View>);
   }

--- a/docs/native-modules-vs-turbo-modules.md
+++ b/docs/native-modules-vs-turbo-modules.md
@@ -22,9 +22,9 @@ AddAttributedModules(packageBuilder, true);
 Alternatively if you are registering modules more manually by calling `IReactPackageBuilder.AddModule`, you can call `IReactPackageBuilder.AddTurboModule` instead.
 
 
-### Additional differences running as NativeModule vs TurboModule
+### Additional differences running as Native Module vs TurboModule
 
-After creating a spec in JS, you should see JS type errors showing that constants should be accessed using `MyModule.getConstants().myconst` instead of `MyModule.myconst`.  If you fail to update you accesses of `myconst` the field will continue to work when the module is running as a NativeModule, since NativeModules promote all the constants to fields on the module.  This behavior does not happen with TurboModules, so the myconst field will be undefined.  Calls using `getConstants().myconst` will work both for NativeModules and TurboModules.
+After creating a spec in JS, you should see JS type errors showing that constants should be accessed using `MyModule.getConstants().myconst` instead of `MyModule.myconst`.  If you fail to update you accesses of `myconst` the field will continue to work when the module is running as a Native Module, since Native Modules promote all the constants to fields on the module.  This behavior does not happen with TurboModules, so the `myconst` field will be undefined.  Calls using `getConstants().myconst` will work both for Native Modules and TurboModules.
 
 ### Web Debugging Behavior
 

--- a/docs/native-modules-vs-turbo-modules.md
+++ b/docs/native-modules-vs-turbo-modules.md
@@ -22,6 +22,10 @@ AddAttributedModules(packageBuilder, true);
 Alternatively if you are registering modules more manually by calling `IReactPackageBuilder.AddModule`, you can call `IReactPackageBuilder.AddTurboModule` instead.
 
 
+### Additional differences running as NativeModule vs TurboModule
+
+After creating a spec in JS, you should see JS type errors showing that constants should be accessed using `MyModule.getConstants().myconst` instead of `MyModule.myconst`.  If you fail to update you accesses of `myconst` the field will continue to work when the module is running as a NativeModule, since NativeModules promote all the constants to fields on the module.  This behavior does not happen with TurboModules, so the myconst field will be undefined.  Calls using `getConstants().myconst` will work both for NativeModules and TurboModules.
+
 ### Web Debugging Behavior
 
 TurboModules cannot run when using Remote Debugging / Web Debugging.  React-Native-Windows will attempt to run a TurboModule as a native module when running in that mode, but if the module is using JSI directly, that fallback may not work.

--- a/docs/native-modules.md
+++ b/docs/native-modules.md
@@ -76,10 +76,10 @@ export interface Spec extends TurboModule {
 
   getConstants: () => {
     E: number,
-    PI: number,
+    Pi: number,
   };
 
-  add(a: number, b: number): Promise<number>;
+  add: (a: number, b: number, callback: (value: number) => void) => void;
 }
 
 export default TurboModuleRegistry.get<Spec>(
@@ -152,7 +152,7 @@ You can specify a different event emitter like this: `[ReactModule(EventEmitter 
 
 > NOTE: Using the default event emitter, `RCTDeviceEventEmitter`, all native event names must be **globally unique across all native modules** (even the ones built-in to RN). However, specifying your own event emitter means you'll need to create and register that too. This process is outlined in the [Native Modules and React Native Windows (Advanced Topics)](native-modules-advanced.md) document.
 
-The `[ReactConstant]` attribute is how you can define constants. Here `FancyMath` has defined two constants: `E` and `Pi`. By default, the name exposed to JS will be the same name as the field (`E` for `E`), but you can override the name like this: `[ReactConstant("Pi")]`.
+The `[ReactConstant]` attribute is how you can define constants. Here `FancyMath` has defined two constants: `E` and `Pi`. When accessing these constants you should use `FancyMath.getConstants().E`.  If you want to use another name in JS you could override the JS name like this: `[ReactConstant("e")]`.  
 
 The `[ReactMethod]` attribute is how you define methods. In `FancyMath` we have one method, `add`, which takes two doubles and returns their sum. As before, you can optionally customize the name like this: `[ReactMethod("add")]`.
 
@@ -221,7 +221,7 @@ The `Microsoft.ReactNative.Managed.ReactPackageProvider` is a convenience that m
 | `REACT_MODULE`           | Specifies the class is a native module.                   |
 | `REACT_METHOD`           | Specifies an asynchronous method.                         |
 | `REACT_SYNC_METHOD`      | Specifies a synchronous method.                           |
-| `REACT_GET_CONSTANT`         | Specifies a method that provides a set of constants. (Preferred) |
+| `REACT_GET_CONSTANTS`    | Specifies a method that provides a set of constants. (Preferred) |
 | `REACT_CONSTANT`         | Specifies a field or property that represents a constant. |
 | `REACT_CONSTANTPROVIDER` | Specifies a method that provides a set of constants.      |
 | `REACT_EVENT`            | Specifies a field or property that represents an event.   |
@@ -260,7 +260,7 @@ namespace NativeModuleSample
     SampleLibraryCodegen::FancyMathSpec_Constants GetConstants() noexcept {
       SampleLibraryCodegen::FancyMathSpec_Constants constants;
       constants.E = M_E;
-      constants.PI = M_PI;
+      constants.Pi = M_PI;
       return constants;
     }
 
@@ -494,12 +494,12 @@ class NativeModuleSample extends Component {
   _onPressHandler() {
     // Calling FancyMath.add method
     FancyMath.add(
-      /* arg a */ FancyMath.Pi,
+      /* arg a */ FancyMath.getConstants().Pi,
       /* arg b */ FancyMath.E,
       /* callback */ function (result) {
         Alert.alert(
           'FancyMath',
-          `FancyMath says ${FancyMath.Pi} + ${FancyMath.E} = ${result}`,
+          `FancyMath says ${FancyMath.getConstants().Pi} + ${FancyMath.getConstants().E} = ${result}`,
           [{ text: 'OK' }],
           {cancelable: false});
       });
@@ -508,8 +508,8 @@ class NativeModuleSample extends Component {
   render() {
     return (
       <View>
-         <Text>FancyMath says PI = {FancyMath.Pi}</Text>
-         <Text>FancyMath says E = {FancyMath.E}</Text>
+         <Text>FancyMath says PI = {FancyMath.getConstants().Pi}</Text>
+         <Text>FancyMath says E = {FancyMath.getConstants().E}</Text>
          <Button onPress={this._onPressHandler} title="Click me!"/>
       </View>);
   }
@@ -520,7 +520,7 @@ AppRegistry.registerComponent('NativeModuleSample', () => NativeModuleSample);
 
 To access your native modules, you need to import from your spec file, in this case `NativeFancyMath`. Since our modules fires events, we're also bringing in `NativeEventEmitter`.
 
-To access our `FancyMath` constants, we can simply call `FancyMath.E` and `FancyMath.Pi`.
+To access our `FancyMath` constants, we can simply call `FancyMath.getConstants().E` and `FancyMath.getConstants().Pi`.
 
 Calls to methods are a little different due to the asynchronous nature of the JS engine. If the native method returns nothing, we can simply call the method. However, in this case `FancyMath.add()` returns a value, so in addition to the two necessary parameters we also include a callback function which will be called with the result of `FancyMath.add()`. In the example above, we can see that the callback raises an Alert dialog with the result value.
 

--- a/samples/NativeModuleSample/cppwinrt/windows/NativeModuleSample/ReactPackageProvider.cpp
+++ b/samples/NativeModuleSample/cppwinrt/windows/NativeModuleSample/ReactPackageProvider.cpp
@@ -2,13 +2,15 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
+
 #include "ReactPackageProvider.h"
-#include "FancyMath.h"
-#include "DataMarshallingExamples.h"
-#include "AsyncMethodExamples.h"
 #if __has_include("ReactPackageProvider.g.cpp")
 #include "ReactPackageProvider.g.cpp"
 #endif
+
+// NOTE: You must include the headers of your native modules here in
+// order for the AddAttributedModules call below to find them.
+#include "FancyMath.h"
 
 using namespace winrt::Microsoft::ReactNative;
 


### PR DESCRIPTION
## Description
TurboModule docs do not mention or show the need to use getConstants() to access constants.  And a couple of other minor fixes

Fixes at least some of the issues from #797 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/799)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/799)