### PR TITLE
Update getting-started.md ; need to npm install react-native 

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,12 +25,14 @@ Remember to call `react-native init` from the place you want your project direct
 npx react-native@nightly init <projectName> --version "nightly"
 ```
 
-### Navigate into this newly created directory
+### Navigate into this newly created directory and use npm to install react-native
 
 Once your project has been initialized, React Native will have created a new sub directory where all your generated files live.
+Use NPM to install react-native.
 
 ```bat
 cd projectName
+npm install react-native
 ```
 
 ### Install the Windows extension


### PR DESCRIPTION
## Description

Getting started for fresh windows installations leads to a tripping point for new users who simply start with the first npx command. (npx react-native@latest init <projectName> --version "latest")  does not install react-native 

### Why
need react-native installed otherwise the second npx command [:](![npxSecondCommandTrippingPoint](https://github.com/microsoft/react-native-windows-samples/assets/120077575/ff1f6a89-f935-4234-8663-11a2f5b59a46))
```
npx react-native-windows-init --overwrite
```
has error:
Reading project name from package.json...
Reading react-native version from node_modules...
Cannot find module 'react-native/package.json'

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/926)