### PR TITLE
Add TextInput windows-specific properties to documentation

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -38,6 +38,7 @@ i.e.
 initializer
 interop
 iOS
+KeyEvents
 ItemGroup
 lifecycle
 macOS
@@ -45,6 +46,7 @@ middleware
 monorepos
 MSBuild
 MSBuild.exe
+multiline
 namespace
 namespaces
 native-ized
@@ -73,11 +75,13 @@ roadmap
 runtime
 runtimes
 schemas
+shiftKey
 Sourcetree
 struct
 symlink
 symlinks
 tada
+TextInput
 theming
 toolchain
 TurboModule

--- a/docs/textinput-component-windows.md
+++ b/docs/textinput-component-windows.md
@@ -13,7 +13,7 @@ Inherits [TextInput Props](https://reactnative.dev/docs/textinput).
 
 ### `submitKeyEvent`
 
-A property that registers a set of KeyEvents that may trigger `OnSubmitEditing` in a multiline scenario.
+A property that registers a set of KeyEvents that may trigger `onSubmitEditing` in a multiline scenario.
 
 | type | required |
 |:--|:--|
@@ -21,7 +21,7 @@ A property that registers a set of KeyEvents that may trigger `OnSubmitEditing` 
 
 ### `clearTextOnSubmit`
 
-If true, the text field will clear when submitted. The default is false.
+If `true`, the text field will clear when submitted. The default value is false.
 
 | type | required |
 |:--|:--|

--- a/docs/textinput-component-windows.md
+++ b/docs/textinput-component-windows.md
@@ -1,0 +1,32 @@
+---
+id: textinput-component
+title: TextInput
+---
+
+# Reference
+
+## Props
+
+Inherits [TextInput Props](https://reactnative.dev/docs/textinput).
+
+## Windows-Specific Properties
+
+### `submitKeyEvent`
+
+A property that registers a set of KeyEvents that may trigger `OnSubmitEditing` in a multiline scenario.
+
+| type | required |
+|:--|:--|
+| { code: 'Enter', shiftKey: bool } | No |
+
+### `clearTextOnSubmit`
+
+If true, the text field will clear when submitted. The default is false.
+
+| type | required |
+|:--|:--|
+| bool | No |
+
+## Examples
+
+Examples can be found in the [React Native Gallery App](https://github.com/microsoft/react-native-gallery/blob/main/src/examples/TextInputExamplePage.tsx) available in the [Microsoft Store](http://aka.ms/reactnativegalleryapp)

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -53,7 +53,8 @@
     "Components (Windows)": [
       "flyout-component",
       "glyph-component",
-      "popup-component"
+      "popup-component",
+      "textinput-component"
     ],
     "JavaScript API (Windows)": [
       "apptheme-api",


### PR DESCRIPTION
## Description
Adds TextInput into components so we can document windows-specific properties.

### Why
There is currently no documentation for these properties even though they get used quite often. This adds a section to the components so it's easily discoverable. But let me know if there's a better place for these properties!

Resolves #916

## Screenshots
![image](https://github.com/microsoft/react-native-windows-samples/assets/42554868/7067c78a-e3db-480c-882e-bdcc1c28c683)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/927)