### PR TITLE
Upgrade NativeModuleSample/cpp-lib to RNW 0.78.4

### DIFF
--- a/samples/NativeModuleSample/cpp-lib/example-old/package.json
+++ b/samples/NativeModuleSample/cpp-lib/example-old/package.json
@@ -10,15 +10,15 @@
   "dependencies": {
     "react": "19.0.0",
     "react-native": "0.78.0",
-    "react-native-windows": "0.78.2"
+    "react-native-windows": "0.78.4"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
     "@babel/runtime": "^7.25.0",
-    "@react-native-community/cli": "15.0.0-alpha.2",
-    "@react-native-community/cli-platform-android": "15.0.0-alpha.2",
-    "@react-native-community/cli-platform-ios": "15.0.0-alpha.2",
+    "@react-native-community/cli": "15.0.0",
+    "@react-native-community/cli-platform-android": "15.0.0",
+    "@react-native-community/cli-platform-ios": "15.0.0",
     "@react-native/babel-preset": "0.78.0",
     "@react-native/metro-config": "0.78.0",
     "@react-native/typescript-config": "0.78.0",

--- a/samples/NativeModuleSample/cpp-lib/example-old/windows/NativeModuleSampleExampleOld/packages.lock.json
+++ b/samples/NativeModuleSample/cpp-lib/example-old/windows/NativeModuleSampleExampleOld/packages.lock.json
@@ -10,17 +10,17 @@
       },
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.78.2, )",
-        "resolved": "0.78.2",
-        "contentHash": "dC8qT8Y7PX8LmOfSE+Xh3Mt6a7r7EHx1wO6mI3ZGU9kTahqtf759fE0oatydEgvCvugYvZIu0BFarZpvVSOmhA=="
+        "requested": "[0.78.4, )",
+        "resolved": "0.78.4",
+        "contentHash": "NJSJgWGNEEtC2mgrEn4kHIN4FcP4DaTA5++iqPTlCkIfX2y20XIhCigqnGLcG591SJFkzNVi4RPuGp2XFvHWsg=="
       },
       "Microsoft.ReactNative.Cxx": {
         "type": "Direct",
-        "requested": "[0.78.2, )",
-        "resolved": "0.78.2",
-        "contentHash": "b37+ruqhuA/HCi8TYVAcklgSdiBUhHyU3/0RJbcdWSyXrACVY10pTGR4tgzFjU8APwl5hAR+Q8zBj2ObMnkK1A==",
+        "requested": "[0.78.4, )",
+        "resolved": "0.78.4",
+        "contentHash": "Is4EQis7RW3+d7+khbIhlILoKABqGQH9FWM2n+cEjkyfYyKtMJIMxSsSGBfE5ADbFUyNqiPMWfNEGouPsYzC1g==",
         "dependencies": {
-          "Microsoft.ReactNative": "0.78.2"
+          "Microsoft.ReactNative": "0.78.4"
         }
       },
       "Microsoft.UI.Xaml": {
@@ -46,8 +46,8 @@
       "nativemodulesample": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.ReactNative": "[0.78.2, )",
-          "Microsoft.ReactNative.Cxx": "[0.78.2, )",
+          "Microsoft.ReactNative": "[0.78.4, )",
+          "Microsoft.ReactNative.Cxx": "[0.78.4, )",
           "Microsoft.UI.Xaml": "[2.8.0, )"
         }
       }
@@ -55,9 +55,9 @@
     "native,Version=v0.0/win10-arm": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.78.2, )",
-        "resolved": "0.78.2",
-        "contentHash": "dC8qT8Y7PX8LmOfSE+Xh3Mt6a7r7EHx1wO6mI3ZGU9kTahqtf759fE0oatydEgvCvugYvZIu0BFarZpvVSOmhA=="
+        "requested": "[0.78.4, )",
+        "resolved": "0.78.4",
+        "contentHash": "NJSJgWGNEEtC2mgrEn4kHIN4FcP4DaTA5++iqPTlCkIfX2y20XIhCigqnGLcG591SJFkzNVi4RPuGp2XFvHWsg=="
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
@@ -68,9 +68,9 @@
     "native,Version=v0.0/win10-arm-aot": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.78.2, )",
-        "resolved": "0.78.2",
-        "contentHash": "dC8qT8Y7PX8LmOfSE+Xh3Mt6a7r7EHx1wO6mI3ZGU9kTahqtf759fE0oatydEgvCvugYvZIu0BFarZpvVSOmhA=="
+        "requested": "[0.78.4, )",
+        "resolved": "0.78.4",
+        "contentHash": "NJSJgWGNEEtC2mgrEn4kHIN4FcP4DaTA5++iqPTlCkIfX2y20XIhCigqnGLcG591SJFkzNVi4RPuGp2XFvHWsg=="
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
@@ -81,9 +81,9 @@
     "native,Version=v0.0/win10-arm64-aot": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.78.2, )",
-        "resolved": "0.78.2",
-        "contentHash": "dC8qT8Y7PX8LmOfSE+Xh3Mt6a7r7EHx1wO6mI3ZGU9kTahqtf759fE0oatydEgvCvugYvZIu0BFarZpvVSOmhA=="
+        "requested": "[0.78.4, )",
+        "resolved": "0.78.4",
+        "contentHash": "NJSJgWGNEEtC2mgrEn4kHIN4FcP4DaTA5++iqPTlCkIfX2y20XIhCigqnGLcG591SJFkzNVi4RPuGp2XFvHWsg=="
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
@@ -94,9 +94,9 @@
     "native,Version=v0.0/win10-x64": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.78.2, )",
-        "resolved": "0.78.2",
-        "contentHash": "dC8qT8Y7PX8LmOfSE+Xh3Mt6a7r7EHx1wO6mI3ZGU9kTahqtf759fE0oatydEgvCvugYvZIu0BFarZpvVSOmhA=="
+        "requested": "[0.78.4, )",
+        "resolved": "0.78.4",
+        "contentHash": "NJSJgWGNEEtC2mgrEn4kHIN4FcP4DaTA5++iqPTlCkIfX2y20XIhCigqnGLcG591SJFkzNVi4RPuGp2XFvHWsg=="
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
@@ -107,9 +107,9 @@
     "native,Version=v0.0/win10-x64-aot": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.78.2, )",
-        "resolved": "0.78.2",
-        "contentHash": "dC8qT8Y7PX8LmOfSE+Xh3Mt6a7r7EHx1wO6mI3ZGU9kTahqtf759fE0oatydEgvCvugYvZIu0BFarZpvVSOmhA=="
+        "requested": "[0.78.4, )",
+        "resolved": "0.78.4",
+        "contentHash": "NJSJgWGNEEtC2mgrEn4kHIN4FcP4DaTA5++iqPTlCkIfX2y20XIhCigqnGLcG591SJFkzNVi4RPuGp2XFvHWsg=="
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
@@ -120,9 +120,9 @@
     "native,Version=v0.0/win10-x86": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.78.2, )",
-        "resolved": "0.78.2",
-        "contentHash": "dC8qT8Y7PX8LmOfSE+Xh3Mt6a7r7EHx1wO6mI3ZGU9kTahqtf759fE0oatydEgvCvugYvZIu0BFarZpvVSOmhA=="
+        "requested": "[0.78.4, )",
+        "resolved": "0.78.4",
+        "contentHash": "NJSJgWGNEEtC2mgrEn4kHIN4FcP4DaTA5++iqPTlCkIfX2y20XIhCigqnGLcG591SJFkzNVi4RPuGp2XFvHWsg=="
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
@@ -133,9 +133,9 @@
     "native,Version=v0.0/win10-x86-aot": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.78.2, )",
-        "resolved": "0.78.2",
-        "contentHash": "dC8qT8Y7PX8LmOfSE+Xh3Mt6a7r7EHx1wO6mI3ZGU9kTahqtf759fE0oatydEgvCvugYvZIu0BFarZpvVSOmhA=="
+        "requested": "[0.78.4, )",
+        "resolved": "0.78.4",
+        "contentHash": "NJSJgWGNEEtC2mgrEn4kHIN4FcP4DaTA5++iqPTlCkIfX2y20XIhCigqnGLcG591SJFkzNVi4RPuGp2XFvHWsg=="
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",

--- a/samples/NativeModuleSample/cpp-lib/example/package.json
+++ b/samples/NativeModuleSample/cpp-lib/example/package.json
@@ -10,15 +10,15 @@
   "dependencies": {
     "react": "19.0.0",
     "react-native": "0.78.0",
-    "react-native-windows": "0.78.2"
+    "react-native-windows": "0.78.4"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
     "@babel/runtime": "^7.25.0",
-    "@react-native-community/cli": "15.0.0-alpha.2",
-    "@react-native-community/cli-platform-android": "15.0.0-alpha.2",
-    "@react-native-community/cli-platform-ios": "15.0.0-alpha.2",
+    "@react-native-community/cli": "15.0.0",
+    "@react-native-community/cli-platform-android": "15.0.0",
+    "@react-native-community/cli-platform-ios": "15.0.0",
     "@react-native/babel-preset": "0.78.0",
     "@react-native/metro-config": "0.78.0",
     "@react-native/typescript-config": "0.78.0",

--- a/samples/NativeModuleSample/cpp-lib/example/windows/NativeModuleSampleExample.Package/packages.lock.json
+++ b/samples/NativeModuleSample/cpp-lib/example/windows/NativeModuleSampleExample.Package/packages.lock.json
@@ -24,15 +24,15 @@
       },
       "Microsoft.ReactNative": {
         "type": "Transitive",
-        "resolved": "0.78.2-Fabric",
-        "contentHash": "YFIUioiHtgR1MdOC+NtqlYGTFz38k5eqTRy4dynrFqe69c7Oj28QJRb2aARBtN2iExLD08Cy9x6T5cHIx9RPZg=="
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "cQULMq+ehY7i6d1QOl9F2/1sR6T2NeGWhOWRPBvdbhr6eqohNgsg2NcKNTVIWXRSgvV7xz1VqRddE0AHdn3Bmw=="
       },
       "Microsoft.ReactNative.Cxx": {
         "type": "Transitive",
-        "resolved": "0.78.2-Fabric",
-        "contentHash": "JvXWCbp5EjoE7G/82BHRoIdpK0RkG/PpefzGMnCF0enoOzmOSmWFJmWZQV86lbJQ6BllElCVAGG37z3JYyNqoQ==",
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "dQmAEkpWEdvTKs9xEWM49XAlq8b5XJpiEl6yk3TFPmDRgnOXdx77KyMqnxt6JgAGPUQ7MvmFTXlYXaAmwxiGig==",
         "dependencies": {
-          "Microsoft.ReactNative": "0.78.2-Fabric"
+          "Microsoft.ReactNative": "0.78.4-Fabric"
         }
       },
       "Microsoft.VCRTForwarders.140": {
@@ -53,8 +53,8 @@
       "nativemodulesample": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.ReactNative": "[0.78.2-Fabric, )",
-          "Microsoft.ReactNative.Cxx": "[0.78.2-Fabric, )",
+          "Microsoft.ReactNative": "[0.78.4-Fabric, )",
+          "Microsoft.ReactNative.Cxx": "[0.78.4-Fabric, )",
           "Microsoft.VCRTForwarders.140": "[1.0.2-rc, )",
           "Microsoft.WindowsAppSDK": "[1.6.240923002, )",
           "boost": "[1.83.0, )"
@@ -64,8 +64,8 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.JavaScript.Hermes": "[0.1.23, )",
-          "Microsoft.ReactNative": "[0.78.2-Fabric, )",
-          "Microsoft.ReactNative.Cxx": "[0.78.2-Fabric, )",
+          "Microsoft.ReactNative": "[0.78.4-Fabric, )",
+          "Microsoft.ReactNative.Cxx": "[0.78.4-Fabric, )",
           "Microsoft.VCRTForwarders.140": "[1.0.2-rc, )",
           "Microsoft.WindowsAppSDK": "[1.6.240923002, )",
           "NativeModuleSample": "[1.0.0, )",
@@ -86,8 +86,8 @@
       },
       "Microsoft.ReactNative": {
         "type": "Transitive",
-        "resolved": "0.78.2-Fabric",
-        "contentHash": "YFIUioiHtgR1MdOC+NtqlYGTFz38k5eqTRy4dynrFqe69c7Oj28QJRb2aARBtN2iExLD08Cy9x6T5cHIx9RPZg=="
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "cQULMq+ehY7i6d1QOl9F2/1sR6T2NeGWhOWRPBvdbhr6eqohNgsg2NcKNTVIWXRSgvV7xz1VqRddE0AHdn3Bmw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Transitive",
@@ -113,8 +113,8 @@
       },
       "Microsoft.ReactNative": {
         "type": "Transitive",
-        "resolved": "0.78.2-Fabric",
-        "contentHash": "YFIUioiHtgR1MdOC+NtqlYGTFz38k5eqTRy4dynrFqe69c7Oj28QJRb2aARBtN2iExLD08Cy9x6T5cHIx9RPZg=="
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "cQULMq+ehY7i6d1QOl9F2/1sR6T2NeGWhOWRPBvdbhr6eqohNgsg2NcKNTVIWXRSgvV7xz1VqRddE0AHdn3Bmw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Transitive",
@@ -140,8 +140,8 @@
       },
       "Microsoft.ReactNative": {
         "type": "Transitive",
-        "resolved": "0.78.2-Fabric",
-        "contentHash": "YFIUioiHtgR1MdOC+NtqlYGTFz38k5eqTRy4dynrFqe69c7Oj28QJRb2aARBtN2iExLD08Cy9x6T5cHIx9RPZg=="
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "cQULMq+ehY7i6d1QOl9F2/1sR6T2NeGWhOWRPBvdbhr6eqohNgsg2NcKNTVIWXRSgvV7xz1VqRddE0AHdn3Bmw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Transitive",
@@ -167,8 +167,8 @@
       },
       "Microsoft.ReactNative": {
         "type": "Transitive",
-        "resolved": "0.78.2-Fabric",
-        "contentHash": "YFIUioiHtgR1MdOC+NtqlYGTFz38k5eqTRy4dynrFqe69c7Oj28QJRb2aARBtN2iExLD08Cy9x6T5cHIx9RPZg=="
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "cQULMq+ehY7i6d1QOl9F2/1sR6T2NeGWhOWRPBvdbhr6eqohNgsg2NcKNTVIWXRSgvV7xz1VqRddE0AHdn3Bmw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Transitive",
@@ -194,8 +194,8 @@
       },
       "Microsoft.ReactNative": {
         "type": "Transitive",
-        "resolved": "0.78.2-Fabric",
-        "contentHash": "YFIUioiHtgR1MdOC+NtqlYGTFz38k5eqTRy4dynrFqe69c7Oj28QJRb2aARBtN2iExLD08Cy9x6T5cHIx9RPZg=="
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "cQULMq+ehY7i6d1QOl9F2/1sR6T2NeGWhOWRPBvdbhr6eqohNgsg2NcKNTVIWXRSgvV7xz1VqRddE0AHdn3Bmw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Transitive",
@@ -221,8 +221,8 @@
       },
       "Microsoft.ReactNative": {
         "type": "Transitive",
-        "resolved": "0.78.2-Fabric",
-        "contentHash": "YFIUioiHtgR1MdOC+NtqlYGTFz38k5eqTRy4dynrFqe69c7Oj28QJRb2aARBtN2iExLD08Cy9x6T5cHIx9RPZg=="
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "cQULMq+ehY7i6d1QOl9F2/1sR6T2NeGWhOWRPBvdbhr6eqohNgsg2NcKNTVIWXRSgvV7xz1VqRddE0AHdn3Bmw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Transitive",
@@ -248,8 +248,8 @@
       },
       "Microsoft.ReactNative": {
         "type": "Transitive",
-        "resolved": "0.78.2-Fabric",
-        "contentHash": "YFIUioiHtgR1MdOC+NtqlYGTFz38k5eqTRy4dynrFqe69c7Oj28QJRb2aARBtN2iExLD08Cy9x6T5cHIx9RPZg=="
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "cQULMq+ehY7i6d1QOl9F2/1sR6T2NeGWhOWRPBvdbhr6eqohNgsg2NcKNTVIWXRSgvV7xz1VqRddE0AHdn3Bmw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Transitive",

--- a/samples/NativeModuleSample/cpp-lib/example/windows/NativeModuleSampleExample/packages.lock.json
+++ b/samples/NativeModuleSample/cpp-lib/example/windows/NativeModuleSampleExample/packages.lock.json
@@ -16,17 +16,17 @@
       },
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.78.2-Fabric, )",
-        "resolved": "0.78.2-Fabric",
-        "contentHash": "YFIUioiHtgR1MdOC+NtqlYGTFz38k5eqTRy4dynrFqe69c7Oj28QJRb2aARBtN2iExLD08Cy9x6T5cHIx9RPZg=="
+        "requested": "[0.78.4-Fabric, )",
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "cQULMq+ehY7i6d1QOl9F2/1sR6T2NeGWhOWRPBvdbhr6eqohNgsg2NcKNTVIWXRSgvV7xz1VqRddE0AHdn3Bmw=="
       },
       "Microsoft.ReactNative.Cxx": {
         "type": "Direct",
-        "requested": "[0.78.2-Fabric, )",
-        "resolved": "0.78.2-Fabric",
-        "contentHash": "JvXWCbp5EjoE7G/82BHRoIdpK0RkG/PpefzGMnCF0enoOzmOSmWFJmWZQV86lbJQ6BllElCVAGG37z3JYyNqoQ==",
+        "requested": "[0.78.4-Fabric, )",
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "dQmAEkpWEdvTKs9xEWM49XAlq8b5XJpiEl6yk3TFPmDRgnOXdx77KyMqnxt6JgAGPUQ7MvmFTXlYXaAmwxiGig==",
         "dependencies": {
-          "Microsoft.ReactNative": "0.78.2-Fabric"
+          "Microsoft.ReactNative": "0.78.4-Fabric"
         }
       },
       "Microsoft.VCRTForwarders.140": {
@@ -64,8 +64,8 @@
       "nativemodulesample": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.ReactNative": "[0.78.2-Fabric, )",
-          "Microsoft.ReactNative.Cxx": "[0.78.2-Fabric, )",
+          "Microsoft.ReactNative": "[0.78.4-Fabric, )",
+          "Microsoft.ReactNative.Cxx": "[0.78.4-Fabric, )",
           "Microsoft.VCRTForwarders.140": "[1.0.2-rc, )",
           "Microsoft.WindowsAppSDK": "[1.6.240923002, )",
           "boost": "[1.83.0, )"
@@ -75,9 +75,9 @@
     "native,Version=v0.0/win": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.78.2-Fabric, )",
-        "resolved": "0.78.2-Fabric",
-        "contentHash": "YFIUioiHtgR1MdOC+NtqlYGTFz38k5eqTRy4dynrFqe69c7Oj28QJRb2aARBtN2iExLD08Cy9x6T5cHIx9RPZg=="
+        "requested": "[0.78.4-Fabric, )",
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "cQULMq+ehY7i6d1QOl9F2/1sR6T2NeGWhOWRPBvdbhr6eqohNgsg2NcKNTVIWXRSgvV7xz1VqRddE0AHdn3Bmw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -104,9 +104,9 @@
     "native,Version=v0.0/win-arm64": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.78.2-Fabric, )",
-        "resolved": "0.78.2-Fabric",
-        "contentHash": "YFIUioiHtgR1MdOC+NtqlYGTFz38k5eqTRy4dynrFqe69c7Oj28QJRb2aARBtN2iExLD08Cy9x6T5cHIx9RPZg=="
+        "requested": "[0.78.4-Fabric, )",
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "cQULMq+ehY7i6d1QOl9F2/1sR6T2NeGWhOWRPBvdbhr6eqohNgsg2NcKNTVIWXRSgvV7xz1VqRddE0AHdn3Bmw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -133,9 +133,9 @@
     "native,Version=v0.0/win-x64": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.78.2-Fabric, )",
-        "resolved": "0.78.2-Fabric",
-        "contentHash": "YFIUioiHtgR1MdOC+NtqlYGTFz38k5eqTRy4dynrFqe69c7Oj28QJRb2aARBtN2iExLD08Cy9x6T5cHIx9RPZg=="
+        "requested": "[0.78.4-Fabric, )",
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "cQULMq+ehY7i6d1QOl9F2/1sR6T2NeGWhOWRPBvdbhr6eqohNgsg2NcKNTVIWXRSgvV7xz1VqRddE0AHdn3Bmw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -162,9 +162,9 @@
     "native,Version=v0.0/win-x86": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.78.2-Fabric, )",
-        "resolved": "0.78.2-Fabric",
-        "contentHash": "YFIUioiHtgR1MdOC+NtqlYGTFz38k5eqTRy4dynrFqe69c7Oj28QJRb2aARBtN2iExLD08Cy9x6T5cHIx9RPZg=="
+        "requested": "[0.78.4-Fabric, )",
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "cQULMq+ehY7i6d1QOl9F2/1sR6T2NeGWhOWRPBvdbhr6eqohNgsg2NcKNTVIWXRSgvV7xz1VqRddE0AHdn3Bmw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",

--- a/samples/NativeModuleSample/cpp-lib/package.json
+++ b/samples/NativeModuleSample/cpp-lib/package.json
@@ -54,7 +54,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
-    "@react-native-community/cli": "15.0.0-alpha.2",
+    "@react-native-community/cli": "15.0.0",
     "@react-native/eslint-config": "0.78.0",
     "@types/jest": "^29.5.5",
     "@types/react": "19.0.0",
@@ -66,7 +66,7 @@
     "react": "19.0.0",
     "react-native": "0.78.0",
     "react-native-builder-bob": "^0.31.0",
-    "react-native-windows": "0.78.2",
+    "react-native-windows": "0.78.4",
     "typescript": "^5.2.2"
   },
   "resolutions": {

--- a/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/codegen/react/components/NativeModuleSampleSpec/CircleMask.g.h
+++ b/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/codegen/react/components/NativeModuleSampleSpec/CircleMask.g.h
@@ -150,7 +150,7 @@ void RegisterCircleMaskNativeComponent(
           builder.SetUpdateStateHandler([](const winrt::Microsoft::ReactNative::ComponentView &view,
                                      const winrt::Microsoft::ReactNative::IComponentState &newState) noexcept {
             auto userData = view.UserData().as<TUserData>();
-            userData->member(view, newState);
+            userData->UpdateState(view, newState);
           });
         }
 

--- a/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/packages.lock.json
+++ b/samples/NativeModuleSample/cpp-lib/windows/NativeModuleSample/packages.lock.json
@@ -2,29 +2,32 @@
   "version": 1,
   "dependencies": {
     "native,Version=v0.0": {
+      "boost": {
+        "type": "Direct",
+        "requested": "[1.83.0, )",
+        "resolved": "1.83.0",
+        "contentHash": "cy53VNMzysEMvhBixDe8ujPk67Fcj3v6FPHQnH91NYJNLHpc6jxa2xq9ruCaaJjE4M3YrGSHDi4uUSTGBWw6EQ=="
+      },
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.78.2, )",
-        "resolved": "0.78.2",
-        "contentHash": "dC8qT8Y7PX8LmOfSE+Xh3Mt6a7r7EHx1wO6mI3ZGU9kTahqtf759fE0oatydEgvCvugYvZIu0BFarZpvVSOmhA=="
+        "requested": "[0.78.4-Fabric, )",
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "cQULMq+ehY7i6d1QOl9F2/1sR6T2NeGWhOWRPBvdbhr6eqohNgsg2NcKNTVIWXRSgvV7xz1VqRddE0AHdn3Bmw=="
       },
       "Microsoft.ReactNative.Cxx": {
         "type": "Direct",
-        "requested": "[0.78.2, )",
-        "resolved": "0.78.2",
-        "contentHash": "b37+ruqhuA/HCi8TYVAcklgSdiBUhHyU3/0RJbcdWSyXrACVY10pTGR4tgzFjU8APwl5hAR+Q8zBj2ObMnkK1A==",
+        "requested": "[0.78.4-Fabric, )",
+        "resolved": "0.78.4-Fabric",
+        "contentHash": "dQmAEkpWEdvTKs9xEWM49XAlq8b5XJpiEl6yk3TFPmDRgnOXdx77KyMqnxt6JgAGPUQ7MvmFTXlYXaAmwxiGig==",
         "dependencies": {
-          "Microsoft.ReactNative": "0.78.2"
+          "Microsoft.ReactNative": "0.78.4-Fabric"
         }
       },
-      "Microsoft.UI.Xaml": {
+      "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
-        "requested": "[2.8.0, )",
-        "resolved": "2.8.0",
-        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
-        "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.1264.42"
-        }
+        "requested": "[1.0.2-rc, )",
+        "resolved": "1.0.2-rc",
+        "contentHash": "/r+sjtEeCIGyDhobIZ5hSmYhC/dSyGZxf1SxYJpElUhB0LMCktOMFs9gXrauXypIFECpVynNyVjAmJt6hjJ5oQ=="
       },
       "Microsoft.Windows.CppWinRT": {
         "type": "Direct",
@@ -32,10 +35,25 @@
         "resolved": "2.0.230706.1",
         "contentHash": "l0D7oCw/5X+xIKHqZTi62TtV+1qeSz7KVluNFdrJ9hXsst4ghvqQ/Yhura7JqRdZWBXAuDS0G0KwALptdoxweQ=="
       },
+      "Microsoft.WindowsAppSDK": {
+        "type": "Direct",
+        "requested": "[1.6.240923002, )",
+        "resolved": "1.6.240923002",
+        "contentHash": "7PfOz2scXU+AAM/GYge+f6s7k3DVI+R1P8MNPZQr56GOPCGw+csvcg3S5KZg47z/o04kNvWH3GKtWT1ML9tpZw==",
+        "dependencies": {
+          "Microsoft.Web.WebView2": "1.0.2651.64",
+          "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
+        }
+      },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+        "resolved": "1.0.2651.64",
+        "contentHash": "f5sc/vcAoTCTEW7Nqzp4galAuTRguZViw8ksn+Nx2uskEBPm0/ubzy6gVjvXS/P96jLS89C8T9I0hPc417xpNg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Transitive",
+        "resolved": "10.0.22621.756",
+        "contentHash": "7ZL2sFSioYm1Ry067Kw1hg0SCcW5kuVezC2SwjGbcPE61Nn+gTbH86T73G3LcEOVj0S3IZzNuE/29gZvOLS7VA=="
       }
     }
   }

--- a/samples/NativeModuleSample/cpp-lib/yarn.lock
+++ b/samples/NativeModuleSample/cpp-lib/yarn.lock
@@ -2296,50 +2296,109 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-clean@npm:15.0.0-alpha.2":
-  version: 15.0.0-alpha.2
-  resolution: "@react-native-community/cli-clean@npm:15.0.0-alpha.2"
+"@react-native-community/cli-clean@npm:15.0.0":
+  version: 15.0.0
+  resolution: "@react-native-community/cli-clean@npm:15.0.0"
   dependencies:
-    "@react-native-community/cli-tools": 15.0.0-alpha.2
+    "@react-native-community/cli-tools": 15.0.0
     chalk: ^4.1.2
     execa: ^5.0.0
     fast-glob: ^3.3.2
-  checksum: 2dcf0019aaaea1972324b47cf1fdc0912c8e76ee70e46c0399467e629f7fc3b20dec4065f37a69ffb1bda75c9e8300800868b05df92371a62a116abfed15865c
+  checksum: ccea833beddf18b9d115cff25a9bd2bac785308c67a4105977362fef3478327a9a9990c8d79ef9519e3eb8761b71c683ff3f5bd84fcf0403970b26893979084b
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-config@npm:15.0.0-alpha.2":
-  version: 15.0.0-alpha.2
-  resolution: "@react-native-community/cli-config@npm:15.0.0-alpha.2"
+"@react-native-community/cli-clean@npm:15.1.3":
+  version: 15.1.3
+  resolution: "@react-native-community/cli-clean@npm:15.1.3"
   dependencies:
-    "@react-native-community/cli-tools": 15.0.0-alpha.2
+    "@react-native-community/cli-tools": 15.1.3
+    chalk: ^4.1.2
+    execa: ^5.0.0
+    fast-glob: ^3.3.2
+  checksum: 95777b9786a0e7787033d251258e7dbacd530c31bd2f2919798643e9bebb94aa07b9936d9f65c68db199deeb7d4fd66fa993d0e89e40c61c2d014580da3da2f8
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli-config-android@npm:15.1.3":
+  version: 15.1.3
+  resolution: "@react-native-community/cli-config-android@npm:15.1.3"
+  dependencies:
+    "@react-native-community/cli-tools": 15.1.3
+    chalk: ^4.1.2
+    fast-glob: ^3.3.2
+    fast-xml-parser: ^4.4.1
+  checksum: 07c207c5b9d9f21240c40c771a8761709c6f62e2d01272ca83d1649c728569e5447c172b0ef8868f1ba188217591fe63b731578cc2cec8b3c8705d4056e03186
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli-config-apple@npm:15.1.3":
+  version: 15.1.3
+  resolution: "@react-native-community/cli-config-apple@npm:15.1.3"
+  dependencies:
+    "@react-native-community/cli-tools": 15.1.3
+    chalk: ^4.1.2
+    execa: ^5.0.0
+    fast-glob: ^3.3.2
+  checksum: 8c956e15505fd2753b2b8c5bf3a2b8838bb637ec84e8f44c4c29b12b1b60b601779611655eaa0adefe54d693818d7888eb77e07a0f915a3709c35d9c72e306a3
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli-config@npm:15.0.0":
+  version: 15.0.0
+  resolution: "@react-native-community/cli-config@npm:15.0.0"
+  dependencies:
+    "@react-native-community/cli-tools": 15.0.0
     chalk: ^4.1.2
     cosmiconfig: ^9.0.0
     deepmerge: ^4.3.0
     fast-glob: ^3.3.2
     joi: ^17.2.1
-  checksum: 2774c0b312d98637ade4c1429850588f267bb9b02361f88340a127436dfb61308072c88e3ed8e18ccb17c6f8ed6837589b5ad3717ddf8ea0402cf81029ae3665
+  checksum: 90b4e443c4ad5ee83ebd8d8f29e568fbc536054c4a617c8acd62ea2b5ce694900909abdee999e6f11e696f7febb7687589a30792ccc8d470dcf8895d05165bab
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-debugger-ui@npm:15.0.0-alpha.2":
-  version: 15.0.0-alpha.2
-  resolution: "@react-native-community/cli-debugger-ui@npm:15.0.0-alpha.2"
+"@react-native-community/cli-config@npm:15.1.3":
+  version: 15.1.3
+  resolution: "@react-native-community/cli-config@npm:15.1.3"
+  dependencies:
+    "@react-native-community/cli-tools": 15.1.3
+    chalk: ^4.1.2
+    cosmiconfig: ^9.0.0
+    deepmerge: ^4.3.0
+    fast-glob: ^3.3.2
+    joi: ^17.2.1
+  checksum: 3e8fc8fc9f683ddebe8177b38ba5811e18456c5da3f2779796e9491733a0aae0f3c0dcc431ceaa1622fcef5276cfb8e10bed91cb7a9bf1243bd5d585bc0a4e56
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli-debugger-ui@npm:15.0.0":
+  version: 15.0.0
+  resolution: "@react-native-community/cli-debugger-ui@npm:15.0.0"
   dependencies:
     serve-static: ^1.13.1
-  checksum: b25322f1f672edc13db631629bbeda0467a645cc5ccf87f99715797f275e35909683ba44601ad23a85d49b6ddc02a6bf94f585010985aaf829ce849ccd8a5960
+  checksum: ebb275a90cf0a15b9773fe4d6e14a008bd899e1e0fca6ea1ad7c9d9c48e240e48c52c8b9d5b72e3e4b8a419c43ffdf00845b0b9fdc862a021b2d07d9953ecf6a
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-doctor@npm:15.0.0-alpha.2":
-  version: 15.0.0-alpha.2
-  resolution: "@react-native-community/cli-doctor@npm:15.0.0-alpha.2"
+"@react-native-community/cli-debugger-ui@npm:15.1.3":
+  version: 15.1.3
+  resolution: "@react-native-community/cli-debugger-ui@npm:15.1.3"
   dependencies:
-    "@react-native-community/cli-config": 15.0.0-alpha.2
-    "@react-native-community/cli-platform-android": 15.0.0-alpha.2
-    "@react-native-community/cli-platform-apple": 15.0.0-alpha.2
-    "@react-native-community/cli-platform-ios": 15.0.0-alpha.2
-    "@react-native-community/cli-tools": 15.0.0-alpha.2
+    serve-static: ^1.13.1
+  checksum: 0f52a737cfd4ee8d7d735f7031590e02f127df9e7cde78653c68ec694a4806eec6ce641406f5ce7ae50947e44f02cff5c4ec94d5fb76e372b42d12f78d3f49ed
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli-doctor@npm:15.0.0":
+  version: 15.0.0
+  resolution: "@react-native-community/cli-doctor@npm:15.0.0"
+  dependencies:
+    "@react-native-community/cli-config": 15.0.0
+    "@react-native-community/cli-platform-android": 15.0.0
+    "@react-native-community/cli-platform-apple": 15.0.0
+    "@react-native-community/cli-platform-ios": 15.0.0
+    "@react-native-community/cli-tools": 15.0.0
     chalk: ^4.1.2
     command-exists: ^1.2.8
     deepmerge: ^4.3.0
@@ -2351,53 +2410,112 @@ __metadata:
     strip-ansi: ^5.2.0
     wcwidth: ^1.0.1
     yaml: ^2.2.1
-  checksum: 9dae312408d663e3da6258352bb4aa572042aa2e16941b2da9f0db387af5e0a1d7bd494a75145c6077a98d3232322a4dc26d82360e9e92726480ff53e02c73fa
+  checksum: 6584785c59da5cf12587ceb1f444a49bec768f02666257ead7c606d77b76a848a6dc4d94017c797008c36e7a35462d4be38f1e500ea08a12bceda35ef2ed6cb1
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-platform-android@npm:15.0.0-alpha.2":
-  version: 15.0.0-alpha.2
-  resolution: "@react-native-community/cli-platform-android@npm:15.0.0-alpha.2"
+"@react-native-community/cli-doctor@npm:15.1.3":
+  version: 15.1.3
+  resolution: "@react-native-community/cli-doctor@npm:15.1.3"
   dependencies:
-    "@react-native-community/cli-tools": 15.0.0-alpha.2
+    "@react-native-community/cli-config": 15.1.3
+    "@react-native-community/cli-platform-android": 15.1.3
+    "@react-native-community/cli-platform-apple": 15.1.3
+    "@react-native-community/cli-platform-ios": 15.1.3
+    "@react-native-community/cli-tools": 15.1.3
+    chalk: ^4.1.2
+    command-exists: ^1.2.8
+    deepmerge: ^4.3.0
+    envinfo: ^7.13.0
+    execa: ^5.0.0
+    node-stream-zip: ^1.9.1
+    ora: ^5.4.1
+    semver: ^7.5.2
+    strip-ansi: ^5.2.0
+    wcwidth: ^1.0.1
+    yaml: ^2.2.1
+  checksum: 9be335ef0203b15d20d8b13f052a742f6faf67435c614ad9e714707ebc04d76a0a8845baafa49e80d05f3fe3822c4020cc60a568c1c4564a50e8d35bea7e3169
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli-platform-android@npm:15.0.0":
+  version: 15.0.0
+  resolution: "@react-native-community/cli-platform-android@npm:15.0.0"
+  dependencies:
+    "@react-native-community/cli-tools": 15.0.0
     chalk: ^4.1.2
     execa: ^5.0.0
     fast-glob: ^3.3.2
     fast-xml-parser: ^4.4.1
     logkitty: ^0.7.1
-  checksum: 05fe7d0b09f63d7d3236c5cf16426a535c428c50e099f5262d6f530778c71bbf7018d0af98215d88dc09c34506178909e0d041d5ae390b3d06cd783d48037953
+  checksum: 464ab550fde173dbf37b37725ab6272f341c9550660943108e15e20ed041c36a68a99bbcf7c8359771984fea2f5268b6cf1fdc8c197698bdb4f2d76dd510402d
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-platform-apple@npm:15.0.0-alpha.2":
-  version: 15.0.0-alpha.2
-  resolution: "@react-native-community/cli-platform-apple@npm:15.0.0-alpha.2"
+"@react-native-community/cli-platform-android@npm:15.1.3, @react-native-community/cli-platform-android@npm:^15.0.0":
+  version: 15.1.3
+  resolution: "@react-native-community/cli-platform-android@npm:15.1.3"
   dependencies:
-    "@react-native-community/cli-tools": 15.0.0-alpha.2
+    "@react-native-community/cli-config-android": 15.1.3
+    "@react-native-community/cli-tools": 15.1.3
+    chalk: ^4.1.2
+    execa: ^5.0.0
+    logkitty: ^0.7.1
+  checksum: 5fd57035dfc3a07f0bab42acb816fd2fbdb81a5aac21fc5f6c2b389611ffac571a99deb99e36858771c0480087e02b30a8a584e69fcba5ad5b5a8b241aa3d886
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli-platform-apple@npm:15.0.0":
+  version: 15.0.0
+  resolution: "@react-native-community/cli-platform-apple@npm:15.0.0"
+  dependencies:
+    "@react-native-community/cli-tools": 15.0.0
     chalk: ^4.1.2
     execa: ^5.0.0
     fast-glob: ^3.3.2
     fast-xml-parser: ^4.4.1
     ora: ^5.4.1
-  checksum: 4703445b076262c9a8fffdf142b8cfb9d8b656ec284754ef5d6e7d5cc72f7d9a8e908c5bbbaace35f577c2a15ec4a74117f29a8f51f69499abd8025c55b07cb1
+  checksum: b9c0a50980c29c43f699f209dc975e3de81fda7602eef66fd8c8ecac33c17daac74e8285664f4d652f15a0c7ae4a338726c54ca593364bc1af14b8f9a562a4cf
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-platform-ios@npm:15.0.0-alpha.2":
-  version: 15.0.0-alpha.2
-  resolution: "@react-native-community/cli-platform-ios@npm:15.0.0-alpha.2"
+"@react-native-community/cli-platform-apple@npm:15.1.3":
+  version: 15.1.3
+  resolution: "@react-native-community/cli-platform-apple@npm:15.1.3"
   dependencies:
-    "@react-native-community/cli-platform-apple": 15.0.0-alpha.2
-  checksum: 485cfe403b30be954848df229a838caac03571941efc3c20280f5c1f26c8cc228dc507e00f65f876d196708b5beb2b433f83fd8b1920880c370be448fe11531b
+    "@react-native-community/cli-config-apple": 15.1.3
+    "@react-native-community/cli-tools": 15.1.3
+    chalk: ^4.1.2
+    execa: ^5.0.0
+    fast-xml-parser: ^4.4.1
+  checksum: 380d9abbb7667ec377c36fdd2f3139c4df24fdb64900fc45a40205d30791caf02406241a1073080c8276b635d24c967314134acd01d228cd50da0459c3e48204
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-server-api@npm:15.0.0-alpha.2":
-  version: 15.0.0-alpha.2
-  resolution: "@react-native-community/cli-server-api@npm:15.0.0-alpha.2"
+"@react-native-community/cli-platform-ios@npm:15.0.0":
+  version: 15.0.0
+  resolution: "@react-native-community/cli-platform-ios@npm:15.0.0"
   dependencies:
-    "@react-native-community/cli-debugger-ui": 15.0.0-alpha.2
-    "@react-native-community/cli-tools": 15.0.0-alpha.2
+    "@react-native-community/cli-platform-apple": 15.0.0
+  checksum: 8394161e6d64f720699bb2e34f9e58cb242ea331eeda32026762c20200f8ea3c5334f60ac770c61a13684cb8836755b6ccaf51da5a4f3ea89c416b163f2b68f2
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli-platform-ios@npm:15.1.3, @react-native-community/cli-platform-ios@npm:^15.0.0":
+  version: 15.1.3
+  resolution: "@react-native-community/cli-platform-ios@npm:15.1.3"
+  dependencies:
+    "@react-native-community/cli-platform-apple": 15.1.3
+  checksum: b99e0a2b51ca1be631e94ce7061b353811bf1b146e670928ae890287380ac652ae48e16f67751d4a772b2035781cf0a55847bb18648359048536d2d314c3ed97
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli-server-api@npm:15.0.0":
+  version: 15.0.0
+  resolution: "@react-native-community/cli-server-api@npm:15.0.0"
+  dependencies:
+    "@react-native-community/cli-debugger-ui": 15.0.0
+    "@react-native-community/cli-tools": 15.0.0
     compression: ^1.7.1
     connect: ^3.6.5
     errorhandler: ^1.5.1
@@ -2405,13 +2523,30 @@ __metadata:
     pretty-format: ^26.6.2
     serve-static: ^1.13.1
     ws: ^6.2.3
-  checksum: c447a0017bb743028aad8f26bc25aa0a4e6b3054a2b722ee7c8a7f1ca14b708f2b9cdea041d154e8ed6e1190bb7fbe04dada2a4529a200e138fc976f4b113b9e
+  checksum: c1203419f92b85ad0e0ae48389068c7e74e5e8d519366544b5ebbd8f4a2c4306b21aa8ad6f735534f7dcc5740f089e07b2be4f098533d4fffd09715cbff5cee3
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-tools@npm:15.0.0-alpha.2":
-  version: 15.0.0-alpha.2
-  resolution: "@react-native-community/cli-tools@npm:15.0.0-alpha.2"
+"@react-native-community/cli-server-api@npm:15.1.3":
+  version: 15.1.3
+  resolution: "@react-native-community/cli-server-api@npm:15.1.3"
+  dependencies:
+    "@react-native-community/cli-debugger-ui": 15.1.3
+    "@react-native-community/cli-tools": 15.1.3
+    compression: ^1.7.1
+    connect: ^3.6.5
+    errorhandler: ^1.5.1
+    nocache: ^3.0.1
+    pretty-format: ^26.6.2
+    serve-static: ^1.13.1
+    ws: ^6.2.3
+  checksum: 2bc164d6fc33298b3df8fbe6b27745b72ea3287a4b87c1dd32a77c8a277b62882d6cec3c12915496568d04ee3989ad01de81b4088b18cd40ddd5cb0532260903
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli-tools@npm:15.0.0":
+  version: 15.0.0
+  resolution: "@react-native-community/cli-tools@npm:15.0.0"
   dependencies:
     appdirsjs: ^1.2.4
     chalk: ^4.1.2
@@ -2420,33 +2555,62 @@ __metadata:
     mime: ^2.4.1
     open: ^6.2.0
     ora: ^5.4.1
+    prompts: ^2.4.2
     semver: ^7.5.2
     shell-quote: ^1.7.3
     sudo-prompt: ^9.0.0
-  checksum: 15f996ee45d957ef2ee134634f02eb8921263cff4cb009d7373be4c468295d001137f5b09430117c68700e860ed4431cd6b0dc6ecf905f7e8208e8d84d356412
+  checksum: c4b9a4b5824ac4a58131ece2dbef264506c879e61c5b031410a2c9e88fa5dbb3fa2ebf1b7551704826bb55cfb21c8dcd8b20875e7194e2842b4aa492b0a80b70
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-types@npm:15.0.0-alpha.2":
-  version: 15.0.0-alpha.2
-  resolution: "@react-native-community/cli-types@npm:15.0.0-alpha.2"
+"@react-native-community/cli-tools@npm:15.1.3":
+  version: 15.1.3
+  resolution: "@react-native-community/cli-tools@npm:15.1.3"
+  dependencies:
+    appdirsjs: ^1.2.4
+    chalk: ^4.1.2
+    execa: ^5.0.0
+    find-up: ^5.0.0
+    mime: ^2.4.1
+    open: ^6.2.0
+    ora: ^5.4.1
+    prompts: ^2.4.2
+    semver: ^7.5.2
+    shell-quote: ^1.7.3
+    sudo-prompt: ^9.0.0
+  checksum: f62997b7ed16df5beffc699c7556eebe0b27a63ac0b10dcf8af3e2875231183752e4a1a7e55e9d60f0b9cbfd7c3a2dd264eccc0e3430b81660538e27d5deffc8
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli-types@npm:15.0.0":
+  version: 15.0.0
+  resolution: "@react-native-community/cli-types@npm:15.0.0"
   dependencies:
     joi: ^17.2.1
-  checksum: 50de0db59c79ff4a302f8fa2b29d2cc3d3e7bc6a3c0c346dd4b1c26c90796a65c4ba6230c2de0b619e5a1548f751a81bad2ef7740367ca4a94da6e02857fd645
+  checksum: c67177ff58d76e08341a8510745d834c9fdabb1f84b3f6d427313c5724b36920ca5844291e9690f0c95a9626bba9745f688f6573237c48ddd127c9dc939f81fe
   languageName: node
   linkType: hard
 
-"@react-native-community/cli@npm:15.0.0-alpha.2":
-  version: 15.0.0-alpha.2
-  resolution: "@react-native-community/cli@npm:15.0.0-alpha.2"
+"@react-native-community/cli-types@npm:15.1.3":
+  version: 15.1.3
+  resolution: "@react-native-community/cli-types@npm:15.1.3"
   dependencies:
-    "@react-native-community/cli-clean": 15.0.0-alpha.2
-    "@react-native-community/cli-config": 15.0.0-alpha.2
-    "@react-native-community/cli-debugger-ui": 15.0.0-alpha.2
-    "@react-native-community/cli-doctor": 15.0.0-alpha.2
-    "@react-native-community/cli-server-api": 15.0.0-alpha.2
-    "@react-native-community/cli-tools": 15.0.0-alpha.2
-    "@react-native-community/cli-types": 15.0.0-alpha.2
+    joi: ^17.2.1
+  checksum: 5551e218499645ec7f1c8c3e24cfed427a5b4fab54d376b20f04fbe6b304bbf7dc69a7e64677e10c5d263ab8d98a37cb26d006ce0bcdad0d9710e09568fd297e
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli@npm:15.0.0":
+  version: 15.0.0
+  resolution: "@react-native-community/cli@npm:15.0.0"
+  dependencies:
+    "@react-native-community/cli-clean": 15.0.0
+    "@react-native-community/cli-config": 15.0.0
+    "@react-native-community/cli-debugger-ui": 15.0.0
+    "@react-native-community/cli-doctor": 15.0.0
+    "@react-native-community/cli-server-api": 15.0.0
+    "@react-native-community/cli-tools": 15.0.0
+    "@react-native-community/cli-types": 15.0.0
     chalk: ^4.1.2
     commander: ^9.4.1
     deepmerge: ^4.3.0
@@ -2458,15 +2622,41 @@ __metadata:
     semver: ^7.5.2
   bin:
     rnc-cli: build/bin.js
-  checksum: 8cc2c7c111e40aca6726e53a2abf97c065964274493770db4066e373387b2acd2584ba917f2a265cca7eca478b7b25de1fdf9bd4262b0012f1dc6a7828fe4ef9
+  checksum: f056899a3537982efbb5a918e421b6dd9a090b33d95ee89182a0d626013bf56b4456e3e4308498b52d1f8db31bfd309183bca652cef606dad8cf0fd3395b25bf
   languageName: node
   linkType: hard
 
-"@react-native-windows/cli@npm:0.78.0":
-  version: 0.78.0
-  resolution: "@react-native-windows/cli@npm:0.78.0"
+"@react-native-community/cli@npm:^15.0.0":
+  version: 15.1.3
+  resolution: "@react-native-community/cli@npm:15.1.3"
   dependencies:
-    "@react-native-windows/codegen": 0.78.0
+    "@react-native-community/cli-clean": 15.1.3
+    "@react-native-community/cli-config": 15.1.3
+    "@react-native-community/cli-debugger-ui": 15.1.3
+    "@react-native-community/cli-doctor": 15.1.3
+    "@react-native-community/cli-server-api": 15.1.3
+    "@react-native-community/cli-tools": 15.1.3
+    "@react-native-community/cli-types": 15.1.3
+    chalk: ^4.1.2
+    commander: ^9.4.1
+    deepmerge: ^4.3.0
+    execa: ^5.0.0
+    find-up: ^5.0.0
+    fs-extra: ^8.1.0
+    graceful-fs: ^4.1.3
+    prompts: ^2.4.2
+    semver: ^7.5.2
+  bin:
+    rnc-cli: build/bin.js
+  checksum: 165c946856b5c4d6eadb0f8b9e29dfa0ab197bf43ce63179ca781d45163419fa9e85c3721be6908b6850415cd25d84bef63b4a61b78b5d44cae22ec21a92efec
+  languageName: node
+  linkType: hard
+
+"@react-native-windows/cli@npm:0.78.2":
+  version: 0.78.2
+  resolution: "@react-native-windows/cli@npm:0.78.2"
+  dependencies:
+    "@react-native-windows/codegen": 0.78.1
     "@react-native-windows/fs": 0.78.0
     "@react-native-windows/package-utils": 0.78.0
     "@react-native-windows/telemetry": 0.78.0
@@ -2488,13 +2678,13 @@ __metadata:
     xpath: ^0.0.27
   peerDependencies:
     react-native: "*"
-  checksum: 657aff4bfbf5d1d3a7d89323cc08c8e0bb45f325fb4dc723d75ef62a3ffed54c37c068e805206a9da2b38030da4ce155be81dab25998f9c3f7e1a208e132adf9
+  checksum: 6f7564b4c2e42d3b0edf4bd058e29a50b728f74856a8e56e3df280f7d963f7f8d97d580737aa7127b3e57f302b036dca6790fed890c924959e9109f2b5228a78
   languageName: node
   linkType: hard
 
-"@react-native-windows/codegen@npm:0.78.0":
-  version: 0.78.0
-  resolution: "@react-native-windows/codegen@npm:0.78.0"
+"@react-native-windows/codegen@npm:0.78.1":
+  version: 0.78.1
+  resolution: "@react-native-windows/codegen@npm:0.78.1"
   dependencies:
     "@react-native-windows/fs": 0.78.0
     chalk: ^4.1.0
@@ -2506,7 +2696,7 @@ __metadata:
     react-native: "*"
   bin:
     react-native-windows-codegen: bin.js
-  checksum: 4df431b8ac67520fdc0428730869fae5e3636f3dc56940833369f27045f15a697d19886c7788bed7ce004b0588df6a2f29dad6a354aadc9d1c1c70922e157fe7
+  checksum: 9c111edeef0e650e7a957b52c4e8dc16bfd1ab53d784e451b9f78c765af260bbb78223bff0126f43463d5525bf5b251b850699ec3b8df773f7d8d8817bf45159
   languageName: node
   linkType: hard
 
@@ -8192,16 +8382,16 @@ __metadata:
     "@babel/core": ^7.25.2
     "@babel/preset-env": ^7.25.3
     "@babel/runtime": ^7.25.0
-    "@react-native-community/cli": 15.0.0-alpha.2
-    "@react-native-community/cli-platform-android": 15.0.0-alpha.2
-    "@react-native-community/cli-platform-ios": 15.0.0-alpha.2
+    "@react-native-community/cli": 15.0.0
+    "@react-native-community/cli-platform-android": 15.0.0
+    "@react-native-community/cli-platform-ios": 15.0.0
     "@react-native/babel-preset": 0.78.0
     "@react-native/metro-config": 0.78.0
     "@react-native/typescript-config": 0.78.0
     "@rnx-kit/jest-preset": ^0.1.17
     react: 19.0.0
     react-native: 0.78.0
-    react-native-windows: 0.78.2
+    react-native-windows: 0.78.4
   languageName: unknown
   linkType: soft
 
@@ -8212,16 +8402,16 @@ __metadata:
     "@babel/core": ^7.25.2
     "@babel/preset-env": ^7.25.3
     "@babel/runtime": ^7.25.0
-    "@react-native-community/cli": 15.0.0-alpha.2
-    "@react-native-community/cli-platform-android": 15.0.0-alpha.2
-    "@react-native-community/cli-platform-ios": 15.0.0-alpha.2
+    "@react-native-community/cli": 15.0.0
+    "@react-native-community/cli-platform-android": 15.0.0
+    "@react-native-community/cli-platform-ios": 15.0.0
     "@react-native/babel-preset": 0.78.0
     "@react-native/metro-config": 0.78.0
     "@react-native/typescript-config": 0.78.0
     "@rnx-kit/jest-preset": ^0.1.17
     react: 19.0.0
     react-native: 0.78.0
-    react-native-windows: 0.78.2
+    react-native-windows: 0.78.4
   languageName: unknown
   linkType: soft
 
@@ -8229,7 +8419,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "native-module-sample@workspace:."
   dependencies:
-    "@react-native-community/cli": 15.0.0-alpha.2
+    "@react-native-community/cli": 15.0.0
     "@react-native/eslint-config": 0.78.0
     "@types/jest": ^29.5.5
     "@types/react": 19.0.0
@@ -8241,7 +8431,7 @@ __metadata:
     react: 19.0.0
     react-native: 0.78.0
     react-native-builder-bob: ^0.31.0
-    react-native-windows: 0.78.2
+    react-native-windows: 0.78.4
     typescript: ^5.2.2
   peerDependencies:
     react: "*"
@@ -9078,16 +9268,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-windows@npm:0.78.2":
-  version: 0.78.2
-  resolution: "react-native-windows@npm:0.78.2"
+"react-native-windows@npm:0.78.4":
+  version: 0.78.4
+  resolution: "react-native-windows@npm:0.78.4"
   dependencies:
     "@babel/runtime": ^7.0.0
     "@jest/create-cache-key-function": ^29.6.3
-    "@react-native-community/cli": 15.0.0-alpha.2
-    "@react-native-community/cli-platform-android": 15.0.0-alpha.2
-    "@react-native-community/cli-platform-ios": 15.0.0-alpha.2
-    "@react-native-windows/cli": 0.78.0
+    "@react-native-community/cli": ^15.0.0
+    "@react-native-community/cli-platform-android": ^15.0.0
+    "@react-native-community/cli-platform-ios": ^15.0.0
+    "@react-native-windows/cli": 0.78.2
     "@react-native/assets": 1.0.0
     "@react-native/assets-registry": 0.78.0
     "@react-native/codegen": 0.78.0
@@ -9131,7 +9321,7 @@ __metadata:
     "@types/react": ^19.0.0
     react: ^19.0.0
     react-native: ^0.78.0
-  checksum: 3cdae9d59dc26f0ab68de14d72649749e8013b62048669f1a1fe31c321d0453d78f3d798b9fc183685d1161300c228065eddae1e616f1fb556a2852f36662edf
+  checksum: e0194145dac36633fe3ff80730d508d720bbec3032a31155a0f9d45b124fead5d39a9e5b3277df71512bbe68f7ab35544d81e0a6f34d53004d9dc0a0c3d0480f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Upgrade `NativeModuleSample/cpp-lib` to RNW 0.78.4

### Why
The example apps crash when using RNW 0.78.2.

## Screenshots
N/A

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/1027)