### PR TITLE
Update support page for RNW 0.77

### DIFF
--- a/website/pages/en/support.js
+++ b/website/pages/en/support.js
@@ -16,13 +16,13 @@ The React Native for Windows (RNW) Team strives to provide full support for the 
 | [main](https://www.npmjs.com/package/react-native-windows/v/canary) | [Canary](#canary-support) | *N/A* | *N/A* | *N/A* | *N/A* |
 | [0.79](https://www.npmjs.com/package/react-native-windows/v/latest) | [Active](#active-support) | 06/17/2025 | 06/17/2025 | *TBD* | *TBD* |
 | [0.78](https://www.npmjs.com/package/react-native-windows/v/v0.78-stable) | [Active](#active-support) | 02/27/2025 | 02/27/2025 | 07/31/2025 | 09/30/2025 |
-| [0.77](https://www.npmjs.com/package/react-native-windows/v/v0.77-stable) | [Maintenance](#maintenance-support) | 01/24/2025 | 01/24/2025 | 03/27/2025 | 05/31/2025 |
+| [0.77](https://www.npmjs.com/package/react-native-windows/v/v0.77-stable) | [Unsupported](#unsupported) | 01/24/2025 | 01/24/2025 | 03/27/2025 | 05/31/2025 |
 | [0.76](https://www.npmjs.com/package/react-native-windows/v/v0.76-stable) | [Unsupported](#unsupported) | 11/11/2024 | 11/11/2024 | 02/28/2025 | 04/30/2025 |
 | [0.75](https://www.npmjs.com/package/react-native-windows/v/v0.75-stable) | [Unsupported](#unsupported) | 8/19/2024 | 8/19/2024 | 12/31/2024 | 02/28/2025 |
-| [0.74](https://www.npmjs.com/package/react-native-windows/v/v0.74-stable) | [Unsupported](#unsupported) | 4/29/2024 | 4/29/2024 | 9/30/2024 | 11/30/2024 |
 
 <!--
 // We don't want the table to grow indefinitely, so only keep the last 5 stable (non-main) versions visible above, keep the rest here for posterity.
+| [0.74](https://www.npmjs.com/package/react-native-windows/v/v0.74-stable) | [Unsupported](#unsupported) | 4/29/2024 | 4/29/2024 | 9/30/2024 | 11/30/2024 |
 | [0.73](https://www.npmjs.com/package/react-native-windows/v/v0.73-stable) | [Unsupported](#unsupported) | 12/11/2023 | 12/11/2023 | 5/31/2024 | 7/31/2024 |
 | [0.72](https://www.npmjs.com/package/react-native-windows/v/v0.72-stable) | [Unsupported](#unsupported) | 06/23/2023 | 06/23/2023 | 01/31/2024 | 03/31/2024 |
 | [0.71](https://www.npmjs.com/package/react-native-windows/v/v0.71-stable) | [Unsupported](#unsupported) | 01/23/2023 | 01/23/2023 | 07/31/2023 | 09/30/2023 |


### PR DESCRIPTION
## Description

Update RNW 0.77 status in support page.

### Why
RNW 0.77 is no longer supported.

## Screenshots
N/A

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/1045)