### PR TITLE
Mark remote debugging as deprecated in CLI docs

### DIFF
--- a/docs/run-windows-cli.md
+++ b/docs/run-windows-cli.md
@@ -16,6 +16,9 @@ Run this from an existing React Native for Windows app to build and deploy.
 npx react-native run-windows
 ```
 ### Options
+
+> **Note:** Remote Debugging was officially marked as deprecated in RN 0.73 and will be removed in a later release.
+
 Here are the options that `react-native run-windows` takes:
 | Option                | Input Type | Description                                      |
 |-----------------------|------------|--------------------------------------------------|
@@ -26,7 +29,7 @@ Here are the options that `react-native run-windows` takes:
 | `--emulator`          | boolean    | Deploys the app to an emulator                   |
 | `--device`            | boolean    | Deploys the app to a connected device            |
 | `--target`            | string     | Deploys the app to the specified `GUID` for a device |
-| `--remote-debugging`  | boolean    | Deploys the app in remote debugging mode.        |
+| `--remote-debugging`  | boolean    | **(Deprecated)** Deploys the app in remote debugging mode.        |
 | `--logging`           | boolean    | Enables logging                                  |
 | `--no-packager`       | boolean    | Do not launch packager while building            |
 | `--bundle`            | boolean    | Enable Bundle configuration and it would be `ReleaseBundle`/`DebugBundle` other than `Release`/`Debug` |

--- a/docs/run-windows-cli.md
+++ b/docs/run-windows-cli.md
@@ -17,7 +17,7 @@ npx react-native run-windows
 ```
 ### Options
 
-> **Note:** Remote Debugging was officially marked as deprecated in RN 0.73 and will be removed in a later release.
+> **Note:** Remote Debugging was officially marked as [deprecated](https://github.com/react-native-community/discussions-and-proposals/discussions/734) in RN 0.73 and will be removed in a later release.
 
 Here are the options that `react-native run-windows` takes:
 | Option                | Input Type | Description                                      |


### PR DESCRIPTION
## Description
Marks the remote debugging flag as deprecated in the CLI documentation.

### Why
Reflect web debugging being deprecated: https://github.com/react-native-community/discussions-and-proposals/discussions/734

Partially resolves https://github.com/microsoft/react-native-windows/issues/12928

## Screenshots

Before:
![image](https://github.com/microsoft/react-native-windows-samples/assets/157416350/48eab82e-d118-448b-af7c-cf8e367c8325)

After:
![image](https://github.com/microsoft/react-native-windows-samples/assets/157416350/3a6b2579-5f6e-42b2-bb39-c48c43a249cb)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/933)