### PR TITLE
Fix broken init command in documentation

### DIFF
--- a/docs/rnm-getting-started.md
+++ b/docs/rnm-getting-started.md
@@ -13,7 +13,7 @@ For information around how to set up:
 
 ## Install React Native for macOS
 
-Remember to call `react-native init` from the place you want your project directory to live. Be sure to use the same minor version between React Native and React Native macOS. We'll use `^0.71.0`
+Remember to call `react-native init` from the place you want your project directory to live. Be sure to use the same minor version between React Native and React Native macOS. We'll use `^0.76.0`
 
 ```
 npx react-native@latest init <projectName> --version 0.76.0

--- a/docs/rnm-getting-started.md
+++ b/docs/rnm-getting-started.md
@@ -16,7 +16,7 @@ For information around how to set up:
 Remember to call `react-native init` from the place you want your project directory to live. Be sure to use the same minor version between React Native and React Native macOS. We'll use `^0.76.0`
 
 ```
-npx react-native@latest init <projectName> --version 0.76.0
+npx @react-native-community/cli init <projectName> --version 0.76
 ```
 
 ### Navigate into this newly created directory

--- a/docs/rnm-getting-started.md
+++ b/docs/rnm-getting-started.md
@@ -13,7 +13,7 @@ For information around how to set up:
 
 ## Install React Native for macOS
 
-Remember to call `react-native init` from the place you want your project directory to live. Be sure to use the same minor version between React Native and React Native macOS. We'll use `^0.76.0`
+Remember to call `@react-native-community/cli init` from the place you want your project directory to live. Be sure to use the same minor version between React Native and React Native macOS. We'll use `^0.76.0`
 
 ```
 npx @react-native-community/cli init <projectName> --version 0.76


### PR DESCRIPTION
## Description

### Why
This PR fixes a insonsitency in the documentation and updates the init command to the latest date because the current command is resulting in the following error
```
npx react-native@latest init ReactNativeGithub --version 0.76.0

🚨️ The `init` command is deprecated.

- Switch to npx @react-native-community/cli init for the identical behavior.
- Refer to the documentation for information about alternative tools: https://reactnative.dev/docs/getting-started
Exiting...
```
Furthermore, I've removed the path level from the version value so the latest patch will be used (0.76.7)
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/1013)