### PR TITLE
Update to specify react-native version when creating a new project

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ Remember to call `react-native init` from the place you want your project direct
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx react-native init <projectName> --version "nightly"
+npx react-native@nightly init <projectName> --version "nightly"
 ```
 
 ### Navigate into this newly created directory

--- a/docs/nuget.md
+++ b/docs/nuget.md
@@ -20,9 +20,8 @@ The other benefit will be that it will be easier to update your projects to futu
 # How to enable on new projects
 When you enable react-native-windows on your new project, you can pass `--experimentalNuGetDependency true`:
 
-1. `npx react-native init <projectName>`
-1. `pushd <projectName>`
-1. `npx react-native-windows-init --overwrite --experimentalNuGetDependency true`
+1. Follow the instructions to create a new project in [Getting Started](getting-started.md) except use:
+1. `npx react-native-windows-init --overwrite --experimentalNuGetDependency true` instead when adding windows support to your project
 
 Of course all the other flags still work.
 

--- a/website/.unbroken_exclusions
+++ b/website/.unbroken_exclusions
@@ -237,6 +237,7 @@ File not found assets/nuget-update-cpp-project.png while parsing versioned_docs/
 File not found assets/nuget-update-cs-project.png while parsing versioned_docs/version-0.63/nuget-update.md
 File not found assets/nuget-update-packages-manager-installed-tab.png while parsing versioned_docs/version-0.63/nuget-update.md
 File not found assets/nuget-update-select-package.png while parsing versioned_docs/version-0.63/nuget-update.md
+File not found getting-started.md while parsing versioned_docs/version-0.63/nuget.md
 File not found supported-community-modules.md while parsing versioned_docs/version-0.63/nuget.md
 File not found winui3.md while parsing versioned_docs/version-0.63/nuget.md
 File not found win10-compat.md while parsing versioned_docs/version-0.63/rnw-dependencies.md

--- a/website/versioned_docs/version-0.63/nuget.md
+++ b/website/versioned_docs/version-0.63/nuget.md
@@ -23,9 +23,8 @@ We are working on getting the packages on [NuGet Gallery](https://nuget.org). Un
 # How to enable on new projects
 When you enable react-native-windows on your new project, you can pass `--experimentalNuGetDependency true`:
 
-1. `npx react-native init <projectName>`
-1. `pushd <projectName>`
-1. `npx react-native-windows-init --overwrite --experimentalNuGetDependency true`
+1. Follow the instructions to create a new project in [Getting Started](getting-started.md) except use:
+1. `npx react-native-windows-init --overwrite --experimentalNuGetDependency true` instead when adding windows support to your project
 
 Of course all the other flags still work.
 

--- a/website/versioned_docs/version-0.71/getting-started.md
+++ b/website/versioned_docs/version-0.71/getting-started.md
@@ -15,7 +15,7 @@ For information around how to set up React Native, see the [React Native Getting
 Remember to call `react-native init` from the place you want your project directory to live.
 
 ```bat
-npx react-native init <projectName> --template react-native@^0.71.0
+npx react-native@0.71-stable init <projectName> --template react-native@0.71-stable
 ```
 
 ### Navigate into this newly created directory

--- a/website/versioned_docs/version-0.71/rnm-getting-started.md
+++ b/website/versioned_docs/version-0.71/rnm-getting-started.md
@@ -17,7 +17,7 @@ For information around how to set up:
 Remember to call `react-native init` from the place you want your project directory to live. Be sure to use the same minor version between React Native and React Native macOS. We'll use `^0.71.0`
 
 ```
-npx react-native init <projectName> --template react-native@^0.71.0
+npx react-native@0.71-stable init <projectName> --template react-native@0.71-stable
 ```
 
 ### Navigate into this newly created directory

--- a/website/versioned_docs/version-0.72/getting-started.md
+++ b/website/versioned_docs/version-0.72/getting-started.md
@@ -23,7 +23,7 @@ Remember to call `react-native init` from the place you want your project direct
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx react-native init <projectName> --version "latest"
+npx react-native@latest init <projectName> --version "latest"
 ```
 
 ### Navigate into this newly created directory


### PR DESCRIPTION
## Description

Docs specify using `npx react-native@latest init` instead of just `npx react-native init`.

### Why

Some developer machines may have cruft on their machines that will cause the wrong version to be used, this is also why the command warns you to to specify the version when it's mising.

Resolves https://github.com/microsoft/react-native-windows/issues/12191

## Screenshots
N/A

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/879)