### PR TITLE
Docs: Update rnm-getting-started.md about code signing

### DIFF
--- a/docs/rnm-getting-started.md
+++ b/docs/rnm-getting-started.md
@@ -35,6 +35,10 @@ Install the React Native for macOS packages.
 npx react-native-macos-init
 ```
 
+> [!NOTE]
+> If the above command fails on ```Invalid `Podfile` file: cannot load such file -- .../ios/node_modules/react-native-macos/scripts/react_native_pods```, then it can help to open the `.xcworkspace`-file in your `ios`-folder with Xcode and straighten out any issues found there, e.g. Signing-issues
+
+
 ## Running a React Native macOS App
 
 - **Without using Xcode**:


### PR DESCRIPTION
Took me a while to figure out, might be helpful to others

## Description

### Why
Took me a couple of days to figure out, on Mac OS Sonoma at least, how to initialize the project on a 0.71.0 template.

Without this action I could not complete pod installation in the init script.

## Screenshots
No relevant screenshots
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/907)