### PR TITLE
Add ADO Production CI

### DIFF
--- a/.ado/ci.yml
+++ b/.ado/ci.yml
@@ -1,0 +1,26 @@
+name: RNW Samples Production CI $(Date:yyyyMMdd).$(Rev:r)
+
+trigger: none
+pr: none
+
+variables:
+  - name: Codeql.Enabled
+    value: true
+  - name: Codeql.Cadence
+     value: 120 # In hours, default to only run every 5 days
+
+pool:
+  name: rnw-pool-4
+  demands: ImageOverride -equals rnw-img-vs2022-node18
+
+steps:
+  - checkout: self
+    clean: false
+
+    - script: yarn install --frozen-lockfile
+      displayName: Yarn Install (Website)
+      workingDirectory: ./website
+    
+    - script: yarn build
+      displayName: Yarn Build (Website)
+      workingDirectory: ./website

--- a/CodeQL.yml
+++ b/CodeQL.yml
@@ -1,0 +1,7 @@
+# This file is used to configure CodeQL alerts.
+# See https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#excluding-external-libraries-test-files-generated-files-docs
+
+path_classifiers:
+  docs:
+    - "**/docs"
+    - "**/website/versioned_docs"


### PR DESCRIPTION
## Description

Adds a simple CI to build the (production) website, so we can start collecting CodeQL scan results.

### Why
We need to get CodeQL scanning for the repo.

Resolves #977

## Screenshots
N/A

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/1002)