### PR TITLE
Fix Upgrade CI

### DIFF
--- a/.github/workflows/ci-upgrade.yml
+++ b/.github/workflows/ci-upgrade.yml
@@ -33,7 +33,6 @@ jobs:
       configuration: ${{ matrix.configuration }}
       platform: ${{ matrix.platform }}
       runInitWindows: true
-      extraInitWindowsArgs: --language ${{ endsWith(matrix.sampleName, 'cppwinrt') && 'cpp' || 'cs' }}
 
   call-upgradesample-native-module-sample:
     name: Upgrade Native Module Sample

--- a/.github/workflows/ci-upgrade.yml
+++ b/.github/workflows/ci-upgrade.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sampleName: ['Calculator\cppwinrt', 'Calculator\csharp', Calculator\fabric]
+        sampleName: ['Calculator\cppwinrt', 'Calculator\csharp', 'Calculator\fabric']
         configuration: ['Debug', 'Release']
         platform: ['x86', 'x64', 'ARM64']
         reactNativeWindowsVersion: [latest, preview, canary]
@@ -52,4 +52,4 @@ jobs:
       configuration: ${{ matrix.configuration }}
       platform: ${{ matrix.platform }}
       extraRunWindowsArgs: --no-autolink --no-deploy
-      # runCodeGenCheck: true # Enable once we get https://github.com/microsoft/react-native-windows/pull/11187 (Maybe 0.72?)
+      runCodeGenCheck: true

--- a/.github/workflows/ci-upgrade.yml
+++ b/.github/workflows/ci-upgrade.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sampleName: ['NativeModuleSample\cppwinrt', 'NativeModuleSample\csharp']
+        sampleName: ['NativeModuleSample\cpp-lib', 'NativeModuleSample\cppwinrt', 'NativeModuleSample\csharp']
         configuration: ['Debug', 'Release']
         platform: ['x86', 'x64', 'ARM64']
         reactNativeWindowsVersion: [latest, preview, canary]

--- a/.github/workflows/template-upgradesample.yml
+++ b/.github/workflows/template-upgradesample.yml
@@ -85,9 +85,9 @@ jobs:
       run: ${{github.workspace}}\.github\scripts\UpgradeSmokeTest.ps1 ${{ inputs.reactNativeWindowsVersion }} -Force ${{ format('${0}', contains(inputs.reactNativeWindowsVersion, 'canary')) }}
       working-directory: ..\..\src
 
-    - name: Run react-native-windows-init
+    - name: Run react-native init-windows
       if: ${{ steps.upgrade.outcome == 'success' && inputs.runInitWindows }}
-      run: npx react-native-windows-init --overwrite ${{ inputs.extraInitWindowsArgs }} --version ${{ inputs.reactNativeWindowsVersion }}
+      run: npx react-native init-windows --logging --overwrite ${{ inputs.extraInitWindowsArgs }}
       working-directory: ..\..\src
 
     - name: Codegen check


### PR DESCRIPTION
## Description

This PR updates the upgrade sample CI to use init-windows instead of react-native-windows-init.

### Why
To re-enable the CI.

## Screenshots
N/A

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/1007)