### PR TITLE
Update CI Docs

### DIFF
--- a/docs/setup-ci.md
+++ b/docs/setup-ci.md
@@ -14,24 +14,28 @@ The VM images supported by GitHub Actions CI/CD can be found [here](https://gith
 Next you need to create a YAML file for GitHub Actions, the basic steps are:
 - Checkout code and setup the environment
 ```yaml
-    - uses: actions/checkout@v2
-      name: Checkout Code
+    name: Windows CI
+    on: [pull_request]
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '14'
+    jobs:
+      run-windows-tests:
+        name: Build & run tests
+        runs-on: windows-2022
 
-    - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
-      with:
-        vs-version: 16.8
+        steps:
+          - uses: actions/checkout@v2
+            name: Checkout Code
 
-    - name: Install node modules
-      run: yarn --frozen-lockfile
+          - name: Setup Node.js
+            uses: actions/setup-node@v1
+            with:
+              node-version: '^18'
 
-    - name: yarn build
-      run:  yarn build
+          - name: Setup MSBuild
+            uses: microsoft/setup-msbuild@v2
+
+          - name: Install node modules
+            run: yarn --frozen-lockfile
 ```
 - Build and run the project
 ```yaml

--- a/docs/setup-ci.md
+++ b/docs/setup-ci.md
@@ -42,7 +42,7 @@ Next you need to create a YAML file for GitHub Actions, the basic steps are:
     - name: Run Windows x64 release
       run: npx react-native run-windows --arch x64 --release --logging
 ```
-Check out the full [`react-native-webview` example](https://github.com/react-native-webview/react-native-webview/blob/v11.17.2/.github/workflows/windows-ci.yml) as well as their [official example](https://github.blog/2019-08-08-github-actions-now-supports-ci-cd/) for more info.
+Check out the full [`react-native-webview` example](https://github.com/react-native-webview/react-native-webview/blob/master/.github/workflows/windows-ci.yml) as well as their [official example](https://github.blog/2019-08-08-github-actions-now-supports-ci-cd/) for more info.
 
 Save the YAML file to `.github\workflows\` and then commit. To learn more about YAML syntax, see [Workflow syntax for GitHub Actions](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions).
 


### PR DESCRIPTION
## Description
Updating the CI documentation to work with a 74+ RNW application.

### Why
Tried to use our CI documentation to add CI to a 74 application and it did not work straight out the box. Updating our CI documentation to use the right dependencies.  Also added the whole file because it helped me figure out how to get CI working :)

## Screenshots
![image](https://github.com/microsoft/react-native-windows-samples/assets/42554868/9a49d279-d3f8-4b63-aa9f-9c6f079bd393)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/942)