### PR TITLE
Add note about Old and New Architectures to relevant docs

### DIFF
--- a/docs/app-publishing.md
+++ b/docs/app-publishing.md
@@ -3,6 +3,8 @@ id: app-publishing
 title: Publishing a React Native Windows App to the Microsoft Store
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 ## Steps to Publish a React Native Windows App to the Microsoft Store
 These are the steps to follow if you are looking to publish a React Native Windows app as a third party to the Microsoft Store. Since React Native Windows apps are Universal Windows Platform (UWP) apps, you can also see [Publish Windows apps - UWP applications | Microsoft Docs](https://docs.microsoft.com/windows/uwp/publish/) for all kinds of documentation on the UWP app publishing process. 
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -3,6 +3,8 @@ id: config
 title: React Native Config Schema
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 The CLI command [`npx react-native config`](https://github.com/react-native-community/cli/blob/master/docs/commands.md#config) outputs project and dependencies configuration in JSON format to `stdout`.
 
 The following describes the schema for projects and dependencies provided by React Native for Windows.

--- a/docs/customizing-SDK-versions.md
+++ b/docs/customizing-SDK-versions.md
@@ -3,6 +3,8 @@ id: customizing-sdk-versions
 title: Customizing SDK versions
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 It is easy for an app to customize which versions of the Windows SDK and WinUI 2.x to use.
 
 ### Details

--- a/docs/debugging-javascript.md
+++ b/docs/debugging-javascript.md
@@ -3,6 +3,8 @@ id: debugging-javascript
 title: JavaScript Debugging
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 This page details how to debug the JavaScript code in your RNW applications, including which tools are supported in which scenarios. You have two different options: *Direct Debugging* and *Web Debugging*.
 
 > Unless stated otherwise, each of the debugging scenarios detailed below assume you're loading your JS bundle from the Metro Packager, not loading a prebuilt bundle file.

--- a/docs/flyout-component-windows.md
+++ b/docs/flyout-component-windows.md
@@ -3,6 +3,8 @@ id: flyout-component
 title: Flyout
 ---
 
+> **Old Architecture Only:** This documentation describes a feature only supported by React Native's "Old" or "Legacy" Architecture. We are still in the progress of updating all of the documentation, but in the meantime, for information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 # Reference
 
 ## Props

--- a/docs/glyph-component-windows.md
+++ b/docs/glyph-component-windows.md
@@ -3,6 +3,8 @@ id: glyph-component
 title: Glyph
 ---
 
+> **Old Architecture Only:** This documentation describes a feature only supported by React Native's "Old" or "Legacy" Architecture. We are still in the progress of updating all of the documentation, but in the meantime, for information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 # Reference
 
 ## Props

--- a/docs/managing-cpp-deps.md
+++ b/docs/managing-cpp-deps.md
@@ -3,6 +3,8 @@ id: managing-cpp-deps
 title: Managing C++ dependencies
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 Details to consider when consuming community modules or other Visual C++ projects.
 
 ### Details

--- a/docs/native-code-language-choice.md
+++ b/docs/native-code-language-choice.md
@@ -3,6 +3,8 @@ id: native-code-language-choice
 title: Choosing C++ or C# for native code
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 React Native for Windows supports writing native code in both C++ and C#, but there are trade-offs with each language. The choice of language can impact the compatibility, developer experience, and performance of your project. So whether you're building an app or native module, you should choose the native language that best meets your requirements.
 
 > **Note**: In this document, C++ refers specifically to C++/WinRT.

--- a/docs/native-code.md
+++ b/docs/native-code.md
@@ -3,6 +3,8 @@ id: native-code
 title: Working with native code on Windows
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 ## What is a React Native for Windows app?
 
 When you create a React Native for Windows app targeting React Native's old architecture, you will get a [Universal Windows Platform app](https://docs.microsoft.com/windows/uwp/get-started/universal-application-platform-guide) (aka UWP app).

--- a/docs/native-modules-advanced.md
+++ b/docs/native-modules-advanced.md
@@ -3,6 +3,8 @@ id: native-modules-advanced
 title: Native Modules (Advanced)
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 >**This documentation and the underlying platform code is a work in progress.**
 >**Examples (C# and C++/WinRT):**
 > - [Native Module Sample in `microsoft/react-native-windows-samples`](https://github.com/microsoft/react-native-windows-samples/tree/main/samples/NativeModuleSample)

--- a/docs/native-modules-async.md
+++ b/docs/native-modules-async.md
@@ -3,6 +3,8 @@ id: native-modules-async
 title: Using Asynchronous Windows APIs
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 >**This documentation and the underlying platform code is a work in progress.**
 
 A common scenario for [Native Modules](native-modules.md) is to call one or more native asynchronous methods from a JS asynchronous method. However it may not be immediately obvious how to properly bridge both asynchronous worlds, which can lead to unstable, difficult to debug code.

--- a/docs/native-modules-autolinking.md
+++ b/docs/native-modules-autolinking.md
@@ -3,6 +3,8 @@ id: native-modules-autolinking
 title: Autolinking Native Modules
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 Autolinking is a mechanism that allows your React Native app project to discover and use native modules and view managers provided by React Native libraries.
 
 This document covers autolinking for the Windows platform. It is an extension to the [React Native CLI Autolinking doc](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).

--- a/docs/native-modules-csharp-codegen.md
+++ b/docs/native-modules-csharp-codegen.md
@@ -3,6 +3,8 @@ id: native-modules-csharp-codegen
 title: Compile time code generation for C#
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 >**This documentation and the underlying platform code is a work in progress.**
 
 In previous versions of React Native for Windows, code generation for C# modules was performed using reflection. Since 0.63 we improved this by adding a compile time code generation.

--- a/docs/native-modules-jsvalue.md
+++ b/docs/native-modules-jsvalue.md
@@ -3,6 +3,8 @@ id: native-modules-jsvalue
 title: Using JSValue
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 >**This documentation and the underlying platform code is a work in progress.**
 
 `JSValue` is a native, immutable invariant value type, and is meant to hold any of the commonly used JS types: `bool`s, `int`s, `double`s, `string`s, arrays, and objects. It is provided for native developers (writing native modules or view managers) who want an equivalent to the `folly::dynamic` type that is compatible with the WinRT ABI surface provided by `Microsoft.ReactNative`.

--- a/docs/native-modules-marshalling-data.md
+++ b/docs/native-modules-marshalling-data.md
@@ -3,6 +3,8 @@ id: native-modules-marshalling-data
 title: Marshaling Data
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 >**This documentation and the underlying platform code is a work in progress.**
 
 ## Overview

--- a/docs/native-modules-setup.md
+++ b/docs/native-modules-setup.md
@@ -3,6 +3,8 @@ id: native-modules-setup
 title: Native Module Setup
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 > **This documentation is a work in progress and version-specific. Please check that the version of this document (top of page) matches the version of RN/RNW you're targeting.**
 
 This guide will set you up with our recommendations for authoring a native module for React Native for Windows. After completing this setup, you should be able to answer the question: *Where do I need to implement the native code so it's available at runtime?*

--- a/docs/native-modules-troubleshooting.md
+++ b/docs/native-modules-troubleshooting.md
@@ -3,6 +3,8 @@ id: native-modules-troubleshooting
 title: Troubleshooting Native Modules
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 So you added a new native module or a new method to a module but it isn't working, **now what?!**
 
 ## Common Issues

--- a/docs/native-modules-using.md
+++ b/docs/native-modules-using.md
@@ -3,6 +3,8 @@ id: native-modules-using
 title: Using Community Native Modules
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 Community native modules are usually distributed as npm packages. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry) useful.
 
 Consuming native modules requires updating your app's native build files to depend on the module's native build files, called "linking". Many modules support "autolinking", where these updates are done automatically when running the [run-windows command](run-windows-cli.md). Others may require you to link the module manually.

--- a/docs/native-modules-vs-turbo-modules.md
+++ b/docs/native-modules-vs-turbo-modules.md
@@ -3,6 +3,8 @@ id: native-modules-vs-turbo-modules
 title: Native Modules vs Turbo Modules
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 If you've worked with React Native, you may be familiar with the concept of Native Modules, which allow JavaScript and platform-native code to communicate over the React Native "bridge", which handles cross-platform serialization via JSON.
 
 TurboModules are the next iteration of Native Modules that provide a few extra benefits, in particular these modules use JSI, a JavaScript interface for native code, which allows for more efficient communication between native and JavaScript code than the bridge.

--- a/docs/native-modules.md
+++ b/docs/native-modules.md
@@ -3,6 +3,8 @@ id: native-modules
 title: Native Modules
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 > **This documentation and the underlying platform code is a work in progress.**
 > **Examples (C# and C++/WinRT):**
 >

--- a/docs/nuget.md
+++ b/docs/nuget.md
@@ -3,6 +3,8 @@ id: NuGet
 title: Using Microsoft.ReactNative NuGet packages
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 >**This documentation and the underlying platform code is a work in progress.**
 
 Traditionally, the default for React Native Windows has been to build all code from source. This includes building all the code shipped by the team in the npm package from source. The amount of code is quite large and takes both a long time to build as well as requiring a high-performance computer. Some configurations have problems building this code with only 8 GB of memory. Especially if you are used to working only with managed code, this can be a big surprise.

--- a/docs/popup-component-windows.md
+++ b/docs/popup-component-windows.md
@@ -3,6 +3,8 @@ id: popup-component
 title: Popup
 ---
 
+> **Old Architecture Only:** This documentation describes a feature only supported by React Native's "Old" or "Legacy" Architecture. We are still in the progress of updating all of the documentation, but in the meantime, for information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 # Reference
 
 ## Props

--- a/docs/setup-ci.md
+++ b/docs/setup-ci.md
@@ -3,6 +3,8 @@ id: setup-ci
 title: Setup Continuous Integration Pipeline for an RNW App
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 This guide will help you get started on setting up your very first continuous integration pipeline for a React Native for Windows app.
 
 ## Setting Up a Continuous Integration Pipeline using GitHub Actions

--- a/docs/textinput-component-windows.md
+++ b/docs/textinput-component-windows.md
@@ -3,6 +3,8 @@ id: textinput-component
 title: TextInput
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 # Reference
 
 ## Props

--- a/docs/view-managers.md
+++ b/docs/view-managers.md
@@ -3,6 +3,8 @@ id: view-managers
 title: Native UI Components
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 > **This documentation and the underlying platform code is a work in progress.**
 > **Examples (C# and C++/WinRT):**
 >

--- a/docs/windowsbrush-and-theme.md
+++ b/docs/windowsbrush-and-theme.md
@@ -3,6 +3,8 @@ id: windowsbrush-and-theme
 title: Using PlatformColor and Responding to Themes
 ---
 
+> **Architecture Review Needed:** This documentation was written to support development against React Native's "Old" or "Legacy" Architecture. It *may or may not* be directly applicable to New Architecture development and needs to be reviewed and potentially updated. For information on React Native architectures in React Native Windows, see [New vs. Old Architecture](new-architecture.md).
+
 ## Overview
 
 Windows supports two unique native styling/theming behaviors: one being the dark and light theme changes and the other being adaptive brushes and system colors. This article will show you how to set up your app to listen to theme changes and use the Windows brushes when and where you want.


### PR DESCRIPTION
## Description

This PR adds a notice to the top of every relevant page that is either clearly:

1. *Old Architecture Only*: doc is for Old Architecture features not planned/supported in the New Arch
2. *Architecture Review Needed*: doc may or may not apply to in the new architecture and therefore needs further review.

### Why
Lots of things change with the migration to the New Architecture, and we want to give some warning about docs that may be out of date while we sort out which to update, which to deprecate, etc.

Resolves #1014 

## Screenshots
N/A
