### PR TITLE
Update support.js with 0.72 preview, older versions

### DIFF
--- a/website/pages/en/support.js
+++ b/website/pages/en/support.js
@@ -4,6 +4,8 @@ const CompLibrary = require("../../core/CompLibrary.js");
 
 const MarkdownBlock = CompLibrary.MarkdownBlock; /* Used to read markdown */
 
+// We don't want the table to grow indefinitely, but keep the last 5 stable (non-main) versions visible in the support table below.
+
 const SupportPolicyMD = `
 # Support Policy
 
@@ -14,8 +16,11 @@ The React Native for Windows (RNW) Team strives to provide full support for the 
 | Version | Support Phase | Release Date | Active Support Start | Maintenance Support Start | End of Support |
 | -- | -- | -- | -- | -- | -- |
 | [main](https://www.npmjs.com/package/react-native-windows/v/canary) | [Canary](#canary-support) | *N/A* | *N/A* | *N/A* | *N/A* |
+| [0.72](https://www.npmjs.com/package/react-native-windows/v/preview) | [Preview](#preview-support) | *TBD* | *TBD* | *TBD* | *TBD* |
 | [0.71](https://www.npmjs.com/package/react-native-windows/v/latest) | [Active](#active-support) | 01/23/2023 | 01/23/2023 | *TBD* | *TBD* |
-| [0.70](https://www.npmjs.com/package/react-native-windows/v/v0.70-stable) | [Maintenance](#maintenance-support) | 09/12/2022 | 09/12/2022 | 02/28/2023 | 04/30/2023 |
+| [0.70](https://www.npmjs.com/package/react-native-windows/v/v0.70-stable) | [Unsupported](#unsupported) | 09/12/2022 | 09/12/2022 | 02/28/2023 | 04/30/2023 |
+| [0.69](https://www.npmjs.com/package/react-native-windows/v/v0.69-stable) | [Unsupported](#unsupported) | 06/27/2022 | 06/27/2022 | 10/31/2022 | 12/31/2022 |
+| [0.68](https://www.npmjs.com/package/react-native-windows/v/v0.68-stable) | [Unsupported](#unsupported) | 04/04/2022 | 04/04/2022 | 07/31/2022 | 09/30/2022 |
 
 <div class="footnote">
 


### PR DESCRIPTION
## Description

0.72 preview is out so we should have that row in the support table.

Also, it's probably a good idea to keep older **Unsupported** versions in the table for a little while, at least so customers can see *when* that version went out of support.

### Why

With 0.70 moving out of Maintenance, we end up with only 1 supported release: 0.71. But it doesn't capture the history if we constantly remove the unsupported versions from the matrix entirely.

## Screenshots
N/A

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/834)