### PR TITLE
docs: use latest react-native cli

### DIFF
--- a/docs/rnm-getting-started.md
+++ b/docs/rnm-getting-started.md
@@ -16,7 +16,7 @@ For information around how to set up:
 Remember to call `react-native init` from the place you want your project directory to live. Be sure to use the same minor version between React Native and React Native macOS. We'll use `^0.71.0`
 
 ```
-npx react-native init <projectName> --template react-native@^0.71.0
+npx react-native@latest init <projectName> --template "react-native@^0.71.0"
 ```
 
 ### Navigate into this newly created directory


### PR DESCRIPTION
## Description

Hello,

Goal of this PR is to use latest version of CLI when initializing the project same as in React Native docs. Also without the `"` I was getting an error in my console: `zsh: no matches found: react-native@^0.71.0` 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/837)