### PR TITLE
Fix macOS getting started page

### DIFF
--- a/website/versioned_docs/version-0.64/rnm-getting-started.md
+++ b/website/versioned_docs/version-0.64/rnm-getting-started.md
@@ -46,7 +46,7 @@ npx react-native-macos-init
   ```
 
 - **Using Xcode**:
-  Open macos\test.xcworkspace in Xcode or run `xed -b macos`; `yarn start:macos`. Hit the Run button.
+  Open `macos\test.xcworkspace` in Xcode or run `xed -b macos`; `yarn start:macos`. Hit the Run button.
 
 A new Command Prompt window will open with the React packager as well as a `react-native-macos` app. This step may take a while during first run since it involves building the entire project and all dependencies. You can now start developing! 🎉
 

--- a/website/versioned_docs/version-0.66/rnm-getting-started.md
+++ b/website/versioned_docs/version-0.66/rnm-getting-started.md
@@ -1,5 +1,5 @@
 ---
-id: version-0.64-rnm-getting-started
+id: version-0.66-rnm-getting-started
 title: Get Started with macOS
 original_id: rnm-getting-started
 ---
@@ -46,6 +46,6 @@ npx react-native-macos-init
   ```
 
 - **Using Xcode**:
-  Open macos\test.xcworkspace in Xcode or run `xed -b macos`; `yarn start:macos`. Hit the Run button.
+  Open `macos\test.xcworkspace` in Xcode or run `xed -b macos`; `yarn start:macos`. Hit the Run button.
 
 A new Command Prompt window will open with the React packager as well as a `react-native-macos` app. This step may take a while during first run since it involves building the entire project and all dependencies. You can now start developing! 🎉

--- a/website/versioned_docs/version-0.68/rnm-getting-started.md
+++ b/website/versioned_docs/version-0.68/rnm-getting-started.md
@@ -1,22 +1,23 @@
 ---
-id: rnm-getting-started
+id: version-0.68-rnm-getting-started
 title: Get Started with macOS
+original_id: rnm-getting-started
 ---
 
 This guide will help you get started on setting up your very first React Native for macOS app.
-
->** Latest stable version available for React Native for macOS is 0.71**
 
 For information around how to set up:
 - React Native for iOS and Android: See [React Native Getting Started Guide](https://reactnative.dev/docs/getting-started)
 - React Native for Windows: See [React Native for Windows Getting Started Guide](https://microsoft.github.io/react-native-windows/docs/getting-started)
 
+Make sure you have installed all the [development dependencies](https://microsoft.github.io/react-native-windows/docs/rnm-dependencies)
+
 ## Install React Native for macOS
 
-Remember to call `react-native init` from the place you want your project directory to live. Be sure to use the same minor version between React Native and React Native macOS. We'll use `^0.71.0`
+Remember to call `react-native init` from the place you want your project directory to live.
 
 ```
-npx react-native init <projectName> --template react-native@^0.71.0
+npx react-native init <projectName> --template react-native@^0.68.0
 ```
 
 ### Navigate into this newly created directory
@@ -45,6 +46,6 @@ npx react-native-macos-init
   ```
 
 - **Using Xcode**:
-  Open `macos\test.xcworkspace` in Xcode or run `xed -b macos`; `yarn start`. Hit the Run button.
+  Open `macos\test.xcworkspace` in Xcode or run `xed -b macos`; `yarn start:macos`. Hit the Run button.
 
 A new Command Prompt window will open with the React packager as well as a `react-native-macos` app. This step may take a while during first run since it involves building the entire project and all dependencies. You can now start developing! 🎉

--- a/website/versioned_docs/version-0.71/rnm-getting-started.md
+++ b/website/versioned_docs/version-0.71/rnm-getting-started.md
@@ -1,6 +1,7 @@
 ---
-id: rnm-getting-started
+id: version-0.71-rnm-getting-started
 title: Get Started with macOS
+original_id: rnm-getting-started
 ---
 
 This guide will help you get started on setting up your very first React Native for macOS app.


### PR DESCRIPTION
PR #828 was merged without fixing spelling mistakes, which causes CI to fail. This PR fixes the spelling mistakes and also puts the correct versioned pages into place so they appear on the website.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/829)