### PR TITLE
Fix version command in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report-documentation.yaml
@@ -1,6 +1,5 @@
 name: Bug report for the documentation
 description: File a bug report for the documentation website
-title: Describe the problem
 labels: [bug, documentation]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug-report-sample.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report-sample.yaml
@@ -71,6 +71,9 @@ body:
         - "10.0.15063"
         - "10.0.16299"
         - "10.0.19041"
+        - "10.0.20348"
+        - "10.0.22000"
+        - "10.0.22621"
   - type: dropdown
     attributes:
       label: Target Device(s)
@@ -85,8 +88,8 @@ body:
       label: Visual Studio Version
       description: Which version of Visual Studio are you using?
       options:
-        - "Visual Studio 2017"
         - "Visual Studio 2019"
+        - "Visual Studio 2022"
   - type: dropdown
     attributes:
       label: Build Configuration

--- a/.github/ISSUE_TEMPLATE/bug-report-sample.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report-sample.yaml
@@ -1,6 +1,5 @@
 name: Bug report for a sample
 description: File a bug report for one of the samples
-title: Describe the problem
 labels: [bug, samples]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug-report-sample.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report-sample.yaml
@@ -52,8 +52,8 @@ body:
     attributes:
       label: CLI version
       description: |
-        Run the command `npx react-native --version` in your terminal and copy the results here
-      value: "npx react-native --version"
+        Run the command `npx react-native -v` in your terminal and copy the results here
+      value: "npx react-native -v"
   - type: textarea
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/request-documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/request-documentation.yaml
@@ -1,6 +1,5 @@
 name: Documentation request
 description: Suggest an area of the documentation that seems missing or could be expanded
-title: Your documentation request
 labels: [enhancement, documentation]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/request-sample.yaml
+++ b/.github/ISSUE_TEMPLATE/request-sample.yaml
@@ -1,6 +1,5 @@
 name: Sample request
 description: Suggest a code sample that would enhance this 
-title: Your sample request
 labels: [enhancement, samples]
 body:
   - type: markdown


### PR DESCRIPTION
## Description
- Updates the version command in the issue template
- Adds more current SDK versions
- Update VS versions
- Removes the default title from the template (which forces people to fill it in)

### Why
Command in the form was wrong. Requires same fix as [this](https://github.com/microsoft/react-native-windows/commit/dfef19308f953f9971d08457bfc645ce2cc6f587).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/833)