### PR TITLE
Replace npm tag for yarn add

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,8 +39,7 @@ cd <projectName>
 <!-- Note, make sure "version" is pointing to the correct react-native-windows NPM tag in the command below. -->
 
 <!-- 1. For the next version (i.e. in docs/getting-started.md) use "canary" -->
-<!-- 2. For the latest stable version in versioned_docs use "latest" -->
-<!-- 3. For older stable versions use the stable tag name, i.e. "0.73-stable" -->
+<!-- 2. For other versions in versioned_docs use the version in the format "^0.XY.0" -->
 
 <!--DOCUSAURUS_CODE_TABS-->
 

--- a/website/versioned_docs/version-0.75/getting-started.md
+++ b/website/versioned_docs/version-0.75/getting-started.md
@@ -40,21 +40,20 @@ cd <projectName>
 <!-- Note, make sure "version" is pointing to the correct react-native-windows NPM tag in the command below. -->
 
 <!-- 1. For the next version (i.e. in docs/getting-started.md) use "canary" -->
-<!-- 2. For the latest stable version in versioned_docs use "latest" -->
-<!-- 3. For older stable versions use the stable tag name, i.e. "0.73-stable" -->
+<!-- 2. For other versions in versioned_docs use the version in the format "^0.XY.0" -->
 
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--Using Yarn (Recommended)-->
 
 ```bat
-yarn add react-native-windows@latest
+yarn add react-native-windows@^0.75.0
 ```
 
 <!--Using NPM-->
 
 ```bat
-npm install --save react-native-windows@latest
+npm install --save react-native-windows@^0.75.0
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->


### PR DESCRIPTION
## Description

Replace `yarn add`  "latest" with a specific semver range.

### Why
Newer versions of yarn just add the tag name to the package.json, which is a good way of messing up projects when new versions come out.

## Screenshots
N/A

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/967)