### PR TITLE
Add CI for AppServiceDemo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,23 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+  call-buildsample-app-service-demo:
+    name: Build App Service Demo
+    needs: setupcheck
+    strategy:
+      fail-fast: false
+      matrix:
+        sampleName: ['AppServiceDemo']
+        configuration: ['Debug', 'Release']
+        platform: ['x86', 'x64', 'ARM64']
+    uses: ./.github/workflows/template-buildsample.yml
+    with:
+      vmImage: windows-2019
+      sampleName:  ${{ matrix.sampleName }}
+      configuration: ${{ matrix.configuration }}
+      extraRunWindowsArgs: --no-deploy
+      platform: ${{ matrix.platform }}
+
   call-buildsample-calculator:
     name: Build Calculator
     needs: setupcheck

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       # These outputs must be set otherwise the dependent jobs won't have access to them
+      app-service-demo: ${{ steps.filter.outputs.app-service-demo }}
       calculator: ${{ steps.filter.outputs.calculator }}
       calculator-nuget: ${{ steps.filter.outputs.calculator-nuget }}
       calculator-coreapp-nuget: ${{ steps.filter.outputs.calculator-coreapp-nuget }}
@@ -30,6 +31,9 @@ jobs:
       id: filter
       with:
         filters: |
+          app-service-demo:
+            - '.github/workflows/template-buildsample.yml'
+            - 'samples/AppServiceDemo/**'
           calculator:
             - '.github/workflows/template-buildsample.yml'
             - 'samples/Calculator/**'
@@ -49,6 +53,24 @@ jobs:
           workflows:
             - '.github/workflows/ci.yml'
             - '.github/workflows/pr.yml'
+
+  call-buildsample-app-service-demo:
+    name: Build App Service Demo
+    needs: setupcheck
+    strategy:
+      fail-fast: true
+      matrix:
+        sampleName: ['AppServiceDemo']
+        configuration: ['Debug']
+        platform: ['x86']
+    uses: ./.github/workflows/template-buildsample.yml
+    with:
+      vmImage: windows-2019
+      sampleName:  ${{ matrix.sampleName }}
+      configuration: ${{ matrix.configuration }}
+      platform: ${{ matrix.platform }}
+      extraRunWindowsArgs: --no-deploy
+      skipBuild: ${{ needs.setupcheck.outputs.workflows != 'true' && needs.setupcheck.outputs.app-service-demo != 'true' }} # Skip if files haven't changed
 
   call-buildsample-calculator:
     name: Build Calculator


### PR DESCRIPTION
## Description

This PR adds AppServiceDemo to the list of samples built by CI/PR workflows.

### Why

All active samples should have PR/CI to verify they still build. AppServiceDemo is still targeting RNW 0.67 (which is out of support) but it still builds. If/until we decide to deprecate AppServiceDemo, I'd rather we know whether or not it still builds.

## Screenshots
N/A

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/805)