### PR TITLE
Fix node download link

### DIFF
--- a/docs/rnw-dependencies.md
+++ b/docs/rnw-dependencies.md
@@ -55,7 +55,7 @@ Options to install [Node.js](https://nodejs.org) separately:
   choco install nodejs-lts
   ```
   - Using [another package manager](https://nodejs.org/en/download/package-manager/) such as [Scoop](https://scoop.sh/) or [Node Version Switcher (nvs)](https://github.com/jasongin/nvs)
-  - Directly from [Node.js](https://nodejs.org/en/download/)
+  - Directly from [Node.js](https://nodejs.org/en/download)
 
 Optional steps that are _highly recommended_:
 

--- a/website/versioned_docs/version-0.60/rnw-dependencies.md
+++ b/website/versioned_docs/version-0.60/rnw-dependencies.md
@@ -31,7 +31,7 @@ To develop React-Native for Windows apps, you will need the following:
   ```
   choco install nodejs.install --version=12.9.1
   ```
-  - Directly from [Node.js](https://nodejs.org/en/download/)
+  - Directly from [Node.js](https://nodejs.org/en/download)
   - By selecting the "Node.js development support" component in the Visual Studio 2019 installer (above)
 - Install [Chrome](https://www.google.com/chrome/) (_optional_, but needed for JS debugging)
 - Install [Yarn](https://yarnpkg.com/en/docs/install) (_optional_ if only consuming react-native-windows, but **required** to contribute to react-native-windows)

--- a/website/versioned_docs/version-0.61/rnw-dependencies.md
+++ b/website/versioned_docs/version-0.61/rnw-dependencies.md
@@ -31,7 +31,7 @@ To develop React-Native for Windows apps, you will need the following:
   ```
   choco install nodejs.install --version=12.9.1
   ```
-  - Directly from [Node.js](https://nodejs.org/en/download/)
+  - Directly from [Node.js](https://nodejs.org/en/download)
   - By selecting the "Node.js development support" component in the Visual Studio 2019 installer (above)
   > For both of the non-chocolatey installations, ensure that you are installing version 12.9.1 as that is the recommended version when building React Native Windows apps.
   

--- a/website/versioned_docs/version-0.62/rnw-dependencies.md
+++ b/website/versioned_docs/version-0.62/rnw-dependencies.md
@@ -34,7 +34,7 @@ Alternatively, you can setup your environment manually:
   ```
   choco install nodejs.install --version=12.9.1
   ```
-  - Directly from [Node.js](https://nodejs.org/en/download/)
+  - Directly from [Node.js](https://nodejs.org/en/download)
   - By selecting the "Node.js development support" component in the Visual Studio 2019 installer (above)
   > For both of the non-chocolatey installations, ensure that you are installing version 12.9.1 as that is the recommended version when building React Native Windows apps.
 

--- a/website/versioned_docs/version-0.63/rnw-dependencies.md
+++ b/website/versioned_docs/version-0.63/rnw-dependencies.md
@@ -49,7 +49,7 @@ You will also need to ensure that certain settings are enabled:
   ```bat
   choco install nodejs-lts
   ```
-  - Directly from [Node.js](https://nodejs.org/en/download/)
+  - Directly from [Node.js](https://nodejs.org/en/download)
   - By selecting the "Node.js development support" component in the Visual Studio 2019 installer (above)
 
 - Install [Chrome](https://www.google.com/chrome/) (_optional_, but needed for JS debugging)

--- a/website/versioned_docs/version-0.64/rnw-dependencies.md
+++ b/website/versioned_docs/version-0.64/rnw-dependencies.md
@@ -47,7 +47,7 @@ You will also need to ensure that certain settings are enabled:
   ```bat
   choco install nodejs-lts
   ```
-  - Directly from [Node.js](https://nodejs.org/en/download/)
+  - Directly from [Node.js](https://nodejs.org/en/download)
   - By selecting the "Node.js development support" component in the Visual Studio 2019 installer (above)
 
 - Install [Chrome](https://www.google.com/chrome/) (_optional_, but needed for JS debugging)

--- a/website/versioned_docs/version-0.65/rnw-dependencies.md
+++ b/website/versioned_docs/version-0.65/rnw-dependencies.md
@@ -50,7 +50,7 @@ Options to install [Node.js](https://nodejs.org) separately:
   choco install nodejs-lts
   ```
   - Using [another package manager](https://nodejs.org/en/download/package-manager/) such as [Scoop](https://scoop.sh/) or [Node Version Switcher (nvs)](https://github.com/jasongin/nvs)
-  - Directly from [Node.js](https://nodejs.org/en/download/)
+  - Directly from [Node.js](https://nodejs.org/en/download)
 
 Optional steps that are _highly recommended_:
 

--- a/website/versioned_docs/version-0.66/rnw-dependencies.md
+++ b/website/versioned_docs/version-0.66/rnw-dependencies.md
@@ -52,7 +52,7 @@ Options to install [Node.js](https://nodejs.org) separately:
   choco install nodejs-lts
   ```
   - Using [another package manager](https://nodejs.org/en/download/package-manager/) such as [Scoop](https://scoop.sh/) or [Node Version Switcher (nvs)](https://github.com/jasongin/nvs)
-  - Directly from [Node.js](https://nodejs.org/en/download/)
+  - Directly from [Node.js](https://nodejs.org/en/download)
 
 Optional steps that are _highly recommended_:
 

--- a/website/versioned_docs/version-0.71/rnw-dependencies.md
+++ b/website/versioned_docs/version-0.71/rnw-dependencies.md
@@ -56,7 +56,7 @@ Options to install [Node.js](https://nodejs.org) separately:
   choco install nodejs-lts
   ```
   - Using [another package manager](https://nodejs.org/en/download/package-manager/) such as [Scoop](https://scoop.sh/) or [Node Version Switcher (nvs)](https://github.com/jasongin/nvs)
-  - Directly from [Node.js](https://nodejs.org/en/download/)
+  - Directly from [Node.js](https://nodejs.org/en/download)
 
 Optional steps that are _highly recommended_:
 


### PR DESCRIPTION
## Description

Removed the trailing slash from the download links.

### Why
The download link for node doesn't like the trailing slash.


## Screenshots
N/A

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/994)