### PR TITLE
chore: use `--version` instead of `--template`

### DIFF
--- a/docs/rnm-getting-started.md
+++ b/docs/rnm-getting-started.md
@@ -16,7 +16,7 @@ For information around how to set up:
 Remember to call `react-native init` from the place you want your project directory to live. Be sure to use the same minor version between React Native and React Native macOS. We'll use `^0.71.0`
 
 ```
-npx react-native@latest init <projectName> --template "react-native@^0.71.0"
+npx react-native@latest init <projectName> --version 0.71.0
 ```
 
 ### Navigate into this newly created directory


### PR DESCRIPTION
## Description

Changes `init` command to use `--version` rather than `--template`.

### Why

Simplicity.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/902)