### PR TITLE
Move 0.71 into maintenance as per schedule

### DIFF
--- a/website/pages/en/support.js
+++ b/website/pages/en/support.js
@@ -17,7 +17,7 @@ The React Native for Windows (RNW) Team strives to provide full support for the 
 | -- | -- | -- | -- | -- | -- |
 | [main](https://www.npmjs.com/package/react-native-windows/v/canary) | [Canary](#canary-support) | *N/A* | *N/A* | *N/A* | *N/A* |
 | [0.72](https://www.npmjs.com/package/react-native-windows/v/latest) | [Active](#active-support) | 06/23/2023 | 06/23/2023 | *TBD* | *TBD* |
-| [0.71](https://www.npmjs.com/package/react-native-windows/v/v0.71-stable) | [Active](#active-support) | 01/23/2023 | 01/23/2023 | 07/31/2023 | 09/30/2023 |
+| [0.71](https://www.npmjs.com/package/react-native-windows/v/v0.71-stable) | [Maintenance](#maintenance-support) | 01/23/2023 | 01/23/2023 | 07/31/2023 | 09/30/2023 |
 | [0.70](https://www.npmjs.com/package/react-native-windows/v/v0.70-stable) | [Unsupported](#unsupported) | 09/12/2022 | 09/12/2022 | 02/28/2023 | 04/30/2023 |
 | [0.69](https://www.npmjs.com/package/react-native-windows/v/v0.69-stable) | [Unsupported](#unsupported) | 06/27/2022 | 06/27/2022 | 10/31/2022 | 12/31/2022 |
 | [0.68](https://www.npmjs.com/package/react-native-windows/v/v0.68-stable) | [Unsupported](#unsupported) | 04/04/2022 | 04/04/2022 | 07/31/2022 | 09/30/2022 |


### PR DESCRIPTION
RNW 0.71 entered maintenance support on 7/31/23.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows-samples/pull/873&drop=dogfoodAlpha