### PR TITLE
Read Scout MacOS project added

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The content here features React Native sample apps, components, and templates fo
 | [ContinuousIntegration](./samples/ContinuousIntegration) | Sample CI pipeline configurations for RNW projects. |
 | [NativeModuleSample](./samples/NativeModuleSample) | A sample RNW native module with both C++ and C# implementations. |
 | [ReactNativeWinRT](https://github.com/microsoft/react-native-winrt/tree/main/samples/RNWinRTTestApp) | A sample RNW app that uses [React Native WinRT](aka.ms/reactnativewinrt) to consume native WinRT APIs. |
+| [Read Scout](https://github.com/BrijenMakwana/read-scout) | A MacOS book management app where users can search for books, categorise them into shelves, and generate AI-powered summaries. |
 
 </div>
 


### PR DESCRIPTION
## Description

A new MacOS project added to the readme. Read Scout is a MacOS book management app where users can search for books, categorise them into shelves, and generate AI-powered summaries. The project is featured on freeCodeCamp as well.



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/966)