### PR TITLE
Fix version of RN init in Getting Started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,8 +13,16 @@ For information around how to set up React Native, see the [React Native Getting
 
 Remember to call `react-native init` from the place you want your project directory to live.
 
+<!-- Note, make sure "version" is pointing to the correct react-native NPM tag in the command below. -->
+
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use "nightly" -->
+<!-- 2. For the latest stable version in versioned_docs use "latest" -->
+<!-- 3. For older stable versions use the stable tag name, i.e. "0.72-stable" -->
+
+<!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
+
 ```bat
-npx react-native init <projectName> --template "react-native@^0.71.0"
+npx react-native init <projectName> --version "nightly"
 ```
 
 ### Navigate into this newly created directory

--- a/website/.unbroken_exclusions
+++ b/website/.unbroken_exclusions
@@ -26,6 +26,7 @@ File not found native-api/ReactNativeHost-api-windows.md while parsing versioned
 #fix-unbroken.js auto-generated do not edit this line or below
 File not found IReactPackageProvider-api-windows.md while parsing versioned_docs/version-0.72/coreapp.md
 File not found ReactInstanceSettings-api-windows.md while parsing versioned_docs/version-0.72/coreapp.md
+File not found getting-started.md while parsing versioned_docs/version-0.72/getting-started.md
 File not found native-modules.md while parsing versioned_docs/version-0.72/getting-started.md
 File not found rnw-dependencies.md while parsing versioned_docs/version-0.72/getting-started.md
 File not found run-windows-cli.md while parsing versioned_docs/version-0.72/getting-started.md

--- a/website/versioned_docs/version-0.72/getting-started.md
+++ b/website/versioned_docs/version-0.72/getting-started.md
@@ -14,8 +14,16 @@ For information around how to set up React Native, see the [React Native Getting
 
 Remember to call `react-native init` from the place you want your project directory to live.
 
+<!-- Note, make sure "version" is pointing to the correct react-native NPM tag in the command below. -->
+
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use "nightly" -->
+<!-- 2. For the latest stable version in versioned_docs use "latest" -->
+<!-- 3. For older stable versions use the stable tag name, i.e. "0.72-stable" -->
+
+<!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
+
 ```bat
-npx react-native init <projectName> --template "react-native@^0.72.0"
+npx react-native init <projectName> --version "latest"
 ```
 
 ### Navigate into this newly created directory


### PR DESCRIPTION
The template for react-native@0.72.0 is broken if you're using the recommended Node 16. RNW now requires a minimum of RN 0.72.3 to operate.

This PR fixes the documentation by specifying the NPM tags rather than static version numbers in our steps for creating a new project. IT also adds some comments to make sure the correct tag is used in the future.

Related: https://github.com/microsoft/react-native-windows/pull/11878
Related: https://github.com/microsoft/react-native-windows/issues/11909
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/871&drop=dogfoodAlpha