### PR TITLE
Update rnm-getting-started.md

### DIFF
--- a/docs/rnm-getting-started.md
+++ b/docs/rnm-getting-started.md
@@ -13,10 +13,10 @@ For information around how to set up:
 
 ## Install React Native for macOS
 
-Remember to call `react-native init` from the place you want your project directory to live. Be sure to use the same minor version between React Native and React Native macOS. We'll use `^0.71.0`
+Remember to call `@react-native-community init` from the place you want your project directory to live. Be sure to use the same minor version between React Native and React Native macOS. We'll use `^0.71.0`
 
 ```
-npx react-native@latest init <projectName> --version 0.76.0
+npx @react-native-community/cli@latest init <projectName> --version 0.76.0
 ```
 
 ### Navigate into this newly created directory


### PR DESCRIPTION
Replaced npx react-native@latest init with @react-native-community/cli@latest init. Because of deprecation error message.

## Description


### Why
#### Getting error:
The `init` command is deprecated.

- Switch to npx @react-native-community/cli init for the identical behavior.

Resolves [Add Relevant Issue Here]

## Screenshots
Add any relevant screen captures here from before or after your changes. 
