### PR TITLE
[0.72] Add workaround to keep using Node 16

### DIFF
--- a/website/versioned_docs/version-0.72/getting-started.md
+++ b/website/versioned_docs/version-0.72/getting-started.md
@@ -46,6 +46,8 @@ npx react-native-windows-init --overwrite
 
 For information on the options that `react-native-windows-init` takes see [React Native Windows Init CLI](https://microsoft.github.io/react-native-windows/init-cli).
 
+> RNW 0.72 depends on Node >= 16.0, but some transitive dependencies may require newer versions of Node. If you're using using Node 16 and see dependencies errors about needing a newer version of Node, you can either upgrade your version of Node, or supress the errors with `yarn config set ignore-engines true`. See [microsoft/react-native-windows#12711](https://github.com/microsoft/react-native-windows/issues/12711).
+
 ## Running a React Native Windows App
 
 > Make sure a browser is launched and running before running a React Native Windows app.

--- a/website/versioned_docs/version-0.72/getting-started.md
+++ b/website/versioned_docs/version-0.72/getting-started.md
@@ -46,7 +46,7 @@ npx react-native-windows-init --overwrite
 
 For information on the options that `react-native-windows-init` takes see [React Native Windows Init CLI](https://microsoft.github.io/react-native-windows/init-cli).
 
-> RNW 0.72 depends on Node >= 16.0, but some transitive dependencies may require newer versions of Node. If you're using using Node 16 and see dependencies errors about needing a newer version of Node, you can either upgrade your version of Node, or suppress the errors with `yarn config set ignore-engines true`. See [microsoft/react-native-windows#12711](https://github.com/microsoft/react-native-windows/issues/12711).
+> RNW 0.72 depends on Node >= 16.0, but some transitive dependencies may require newer versions of Node. If you're using using Node 16 and see dependencies errors about needing a newer version of Node, you can either upgrade your version of Node, or suppress the errors with `yarn config set ignore-engines true`. See [RNW issue #12711](https://github.com/microsoft/react-native-windows/issues/12711).
 
 ## Running a React Native Windows App
 

--- a/website/versioned_docs/version-0.72/getting-started.md
+++ b/website/versioned_docs/version-0.72/getting-started.md
@@ -46,7 +46,7 @@ npx react-native-windows-init --overwrite
 
 For information on the options that `react-native-windows-init` takes see [React Native Windows Init CLI](https://microsoft.github.io/react-native-windows/init-cli).
 
-> RNW 0.72 depends on Node >= 16.0, but some transitive dependencies may require newer versions of Node. If you're using using Node 16 and see dependencies errors about needing a newer version of Node, you can either upgrade your version of Node, or supress the errors with `yarn config set ignore-engines true`. See [microsoft/react-native-windows#12711](https://github.com/microsoft/react-native-windows/issues/12711).
+> RNW 0.72 depends on Node >= 16.0, but some transitive dependencies may require newer versions of Node. If you're using using Node 16 and see dependencies errors about needing a newer version of Node, you can either upgrade your version of Node, or suppress the errors with `yarn config set ignore-engines true`. See [microsoft/react-native-windows#12711](https://github.com/microsoft/react-native-windows/issues/12711).
 
 ## Running a React Native Windows App
 


### PR DESCRIPTION
## Description

Some transitive dependencies require Node 18 even if we only require Node 16. Added the workaround to unlock new projects with RNW 0.72 and Node 16. See https://github.com/microsoft/react-native-windows/issues/12711

### Why
To help with new devs crating new RNW 0.72 apps.

## Screenshots
N/A

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/914)