### PR TITLE
Upgrade sample readmes with new CLI commnads

### DIFF
--- a/samples/Calculator/README.md
+++ b/samples/Calculator/README.md
@@ -23,7 +23,7 @@ npm install
 Once you have all of the dependencies installed, you can run the application with the following command:
 
 ```cmd
-npx react-native run-windows
+npx @react-native-coummunity/cli@latest run-windows
 ```
 
 The command will:

--- a/samples/Calculator/README.md
+++ b/samples/Calculator/README.md
@@ -23,7 +23,7 @@ npm install
 Once you have all of the dependencies installed, you can run the application with the following command:
 
 ```cmd
-npx @react-native-coummunity/cli@latest run-windows
+npx @react-native-community/cli@latest run-windows
 ```
 
 The command will:

--- a/samples/Calculator/cppwinrt/README.md
+++ b/samples/Calculator/cppwinrt/README.md
@@ -46,7 +46,7 @@ To upgrade this sample to the latest version of RNW:
     ```
 7. Verify the new app builds and runs:
     ```
-    npx @react-native-coummunity/cli@latest run-windows
+    npx @react-native-community/cli@latest run-windows
     ```
 8. Look at windows/Calculators/Package.appxmanifast and change the publisher name to "CN=React Native Windows Sample".
 9. Update this readme with the new major version at the top.

--- a/samples/Calculator/cppwinrt/README.md
+++ b/samples/Calculator/cppwinrt/README.md
@@ -25,12 +25,13 @@ To upgrade this sample to the latest version of RNW:
     ```
 3. Create a new React Native app and change version to version you want to upgrade to:
     ```cmd
-    npx react-native init Calculator --template "react-native@^0.72.0"
+    npx @react-native-community/cli@latest init Calculator --template @react-native-community/template@latest
     ```
 4. Add Windows support:
     ```cmd
     cd Calculator
-    npx react-native-windows-init --version latest --overwrite
+    yarn add react-native-windows@latest
+    npx @react-native-community/cli@latest init-windows --template old/uwp-cpp-app --overwrite
     ```
 5. Rename the folder to cppwinrt
     ```
@@ -45,7 +46,7 @@ To upgrade this sample to the latest version of RNW:
     ```
 7. Verify the new app builds and runs:
     ```
-    npx react-native run-windows
+    npx @react-native-coummunity/cli@latest run-windows
     ```
 8. Look at windows/Calculators/Package.appxmanifast and change the publisher name to "CN=React Native Windows Sample".
 9. Update this readme with the new major version at the top.

--- a/samples/Calculator/csharp/README.md
+++ b/samples/Calculator/csharp/README.md
@@ -46,7 +46,7 @@ To upgrade this sample to the latest version of RNW:
     ```
 7. Verify the new app builds and runs:
     ```
-    npx @react-native-coummunity/cli@latest run-windows
+    npx @react-native-community/cli@latest run-windows
     ```
 8. Look at windows/Calculator/Package.appxmanifast and change the publisher name to "CN=React Native Windows Sample".
 9. Update this readme with the new major version at the top.

--- a/samples/Calculator/csharp/README.md
+++ b/samples/Calculator/csharp/README.md
@@ -25,12 +25,13 @@ To upgrade this sample to the latest version of RNW:
     ```
 3. Create a new React Native app and change version to version you want to upgrade to:
     ```cmd
-    npx react-native init Calculator --template "react-native@^0.72.0"
+    npx @react-native-community/cli@latest init Calculator --template @react-native-community/template@latest
     ```
 4. Add Windows support:
     ```cmd
     cd Calculator
-    npx react-native-windows-init --version latest --overwrite --language cs
+    yarn add react-native-windows@latest
+    npx @react-native-community/cli@latest init-windows --template old/uwp-cs-app --overwrite
     ```
 5. Rename the folder to csharp
     ```
@@ -45,7 +46,7 @@ To upgrade this sample to the latest version of RNW:
     ```
 7. Verify the new app builds and runs:
     ```
-    npx react-native run-windows
+    npx @react-native-coummunity/cli@latest run-windows
     ```
 8. Look at windows/Calculator/Package.appxmanifast and change the publisher name to "CN=React Native Windows Sample".
 9. Update this readme with the new major version at the top.

--- a/samples/NativeModuleSample/README.md
+++ b/samples/NativeModuleSample/README.md
@@ -32,7 +32,7 @@ npm install
 Once you have all of the dependencies installed, you can build either module with following command (again, run within either the `cppwinrt` or `csharp` folder):
 
 ```cmd
-npx react-native run-windows --no-deploy --no-launch --no-packager --no-autolink --proj "NativeModuleSample\NativeModuleSample.vsproj"
+npx @react-native-coummunity/cli@latest run-windows --no-deploy --no-launch --no-packager --no-autolink --proj "NativeModuleSample\NativeModuleSample.vsproj"
 ```
 
 ### Upgrade

--- a/samples/NativeModuleSample/README.md
+++ b/samples/NativeModuleSample/README.md
@@ -32,7 +32,8 @@ npm install
 Once you have all of the dependencies installed, you can build either module with following command (again, run within either the `cppwinrt` or `csharp` folder):
 
 ```cmd
-npx @react-native-coummunity/cli@latest run-windows --no-deploy --no-launch --no-packager --no-autolink --proj "NativeModuleSample\NativeModuleSample.vsproj"
+npx @react-native-community/cli@latest run-windows --no-deploy --no-launch --no-packager --no-autolink --proj "NativeModuleSample\NativeModuleSample.vsproj"
+
 ```
 
 ### Upgrade

--- a/samples/NativeModuleSample/cppwinrt/README.md
+++ b/samples/NativeModuleSample/cppwinrt/README.md
@@ -124,6 +124,7 @@ To upgrade this sample to the latest version of RNW:
             ```
 8. Verify the updated sample builds:
     ```cmd
-    npx @react-native-coummunity/cli@latest run-windows --no-deploy --no-launch --no-packager --no-autolink --proj "NativeModuleSample\NativeModuleSample.vcxproj"
+    npx @react-native-community/cli@latest run-windows --no-deploy --no-launch --no-packager --no-autolink --proj "NativeModuleSample\NativeModuleSample.vcxproj"
+
     ```
 9. Update the main readme with the new major version at the top.

--- a/samples/NativeModuleSample/cppwinrt/README.md
+++ b/samples/NativeModuleSample/cppwinrt/README.md
@@ -41,10 +41,13 @@ To upgrade this sample to the latest version of RNW:
         4. Upgrade `react-native` to that version:
             ```cmd
             yarn upgrade react-native@VERSIONFROMLASTSTEP
+        5. Upgrade `react-native-windows` to the latest version:
+            ```cmd
+            yarn upgrade react-native-windows@latest
             ```
 4. Re-run the RNW CLI:
     ```cmd
-    npx react-native-windows-init --version latest --language cpp --projectType lib --overwrite
+    npx @react-native-community/cli@latest init-windows --template old/uwp-cpp-lib --overwrite
     ```
 5. Restore these original native header files (representing the native module samples):
     ```
@@ -121,6 +124,6 @@ To upgrade this sample to the latest version of RNW:
             ```
 8. Verify the updated sample builds:
     ```cmd
-    npx react-native run-windows --no-deploy --no-launch --no-packager --no-autolink --proj "NativeModuleSample\NativeModuleSample.vcxproj"
+    npx @react-native-coummunity/cli@latest run-windows --no-deploy --no-launch --no-packager --no-autolink --proj "NativeModuleSample\NativeModuleSample.vcxproj"
     ```
 9. Update the main readme with the new major version at the top.

--- a/samples/NativeModuleSample/csharp/README.md
+++ b/samples/NativeModuleSample/csharp/README.md
@@ -84,6 +84,7 @@ To upgrade this sample to the latest version of RNW:
             ```
 8. Verify the updated sample builds:
     ```cmd
-    npx @react-native-coummunity/cli@latest run-windows --no-deploy --no-launch --no-packager --no-autolink --proj "NativeModuleSample\NativeModuleSample.csproj"
+    npx @react-native-community/cli@latest run-windows --no-deploy --no-launch --no-packager --no-autolink --proj "NativeModuleSample\NativeModuleSample.csproj"
+
     ```
 9. Update the main readme with the new major version at the top.

--- a/samples/NativeModuleSample/csharp/README.md
+++ b/samples/NativeModuleSample/csharp/README.md
@@ -42,9 +42,13 @@ To upgrade this sample to the latest version of RNW:
             ```cmd
             yarn upgrade react-native@VERSIONFROMLASTSTEP
             ```
+        5. Upgrade `react-native-windows` to the latest version:
+            ```cmd
+            yarn upgrade react-native-windows@latest
+            ```
 4. Re-run the RNW CLI:
     ```cmd
-    npx react-native-windows-init --version latest --language cs --projectType lib --overwrite
+    npx @react-native-community/cli@latest init-windows --template old/uwp-cs-lib --overwrite
     ```
 5. Restore these original native files (representing the native module samples):
     ```
@@ -80,6 +84,6 @@ To upgrade this sample to the latest version of RNW:
             ```
 8. Verify the updated sample builds:
     ```cmd
-    npx react-native run-windows --no-deploy --no-launch --no-packager --no-autolink --proj "NativeModuleSample\NativeModuleSample.csproj"
+    npx @react-native-coummunity/cli@latest run-windows --no-deploy --no-launch --no-packager --no-autolink --proj "NativeModuleSample\NativeModuleSample.csproj"
     ```
 9. Update the main readme with the new major version at the top.

--- a/samples/README.md
+++ b/samples/README.md
@@ -18,7 +18,7 @@ When new major versions of RNW are released (out of preview), the sample apps in
 
 1. Delete the existing sample app folder.
 2. Run the React Native CLI to create a new sample app with the same name.
-3. Run the React Native Windows CLI to add Windows support.
+3. Add RNW and run the RNW CLI to add Windows support.
 4. Restore the original app code to override the "new project" app code.
 5. Verify that the app still builds and runs.
 


### PR DESCRIPTION
## Description

This updates the various steps in our sample readme's with the CLI commands going forward with RN 0.75.

### Why
Starting with RN 0.75, the preference is to call `npx @react-native-community/cli` instead of `npx react-native` and also we're deprecating the `npx react-native-windows-init` command in favor of `npx @react-native-community/cli init-windows`.

Resolves https://github.com/microsoft/react-native-windows/issues/13464

## Screenshots
N/A

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/951)