### PR TITLE
Remove "nightly" from installation instructions

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ Remember to call `react-native init` from the place you want your project direct
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx react-native init <projectName>"
+npx react-native@nightly init <projectName> --version "nightly"
 ```
 
 ### Navigate into this newly created directory

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ Remember to call `react-native init` from the place you want your project direct
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx react-native@nightly init <projectName> --version "nightly"
+npx react-native init <projectName>"
 ```
 
 ### Navigate into this newly created directory

--- a/website/versioned_docs/version-0.72/getting-started.md
+++ b/website/versioned_docs/version-0.72/getting-started.md
@@ -23,7 +23,7 @@ Remember to call `react-native init` from the place you want your project direct
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx react-native@latest init <projectName> --version "latest"
+npx react-native@0.72-stable init <projectName> --version "0.72-stable"
 ```
 
 ### Navigate into this newly created directory

--- a/website/versioned_docs/version-0.73/getting-started.md
+++ b/website/versioned_docs/version-0.73/getting-started.md
@@ -23,7 +23,7 @@ Remember to call `react-native init` from the place you want your project direct
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx react-native@nightly init <projectName> --version "nightly"
+npx react-native@latest init <projectName> --version "latest"
 ```
 
 ### Navigate into this newly created directory


### PR DESCRIPTION
## Description

### Why
Installation instructions, when ran as they are now, currently produce the following error for me:

```
No compatible version of react-native-windows found.
  The latest supported version is react-native-windows@0.73.3.
  Please modify your application to use react-native@^0.73 or another supported version of react-native and try again.

NoAutoMatchingReactNativeWindows:
  No compatible version of react-native-windows found.
  The latest supported version is react-native-windows@0.73.3.
  Please modify your application to use react-native@^0.73 or another supported version of react-native and try again.
 ```

Just running the react-native "init" without pointing to a nightly version works for me. I've also reproduced the error and the solution on another system (with another OS).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/909)