### PR TITLE
Update getting-started to use @react-native-community/cli for new projects

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,18 +11,19 @@ For information around how to set up React Native, see the [React Native Getting
 
 ## Create a new React Native project
 
-Remember to call `react-native init` from the place you want your project directory to live.
+Remember to call `@react-native-community/cli init` from the place you want your project directory to live.
 
-<!-- Note, make sure "version" is pointing to the correct react-native NPM tag in the command below. -->
+<!-- Note, make sure both `@react-native-community/cli@ABC` and `--version "XYZ"` are pointing to the correct NPM tags in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "nightly" -->
-<!-- 2. For the latest stable version in versioned_docs use "latest" -->
-<!-- 3. For older stable versions use the stable tag name, i.e. "0.73-stable" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use "next" for the CLI and "nightly" for the RN version -->
+<!-- 2. For the latest stable version in versioned_docs use "latest" for both the CLI and RN version -->
+<!-- 3. For older stable versions you'll have to look up the CLI version, but for the RN version use the stable tag name, i.e. "0.73-stable" -->
 
+<!-- See https://www.npmjs.com/package/@react-native-community/cli?activeTab=versions for the CLI version tags. -->
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx --yes react-native@nightly init <projectName> --version "nightly"
+npx --yes @react-native-community/cli@next init <projectName> --version "nightly"
 ```
 
 ### Navigate into this newly created directory

--- a/website/versioned_docs/version-0.74/getting-started.md
+++ b/website/versioned_docs/version-0.74/getting-started.md
@@ -14,16 +14,17 @@ For information around how to set up React Native, see the [React Native Getting
 
 Remember to call `react-native init` from the place you want your project directory to live.
 
-<!-- Note, make sure "version" is pointing to the correct react-native NPM tag in the command below. -->
+<!-- Note, make sure both `@react-native-community/cli@ABC` and `--version "XYZ"` are pointing to the correct NPM tags in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "nightly" -->
-<!-- 2. For the latest stable version in versioned_docs use "latest" -->
-<!-- 3. For older stable versions use the stable tag name, i.e. "0.73-stable" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use "next" for the CLI and "nightly" for the RN version -->
+<!-- 2. For the latest stable version in versioned_docs use "latest" for both the CLI and RN version -->
+<!-- 3. For older stable versions you'll have to look up the CLI version, but for the RN version use the stable tag name, i.e. "0.73-stable" -->
 
+<!-- See https://www.npmjs.com/package/@react-native-community/cli?activeTab=versions for the CLI version tags. -->
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx --yes react-native@latest init <projectName> --version "latest"
+npx --yes @react-native-community/cli@latest init <projectName> --version "latest"
 ```
 
 ### Navigate into this newly created directory

--- a/website/versioned_docs/version-0.74/getting-started.md
+++ b/website/versioned_docs/version-0.74/getting-started.md
@@ -12,7 +12,7 @@ For information around how to set up React Native, see the [React Native Getting
 
 ## Install React Native for Windows
 
-Remember to call `react-native init` from the place you want your project directory to live.
+Remember to call `@react-native-community/cli init` from the place you want your project directory to live.
 
 <!-- Note, make sure both `@react-native-community/cli@ABC` and `--version "XYZ"` are pointing to the correct NPM tags in the command below. -->
 


### PR DESCRIPTION
## Description

Update our docs since `react-native init` is getting deprecated, and replace with `@react-native-community/cli init`.

### Why
To avoid users seeing the deprecation warning, and it not warning when the deprecation happens.

## Screenshots
N/A

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/948)