### PR TITLE
Fix deprecated WinUI3 link

### DIFF
--- a/docs/winui3.md
+++ b/docs/winui3.md
@@ -5,7 +5,7 @@ title: WinUI 3
 
 # WinUI 3 Support in RNW
 
-[WinUI](https://microsoft.github.io/microsoft-ui-xaml/) is the modern native UI platform of Windows. For more information about **WinUI 3** see [this link](https://docs.microsoft.com/en-us/windows/apps/winui/winui3/). 
+[WinUI](http://aka.ms/winui) is the modern native UI platform of Windows. For more information about **WinUI 3** see [this link](https://docs.microsoft.com/en-us/windows/apps/winui/winui3/). 
 
 We are working on adding **WinUI 3** support for RNW and have made some good progress towards an alpha.
 

--- a/website/versioned_docs/version-0.62/winui3.md
+++ b/website/versioned_docs/version-0.62/winui3.md
@@ -6,7 +6,7 @@ original_id: winui3
 
 # WinUI 3 Support in RNW
 
-[WinUI](https://microsoft.github.io/microsoft-ui-xaml/) is the modern native UI platform of Windows. As of this writing, **WinUI 3** has published [Preview 1](https://docs.microsoft.com/en-us/windows/apps/winui/winui3/). 
+[WinUI](http://aka.ms/winui/) is the modern native UI platform of Windows. As of this writing, **WinUI 3** has published [Preview 1](https://docs.microsoft.com/en-us/windows/apps/winui/winui3/). 
 
 We are working on adding **WinUI 3** support for RNW and have made some good progress towards an alpha.
 

--- a/website/versioned_docs/version-0.63/winui3.md
+++ b/website/versioned_docs/version-0.63/winui3.md
@@ -6,7 +6,7 @@ original_id: winui3
 
 # WinUI 3 Support in RNW
 
-[WinUI](https://microsoft.github.io/microsoft-ui-xaml/) is the modern native UI platform of Windows. As of this writing, **WinUI 3** has published [Preview 2](https://docs.microsoft.com/en-us/windows/apps/winui/winui3/). 
+[WinUI](http://aka.ms/winui/) is the modern native UI platform of Windows. As of this writing, **WinUI 3** has published [Preview 2](https://docs.microsoft.com/en-us/windows/apps/winui/winui3/). 
 
 We are working on adding **WinUI 3** support for RNW and have made some good progress towards an alpha.
 

--- a/website/versioned_docs/version-0.64/winui3.md
+++ b/website/versioned_docs/version-0.64/winui3.md
@@ -6,7 +6,7 @@ original_id: winui3
 
 # WinUI 3 Support in RNW
 
-[WinUI](https://microsoft.github.io/microsoft-ui-xaml/) is the modern native UI platform of Windows. For more information about **WinUI 3** see [this link](https://docs.microsoft.com/en-us/windows/apps/winui/winui3/). 
+[WinUI](http://aka.ms/winui/) is the modern native UI platform of Windows. For more information about **WinUI 3** see [this link](https://docs.microsoft.com/en-us/windows/apps/winui/winui3/). 
 
 We are working on adding **WinUI 3** support for RNW and have made some good progress towards an alpha.
 

--- a/website/versioned_docs/version-0.67/winui3.md
+++ b/website/versioned_docs/version-0.67/winui3.md
@@ -6,7 +6,7 @@ original_id: winui3
 
 # WinUI 3 Support in RNW
 
-[WinUI](https://microsoft.github.io/microsoft-ui-xaml/) is the modern native UI platform of Windows. For more information about **WinUI 3** see [this link](https://docs.microsoft.com/en-us/windows/apps/winui/winui3/). 
+[WinUI](http://aka.ms/winui/) is the modern native UI platform of Windows. For more information about **WinUI 3** see [this link](https://docs.microsoft.com/en-us/windows/apps/winui/winui3/). 
 
 We are working on adding **WinUI 3** support for RNW and have made some good progress towards an alpha.
 


### PR DESCRIPTION
As per this [PR](https://github.com/microsoft/microsoft-ui-xaml/pull/8570), the location of the WinUI3 docs have moved.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/841&drop=dogfoodAlpha