### PR TITLE
"System Requirements" doc: state explicitly that you have to be on Windows for development and building

### DIFF
--- a/docs/rnw-dependencies.md
+++ b/docs/rnw-dependencies.md
@@ -3,7 +3,7 @@ id: rnw-dependencies
 title: System Requirements
 ---
 
-You can run React Native for Windows apps only on:
+You can only develop React Native for Windows app on Windows. You can run React Native for Windows apps only on:
 
 - All Windows 11 devices
 - Windows 10 devices with Windows version: 10.0.16299.0 (aka 1709, aka Redstone 3, aka Fall Creators Update) or higher


### PR DESCRIPTION
### Why

Other frameworks like Electron or partially Tauri allow developing and building for Windows, so it might not be obvious for newcomers that this requirement exist. I wasn't able to find it in any doc or top google results.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/908)