### PR TITLE
Add CircleMask view example to NativeModuleSample

### DIFF
--- a/samples/NativeModuleSample/cpp-lib/example-old/src/App.tsx
+++ b/samples/NativeModuleSample/cpp-lib/example-old/src/App.tsx
@@ -9,6 +9,7 @@ import {
   SimpleHttpModule,
   type Point,
   DataMarshallingExamples,
+  CircleMask,
 } from 'native-module-sample';
 import type { Int32 } from 'react-native/Libraries/Types/CodegenTypes';
 
@@ -254,6 +255,20 @@ export default function App() {
             )
           )}
         </Text>
+        <Text />
+        <CircleMask style={{ margin: 10 }}>
+          <View
+            style={{
+              backgroundColor: '#006666',
+              width: 100,
+              height: 100,
+              justifyContent: 'center',
+              alignItems: 'center',
+            }}
+          >
+            <Text style={{ fontSize: 20 }}>CircleMask</Text>
+          </View>
+        </CircleMask>
         <Text />
       </View>
     </ScrollView>

--- a/samples/NativeModuleSample/cpp-lib/example/src/App.tsx
+++ b/samples/NativeModuleSample/cpp-lib/example/src/App.tsx
@@ -9,6 +9,7 @@ import {
   SimpleHttpModule,
   type Point,
   DataMarshallingExamples,
+  CircleMask,
 } from 'native-module-sample';
 import type { Int32 } from 'react-native/Libraries/Types/CodegenTypes';
 
@@ -254,6 +255,20 @@ export default function App() {
             )
           )}
         </Text>
+        <Text />
+        <CircleMask style={{ margin: 10 }}>
+          <View
+            style={{
+              backgroundColor: '#006666',
+              width: 100,
+              height: 100,
+              justifyContent: 'center',
+              alignItems: 'center',
+            }}
+          >
+            <Text style={{ fontSize: 20 }}>CircleMask</Text>
+          </View>
+        </CircleMask>
         <Text />
       </View>
     </ScrollView>

--- a/samples/NativeModuleSample/cpp-lib/package.json
+++ b/samples/NativeModuleSample/cpp-lib/package.json
@@ -153,6 +153,10 @@
     "includesGeneratedCode": true,
     "windows": {
       "namespace": "NativeModuleSampleCodegen",
+      "generators": [
+        "modulesWindows",
+        "componentsWindows"
+      ],
       "outputDirectory": "windows/NativeModuleSample/codegen",
       "separateDataTypes": true
     }

--- a/samples/NativeModuleSample/cpp-lib/src/CircleMaskNativeComponent.ts
+++ b/samples/NativeModuleSample/cpp-lib/src/CircleMaskNativeComponent.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import type { ViewProps } from 'react-native';
+
+interface CircleMaskProps extends ViewProps {}
+
+export default codegenNativeComponent<CircleMaskProps>('CircleMask');

--- a/samples/NativeModuleSample/cpp-lib/src/index.tsx
+++ b/samples/NativeModuleSample/cpp-lib/src/index.tsx
@@ -17,3 +17,6 @@ export { type Response } from './NativeSimpleHttpModule';
 export const SimpleHttpModule = {
   GetHttpResponse: NativeSimpleHttpModule.GetHttpResponse,
 };
+
+export {default as CircleMask} from './CircleMaskNativeComponent';
+export * from './CircleMaskNativeComponent';

--- a/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/CircleMask.cpp
+++ b/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/CircleMask.cpp
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include "CircleMask.h"
+
+namespace winrt::NativeModuleSample::implementation
+{
+
+void RegisterCircleMaskNativeComponent(
+    winrt::Microsoft::ReactNative::IReactPackageBuilder const &packageBuilder) noexcept
+{
+#ifdef RNW_NEW_ARCH
+  NativeModuleSampleCodegen::RegisterCircleMaskNativeComponent<CircleMaskComponentView>(packageBuilder, {});
+#else
+  packageBuilder.AddViewManager(L"CircleMaskViewManager", []() { return winrt::make<CircleMaskViewManager>(); });
+#endif  
+}
+
+#ifdef RNW_NEW_ARCH
+
+winrt::Microsoft::UI::Composition::Visual CircleMaskComponentView::CreateVisual(const winrt::Microsoft::ReactNative::ComponentView &view) noexcept
+{
+  // Adapting https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/Samples/SceneGraph/SampleGalleryApp/Samples/CompCapabilities/CompCapabilities.xaml.cs#L139
+
+  auto compositor = view.as<winrt::Microsoft::ReactNative::Composition::ComponentView>().Compositor();
+  // auto compositionContext = view.as<winrt::Microsoft::ReactNative::Composition::ComponentView>().CompositionContext();
+
+  winrt::Windows::Foundation::Size size{100, 100};
+
+  // // Create circle mask 
+  // auto circleMaskSurface = compositionContext.CreateDrawingSurfaceBrush(size)
+
+  // Get child visual
+  auto circleVisual = compositor.CreateSpriteVisual();
+
+  // // Apply mask to Visual
+  // auto maskBrush = compositor.CreateMaskBrush();
+  // maskBrush.Source(???);
+  // maskBrush.Mask(circleMaskSurface);
+
+
+  // circleVisual.Brush(maskBrush);
+
+  // // Insert visual
+  // InnerVisual().InsertAt(circleVisual, 0);
+
+  return circleVisual;
+}
+
+#else
+
+// IViewManager
+winrt::hstring CircleMaskViewManager::Name() noexcept
+{
+  return L"CircleMask";
+}
+
+winrt::Windows::UI::Xaml::FrameworkElement CircleMaskViewManager::CreateView() noexcept
+{
+  auto const &view = winrt::Windows::UI::Xaml::Controls::Border();
+
+  auto const &binding = winrt::Windows::UI::Xaml::Data::Binding();
+  binding.Source(view);
+  binding.Path(winrt::Windows::UI::Xaml::PropertyPath(L"Height"));
+  binding.Converter(HeightToCornerRadiusConverter::Instance());
+
+  view.SetBinding(winrt::Windows::UI::Xaml::Controls::Border::CornerRadiusProperty(), binding);
+
+  return view;
+}
+
+// IViewManagerWithChildren
+
+void CircleMaskViewManager::AddView(
+    winrt::Windows::UI::Xaml::FrameworkElement const &parent,
+    winrt::Windows::UI::Xaml::UIElement const &child,
+    int64_t /*index*/) noexcept
+{
+  if (auto const &border = parent.try_as<winrt::Windows::UI::Xaml::Controls::Border>()) {
+    border.Child(child);
+  }
+}
+
+void CircleMaskViewManager::RemoveAllChildren(winrt::Windows::UI::Xaml::FrameworkElement const &parent) noexcept
+{
+  if (auto const &border = parent.try_as<winrt::Windows::UI::Xaml::Controls::Border>()) {
+    border.Child(nullptr);
+  }
+}
+
+void CircleMaskViewManager::RemoveChildAt(winrt::Windows::UI::Xaml::FrameworkElement const &parent, int64_t /*index*/) noexcept
+{
+  if (auto const &border = parent.try_as<winrt::Windows::UI::Xaml::Controls::Border>()) {
+    border.Child(nullptr);
+  }
+}
+
+void CircleMaskViewManager::ReplaceChild(
+    winrt::Windows::UI::Xaml::FrameworkElement const &parent,
+    winrt::Windows::UI::Xaml::UIElement const & /*oldChild*/,
+    winrt::Windows::UI::Xaml::UIElement const &newChild) noexcept
+{
+  if (auto const &border = parent.try_as<winrt::Windows::UI::Xaml::Controls::Border>()) {
+    border.Child(newChild);
+  }
+}
+
+winrt::Windows::Foundation::IInspectable HeightToCornerRadiusConverter::Convert(
+    winrt::Windows::Foundation::IInspectable const &value,
+    winrt::Windows::UI::Xaml::Interop::TypeName const & /*targetType*/,
+    winrt::Windows::Foundation::IInspectable const & /*parameter*/,
+    winrt::hstring const & /*language*/) noexcept
+{
+  double d = winrt::unbox_value<double>(value);
+
+  if (isnan(d)) {
+    d = 0.0;
+  }
+
+  return winrt::box_value(winrt::Windows::UI::Xaml::CornerRadiusHelper::FromUniformRadius(d));
+}
+
+winrt::Windows::Foundation::IInspectable HeightToCornerRadiusConverter::ConvertBack(
+    winrt::Windows::Foundation::IInspectable const &value,
+    winrt::Windows::UI::Xaml::Interop::TypeName const & /*targetType*/,
+    winrt::Windows::Foundation::IInspectable const & /*parameter*/,
+    winrt::hstring const & /*language*/) noexcept
+{
+  return value;
+}
+
+winrt::Windows::UI::Xaml::Data::IValueConverter HeightToCornerRadiusConverter::Instance() noexcept
+{
+  static auto const &instance = winrt::make<HeightToCornerRadiusConverter>();
+  return instance;
+};
+
+#endif // #ifndef RNW_NEW_ARCH
+
+} // namespace winrt::NativeModuleSample::implementation

--- a/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/CircleMask.h
+++ b/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/CircleMask.h
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "pch.h"
+
+#ifdef RNW_NEW_ARCH
+
+#include "codegen/react/components/NativeModuleSampleSpec/CircleMask.g.h"
+
+#include <winrt/Microsoft.ReactNative.Composition.Experimental.h>
+
+#else
+
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Data.h>
+
+#endif
+
+namespace winrt::NativeModuleSample::implementation
+{
+
+void RegisterCircleMaskNativeComponent(
+    winrt::Microsoft::ReactNative::IReactPackageBuilder const &packageBuilder) noexcept;
+
+#ifdef RNW_NEW_ARCH
+
+struct CircleMaskComponentView : winrt::implements<CircleMaskComponentView, winrt::IInspectable>,
+                                  NativeModuleSampleCodegen::BaseCircleMask<CircleMaskComponentView>
+{
+  winrt::Microsoft::UI::Composition::Visual CreateVisual(const winrt::Microsoft::ReactNative::ComponentView &view) noexcept;
+};
+
+#else
+
+struct CircleMaskViewManager : winrt::implements<
+                                  CircleMaskViewManager,
+                                  winrt::Microsoft::ReactNative::IViewManager,
+                                  winrt::Microsoft::ReactNative::IViewManagerWithChildren>
+{
+ public:
+  CircleMaskViewManager(){}
+
+  // IViewManager
+  winrt::hstring Name() noexcept;
+
+  winrt::Windows::UI::Xaml::FrameworkElement CreateView() noexcept;
+
+  // IViewManagerWithChildren
+
+  void AddView(
+      winrt::Windows::UI::Xaml::FrameworkElement const &parent,
+      winrt::Windows::UI::Xaml::UIElement const &child,
+      int64_t /*index*/) noexcept;
+
+  void RemoveAllChildren(winrt::Windows::UI::Xaml::FrameworkElement const &parent) noexcept;
+
+  void RemoveChildAt(winrt::Windows::UI::Xaml::FrameworkElement const &parent, int64_t /*index*/) noexcept;
+
+  void ReplaceChild(
+      winrt::Windows::UI::Xaml::FrameworkElement const &parent,
+      winrt::Windows::UI::Xaml::UIElement const & /*oldChild*/,
+      winrt::Windows::UI::Xaml::UIElement const &newChild) noexcept;
+};
+
+struct HeightToCornerRadiusConverter
+    : winrt::implements<HeightToCornerRadiusConverter, winrt::Windows::UI::Xaml::Data::IValueConverter>
+{
+ public:
+  HeightToCornerRadiusConverter(){}
+
+  winrt::Windows::Foundation::IInspectable Convert(
+      winrt::Windows::Foundation::IInspectable const &value,
+      winrt::Windows::UI::Xaml::Interop::TypeName const & /*targetType*/,
+      winrt::Windows::Foundation::IInspectable const & /*parameter*/,
+      winrt::hstring const & /*language*/) noexcept;
+
+  winrt::Windows::Foundation::IInspectable ConvertBack(
+      winrt::Windows::Foundation::IInspectable const &value,
+      winrt::Windows::UI::Xaml::Interop::TypeName const & /*targetType*/,
+      winrt::Windows::Foundation::IInspectable const & /*parameter*/,
+      winrt::hstring const & /*language*/) noexcept;
+
+  static winrt::Windows::UI::Xaml::Data::IValueConverter Instance() noexcept;
+
+  // IValueConverter
+};
+
+#endif // #ifdef RNW_NEW_ARCH
+
+} // namespace winrt::NativeModuleSample::implementation

--- a/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/CircleMask.h
+++ b/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/CircleMask.h
@@ -29,7 +29,12 @@ void RegisterCircleMaskNativeComponent(
 struct CircleMaskComponentView : winrt::implements<CircleMaskComponentView, winrt::IInspectable>,
                                   NativeModuleSampleCodegen::BaseCircleMask<CircleMaskComponentView>
 {
-  winrt::Microsoft::UI::Composition::Visual CreateVisual(const winrt::Microsoft::ReactNative::ComponentView &view) noexcept;
+  winrt::Microsoft::UI::Composition::Visual CreateVisual(const winrt::Microsoft::ReactNative::ComponentView &view) noexcept override;
+  void Initialize(const winrt::Microsoft::ReactNative::ComponentView &/*view*/) noexcept override;
+
+private:
+  winrt::Microsoft::ReactNative::ComponentView::LayoutMetricsChanged_revoker m_layoutMetricChangedRevoker;
+  winrt::Microsoft::UI::Composition::SpriteVisual m_visual{nullptr};
 };
 
 #else

--- a/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/NativeModuleSample.vcxproj
+++ b/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/NativeModuleSample.vcxproj
@@ -103,6 +103,7 @@
     <ClInclude Include="DataMarshallingExamples.h" />
     <ClInclude Include="FancyMath.h" />
     <ClInclude Include="SimpleHttpModule.h" />
+    <ClInclude Include="CircleMask.h" />
     <ClInclude Include="ReactPackageProvider.h">
       <DependentUpon>ReactPackageProvider.idl</DependentUpon>
     </ClInclude>
@@ -114,6 +115,7 @@
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="CircleMask.cpp" />
     <ClCompile Include="ReactPackageProvider.cpp">
       <DependentUpon>ReactPackageProvider.idl</DependentUpon>
     </ClCompile>

--- a/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/NativeModuleSample.vcxproj.filters
+++ b/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/NativeModuleSample.vcxproj.filters
@@ -30,11 +30,17 @@
     <ClInclude Include="SimpleHttpModule.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="CircleMask.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="pch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="CircleMask.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="pch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/ReactPackageProvider.cpp
+++ b/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/ReactPackageProvider.cpp
@@ -12,6 +12,8 @@
 #include "FancyMath.h"
 #include "SimpleHttpModule.h"
 
+#include "CircleMask.h"
+
 using namespace winrt::Microsoft::ReactNative;
 
 namespace winrt::NativeModuleSample::implementation
@@ -20,6 +22,7 @@ namespace winrt::NativeModuleSample::implementation
 void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept
 {
   AddAttributedModules(packageBuilder, true);
+  RegisterCircleMaskNativeComponent(packageBuilder);
 }
 
 } // namespace winrt::NativeModuleSample::implementation

--- a/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/codegen/react/components/NativeModuleSampleSpec/CircleMask.g.h
+++ b/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/codegen/react/components/NativeModuleSampleSpec/CircleMask.g.h
@@ -1,0 +1,173 @@
+
+/*
+ * This file is auto-generated from CircleMaskNativeComponent spec file in flow / TypeScript.
+ */
+#pragma once
+
+#include <NativeModules.h>
+
+#ifdef RNW_NEW_ARCH
+#include <JSValueComposition.h>
+
+#include <winrt/Microsoft.ReactNative.Composition.h>
+#include <winrt/Microsoft.UI.Composition.h>
+#endif // #ifdef RNW_NEW_ARCH
+
+#ifdef RNW_NEW_ARCH
+
+namespace NativeModuleSampleCodegen {
+
+REACT_STRUCT(CircleMaskProps)
+struct CircleMaskProps : winrt::implements<CircleMaskProps, winrt::Microsoft::ReactNative::IComponentProps> {
+  CircleMaskProps(winrt::Microsoft::ReactNative::ViewProps props) : ViewProps(props) {}
+
+  void SetProp(uint32_t hash, winrt::hstring propName, winrt::Microsoft::ReactNative::IJSValueReader value) noexcept {
+    winrt::Microsoft::ReactNative::ReadProp(hash, propName, value, *this);
+  }
+
+  const winrt::Microsoft::ReactNative::ViewProps ViewProps;
+};
+
+struct CircleMaskEventEmitter {
+  CircleMaskEventEmitter(const winrt::Microsoft::ReactNative::EventEmitter &eventEmitter)
+      : m_eventEmitter(eventEmitter) {}
+
+ private:
+  winrt::Microsoft::ReactNative::EventEmitter m_eventEmitter{nullptr};
+};
+
+template<typename TUserData>
+struct BaseCircleMask {
+
+  virtual void UpdateProps(
+    const winrt::Microsoft::ReactNative::ComponentView &/*view*/,
+    const winrt::com_ptr<CircleMaskProps> &newProps,
+    const winrt::com_ptr<CircleMaskProps> &/*oldProps*/) noexcept {
+    m_props = newProps;
+  }
+
+  // UpdateState will only be called if this method is overridden
+  virtual void UpdateState(
+    const winrt::Microsoft::ReactNative::ComponentView &/*view*/,
+    const winrt::Microsoft::ReactNative::IComponentState &/*newState*/) noexcept {
+  }
+
+  virtual void UpdateEventEmitter(const std::shared_ptr<CircleMaskEventEmitter> &eventEmitter) noexcept {
+    m_eventEmitter = eventEmitter;
+  }
+
+  // MountChildComponentView will only be called if this method is overridden
+  virtual void MountChildComponentView(const winrt::Microsoft::ReactNative::ComponentView &/*view*/,
+           const winrt::Microsoft::ReactNative::MountChildComponentViewArgs &/*args*/) noexcept {
+  }
+
+  // UnmountChildComponentView will only be called if this method is overridden
+  virtual void UnmountChildComponentView(const winrt::Microsoft::ReactNative::ComponentView &/*view*/,
+           const winrt::Microsoft::ReactNative::UnmountChildComponentViewArgs &/*args*/) noexcept {
+  }
+
+  // Initialize will only be called if this method is overridden
+  virtual void Initialize(const winrt::Microsoft::ReactNative::ComponentView &/*view*/) noexcept {
+  }
+
+  // CreateVisual will only be called if this method is overridden
+  virtual winrt::Microsoft::UI::Composition::Visual CreateVisual(const winrt::Microsoft::ReactNative::ComponentView &view) noexcept {
+    return view.as<winrt::Microsoft::ReactNative::Composition::ComponentView>().Compositor().CreateSpriteVisual();
+  }
+
+  // FinalizeUpdate will only be called if this method is overridden
+  virtual void FinalizeUpdate(const winrt::Microsoft::ReactNative::ComponentView &/*view*/,
+                                        winrt::Microsoft::ReactNative::ComponentViewUpdateMask /*mask*/) noexcept {
+  }
+
+  
+
+  const std::shared_ptr<CircleMaskEventEmitter>& EventEmitter() const { return m_eventEmitter; }
+  const winrt::com_ptr<CircleMaskProps>& Props() const { return m_props; }
+
+private:
+  winrt::com_ptr<CircleMaskProps> m_props;
+  std::shared_ptr<CircleMaskEventEmitter> m_eventEmitter;
+};
+
+template <typename TUserData>
+void RegisterCircleMaskNativeComponent(
+    winrt::Microsoft::ReactNative::IReactPackageBuilder const &packageBuilder,
+    std::function<void(const winrt::Microsoft::ReactNative::Composition::IReactCompositionViewComponentBuilder&)> builderCallback) noexcept {
+  packageBuilder.as<winrt::Microsoft::ReactNative::IReactPackageBuilderFabric>().AddViewComponent(
+      L"CircleMask", [builderCallback](winrt::Microsoft::ReactNative::IReactViewComponentBuilder const &builder) noexcept {
+        auto compBuilder = builder.as<winrt::Microsoft::ReactNative::Composition::IReactCompositionViewComponentBuilder>();
+
+        builder.SetCreateProps(
+            [](winrt::Microsoft::ReactNative::ViewProps props) noexcept { return winrt::make<CircleMaskProps>(props); });
+
+        builder.SetUpdatePropsHandler([](const winrt::Microsoft::ReactNative::ComponentView &view,
+                                     const winrt::Microsoft::ReactNative::IComponentProps &newProps,
+                                     const winrt::Microsoft::ReactNative::IComponentProps &oldProps) noexcept {
+            auto userData = view.UserData().as<TUserData>();
+            userData->UpdateProps(view, newProps ? newProps.as<CircleMaskProps>() : nullptr, oldProps ? oldProps.as<CircleMaskProps>() : nullptr);
+        });
+
+        builder.SetUpdateEventEmitterHandler([](const winrt::Microsoft::ReactNative::ComponentView &view,
+                                     const winrt::Microsoft::ReactNative::EventEmitter &eventEmitter) noexcept {
+          auto userData = view.UserData().as<TUserData>();
+          userData->UpdateEventEmitter(std::make_shared<CircleMaskEventEmitter>(eventEmitter));
+        });
+
+        if constexpr (&TUserData::FinalizeUpdate != &BaseCircleMask<TUserData>::FinalizeUpdate) {
+            builder.SetFinalizeUpdateHandler([](const winrt::Microsoft::ReactNative::ComponentView &view,
+                                     winrt::Microsoft::ReactNative::ComponentViewUpdateMask mask) noexcept {
+            auto userData = view.UserData().as<TUserData>();
+            userData->FinalizeUpdate(view, mask);
+          });
+        } 
+
+        if constexpr (&TUserData::UpdateState != &BaseCircleMask<TUserData>::UpdateState) {
+          builder.SetUpdateStateHandler([](const winrt::Microsoft::ReactNative::ComponentView &view,
+                                     const winrt::Microsoft::ReactNative::IComponentState &newState) noexcept {
+            auto userData = view.UserData().as<TUserData>();
+            userData->member(view, newState);
+          });
+        }
+
+        if constexpr (&TUserData::MountChildComponentView != &BaseCircleMask<TUserData>::MountChildComponentView) {
+          builder.SetMountChildComponentViewHandler([](const winrt::Microsoft::ReactNative::ComponentView &view,
+                                      const winrt::Microsoft::ReactNative::MountChildComponentViewArgs &args) noexcept {
+            auto userData = view.UserData().as<TUserData>();
+            return userData->MountChildComponentView(view, args);
+          });
+        }
+
+        if constexpr (&TUserData::UnmountChildComponentView != &BaseCircleMask<TUserData>::UnmountChildComponentView) {
+          builder.SetUnmountChildComponentViewHandler([](const winrt::Microsoft::ReactNative::ComponentView &view,
+                                      const winrt::Microsoft::ReactNative::UnmountChildComponentViewArgs &args) noexcept {
+            auto userData = view.UserData().as<TUserData>();
+            return userData->UnmountChildComponentView(view, args);
+          });
+        }
+
+        compBuilder.SetViewComponentViewInitializer([](const winrt::Microsoft::ReactNative::ComponentView &view) noexcept {
+          auto userData = winrt::make_self<TUserData>();
+          if constexpr (&TUserData::Initialize != &BaseCircleMask<TUserData>::Initialize) {
+            userData->Initialize(view);
+          }
+          view.UserData(*userData);
+        });
+
+        if constexpr (&TUserData::CreateVisual != &BaseCircleMask<TUserData>::CreateVisual) {
+          compBuilder.SetCreateVisualHandler([](const winrt::Microsoft::ReactNative::ComponentView &view) noexcept {
+            auto userData = view.UserData().as<TUserData>();
+            return userData->CreateVisual(view);
+          });
+        }
+
+        // Allow app to further customize the builder
+        if (builderCallback) {
+          builderCallback(compBuilder);
+        }
+      });
+}
+
+} // namespace NativeModuleSampleCodegen
+
+#endif // #ifdef RNW_NEW_ARCH


### PR DESCRIPTION
## Description

This PR adds a `CircleMask` native view to the `NativeModuleSample`.

### Why
So we have an example of implementing the same native view for both Paper (using Xaml) and Fabric (using Composition).

## Screenshots

| New Arch | Old Arch |
|:-:|:-:|
| ![image](https://github.com/user-attachments/assets/0cd5d355-f970-4fbf-9d25-237efed14e1b) | ![image](https://github.com/user-attachments/assets/b707c136-0e5f-4336-9940-01e87bbb7c8f) |

