### PR TITLE
Update documentation to reflect New Architecture default

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1,4 +1,5 @@
 2.x
+5x
 accessors
 ActivityIndicator
 APIs
@@ -123,4 +124,5 @@ WinGet
 WinRT
 WinUI
 WinUI3
+workstream
 Xcode

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,8 +11,6 @@ Make sure you have installed all of the [development dependencies](rnw-dependenc
 
 For information around how to set up React Native, see the [React Native Getting Started Guide](https://reactnative.dev/docs/getting-started).
 
-> **Interested in migrating to [React Native's New Architecture](https://reactnative.dev/architecture/landing-page)?** New Architecture support in React Native for Windows is now available to preview in 0.76. Note there are several key changes, so if you’d like to be an early adopter, check out the information in the [New Architecture Guide](new-architecture.md). 
-
 ## Create a new React Native project
 
 Call the following from the place where you want your project directory to live:
@@ -70,7 +68,9 @@ Lastly, initialize the React Native for Windows application with the [init-windo
 npx react-native init-windows --overwrite
 ```
 
-> **Note:** RNW templates contain a customized `metro.config.js` file, which is meant to merge cleanly into the default config provided by the standard React Native project template. If you are starting a new app, overwriting `metro.config.js` should have no impact. However, if you are adding Windows to an existing app with an already modified `metro.config.js` file, please make sure to back up and re-apply your modifications after adding RNW.
+> **Architecture Note:** The default React Native for Windows template for *new* projects targets [React Native's New Architecture](https://reactnative.dev/architecture/landing-page). For more information, including options for continuing to use the Old Architecture, see [New vs. Old Architecture](new-architecture.md). 
+
+> **Metro Note:** React Native Windows overwrites the app project's `metro.config.js` file to enable Windows support. If you are starting a new project, overwriting React Native's default `metro.config.js` should have no impact. However, if you have previously modified your `metro.config.js` file, please make sure to back up and re-apply your modifications after adding React Native Windows.
 
 ## Running a React Native Windows App
 

--- a/docs/init-windows-cli.md
+++ b/docs/init-windows-cli.md
@@ -9,37 +9,60 @@ This guide will give you more information on the `init-windows` command of the R
 
 ## `init-windows`
 
-The `init-windows` CLI command is used to initialize a new React Native for Windows project inside an existing React Native project. 
+The `init-windows` CLI command is used to (re-)initialize a new React Native for Windows project inside an existing React Native project. 
 
 ### Usage
-Initializes a new RNW project from a given template.
+Initializes a new React Native for Windows project from a given template.
   
 ```bat
 npx react-native init-windows
 ```
+
 ### Options
 
 Here are the options that `react-native init-windows` takes:
+
 | Option                | Input Type | Description                                      |
 |-----------------------|------------|--------------------------------------------------|
 | `--logging`           | boolean    | Verbose output logging                           |
-| `--template`          | string     | Specify the template to use                      |
+| `--template`          | string     | Specify the template to use (default: `cpp-app`) |
 | `--name`              | string     | The native project name. Defaults to the name property in `app.json` or `package.json` |
 | `--namespace`         | string     | The native project namespace, expressed using dots as separators, i.e. `Level1.Level2.Level3`. Defaults to the same as name |
 | `--overwrite`         | boolean    | Overwrite any existing files without prompting  |
 | `--no-telemetry`      | boolean    | Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI |
+| `--list`              |            | Shows a list with all available templates with their descriptions. |
 | `-h`, `--help`        | boolean    | Display help for command                         |
+
+### Default Options and Re-initializing Projects
+
+After running, the `init-windows` command will save the `name`, `namespace` and `template` configuration in the project's `package.json`:
+
+```json
+"react-native-windows": {
+    "init-windows": {
+      "name": "MyApp",
+      "namespace": "MyApp",
+      "template": "cpp-app"
+    }
+  }
+```
+
+If you later repeat the `init-windows` command to re-initialize a Windows project, without specifying any of those options, the command will default to any saved values. Among other things, this means you can safely re-run `init-windows` without it automatically changing your project to a different template (i.e. if your project is an Old Architecture app, `init-windows` won't force you to migrate to the New Architecture).
+
+If you *want* to change the value (say, you *do* want to migrate to a new template) just explicitly (re-)specify the option when running `init-windows`.
 
 ## Templates
 
-The following templates are available for use with `init-windows` by replacing `--template XYZ`, where `XYZ` can be:
+The following templates are available to `init-windows` and can by manually specified with the `--template` option (i.e. `--template cpp-lib`):
 
-| Template | Name |
-|:-:|:--|
-| `cpp-app` | React Native Windows Application (New Arch, WinAppSDK, C++) |
-| `cpp-lib` | React Native Windows Library (C++) |
-| `old/uwp-cpp-app` | React Native Windows Application (Old Arch, UWP, C++) |
-| `old/uwp-cs-app` | React Native Windows Application (Old Arch, UWP, C#)  |
+| Template | Name | Description |
+|:-:|:--|:--|
+| `cpp-app` | React Native Windows Application (New Arch, WinAppSDK, C++) | `[Default]` A RNW app using RN's New Architecture, built in C++ and targeting WinAppSDK |
+| `cpp-lib` | React Native Windows Library (C++) | A RNW (Turbo) Native Module supporting RN's New and Old Architectures built in C++ |
+| `old/uwp-cpp-app` | React Native Windows Application (Old Arch, UWP, C++) | `[Legacy]` A RNW app using RN's Old Architecture, built in C++ and targeting UWP |
+| `old/uwp-cs-app` | React Native Windows Application (Old Arch, UWP, C#)  | `[Legacy]` A RNW app using RN's Old Architecture, built in C# and targeting UWP |
+
+> **Architecture Note:** When initializing React Native for Windows for the first time, the `init-windows` CLI command defaults to the `cpp-app` template, which targets [React Native's New Architecture](https://reactnative.dev/architecture/landing-page). For more information, see [New vs. Old Architecture](new-architecture.md).
 
 ## Telemetry Notice
 

--- a/docs/new-architecture.md
+++ b/docs/new-architecture.md
@@ -5,101 +5,143 @@ title: New vs. Old Architecture
 
 ![Architecture](https://img.shields.io/badge/architecture-new_&_old-green)
 
-React Native's [New Architecture](https://reactnative.dev/architecture/landing-page) has become the default with [version 0.76](https://reactnative.dev/blog/2024/10/23/the-new-architecture-is-here), bringing many framework improvements including the advanced rendering system [Fabric](https://reactnative.dev/architecture/fabric-renderer). While React Native for Windows isn't quite yet ready to make the New Architecture the default, we've been hard at work and are excited to offer a sneak peek into adopting it on Windows.
+React Native's [New Architecture](https://reactnative.dev/architecture/landing-page) brings many framework improvements including the advanced [Fabric](https://reactnative.dev/architecture/fabric-renderer) rendering system. It greatly improves the speed and responsiveness of React Native apps over the previous *Legacy* or *Old Architecture* and its *Paper* renderer. The New Architecture was enabled by default for the *iOS* and *Android* platforms in [react-native@0.76.0](https://reactnative.dev/blog/2024/10/23/the-new-architecture-is-here).
 
-> **Important:** At this stage, React Native for Windows' New Architecture support comes with some important caveats, and is best suited for early adopters comfortable with a work-in-progress experience with incomplete documentation. For those willing to dive in, the New Architecture offers a glimpse into the exciting future of React Native Windows development.
+React Native for Windows also supports the New Architecture for the *Windows* platform. It was first available as an opt-in preview in [react-native-windows@0.76.0](https://devblogs.microsoft.com/react-native/2025-01-29-new-architecture-on-0-76-0-77/) and became the default for *new* app projects in `react-native-windows@0.80.0`. For more information on the differences between the architectures on Windows, see [New vs. Old Architecture Differences](#new-vs-old-architecture-differences).
 
-## From UWP to WinAppSDK
+> **Important:** Nearly all future investments to React Native (and React Native for Windows) will be toward the New Architecture, and we highly recommend that all projects migrate as soon as possible. React Native (and therefore React Native for Windows) will eventually deprecate, then delete, support for the Old Architecture.
 
-On Windows, the implementation of the (Old Architecture) Paper render used the [Universal Windows Platform](https://learn.microsoft.com/en-us/windows/uwp/). To meet the requirements of the new Fabric renderer, the Windows implementation now uses the modern [Windows App SDK](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/). This evolution allows us to utilize the upstream React Native cross-platform rendering logic while also enabling us to better implement the Windows-specific platform code.
+Unfortunately, React Native for Windows does not support simply "enabling" the New Architecture for existing projects, nor easily switching between the two architectures with a simple setting. Developers must choose their target architecture by selecting the appropriate template (New or Old) when initializing their native Windows app project. For more details, see [Choosing the React Native Architecture on Windows](#choosing-the-react-native-architecture-on-windows) below.
 
-This also means that all React Native for Windows New Architecture apps will now be Win32, WinAppSDK-based applications. This aligns with the current recommendations for Windows app development, providing React Native for Windows developers with greater access to the latest Windows' frameworks.
+Furthermore, we also acknowledge that the React Native for Windows New Architecture experience is not yet at 100% feature parity with its Old Architecture experience, nor at 100% parity with the upstream platforms. While we encourage all developers to try the New Architecture (and help us find the gaps), it remains possible to keep existing apps (and/or create new ones) on the Old Architecture for the time being.
 
-All React Native for Windows Old Architecture apps will remain UWP applications. It is still possible and supported to create and maintain apps that target the Old Architecture and UWP (see the list of ["old" templates](init-windows-cli.md#templates) still available).
+For more information on the feature parity and known issues, see [New Architecture Feature Parity](#new-architecture-feature-parity).
 
-However, understand that while there are no immediate plans to deprecate support for Old Architecture applications, almost all future investments are focused on the New Architecture, and as React Native eventually deprecates Old Architecture support, so too will React Native for Windows. We will provide clear migration guidance for apps once New Architecture support is better established. 
+For answers to common questions, see the [FAQ](#faq).
 
-> **Important:** There are no plans to support New Architecture on UWP nor Old Architecture on WinAppSDK. Previous experimental features that enabled either scenario are not officially supported.
+## New vs. Old Architecture Differences
 
-For more information about the reasoning behind the change from UWP to WinAppSDK, see the [FAQ](#faq) below.
+### Better Cross-Platform Alignment
 
-## Creating a New Architecture application
+In moving to the New Architecture, React Native consolidated several responsibilities away from the individual platforms into a shared core of cross-platform native code, particularly with the Fabric render. React Native for Windows also uses this shared code in the New Architecture.
 
-Starting a React Native Windows project with the new architecture is simple! Follow the steps outlined in our [Getting Started](getting-started.md) guide, but make sure to use a [New Architecture template](init-windows-cli.md#templates) when initializing your project with init-windows.
+This change means that React Native for Windows New Architecture applications should behave more like the other React Native platforms at runtime.
 
-For example, if you previously set up a project using the Old Architecture, you might have used a command like this:
+### Better Developer Experience
+
+React Native for Windows publishes both source packages to [NPM](https://www.npmjs.com/package/react-native-windows) and as pre-built native binary packages on [NuGet](https://www.nuget.org/packages/Microsoft.ReactNative/). While consuming the pre-built binaries was an experimental feature for the Old Architecture, it is the default supported option for all New Architecture projects.
+
+This change means reduced dev machine requirements, including drastically improved build times (up to 5x faster) and reduced disk usage (up to 75% less space needed).
+
+### From UWP to Windows App SDK
+
+On Windows, the implementation of the (Old Architecture) Paper renderer used the [Universal Windows Platform](https://learn.microsoft.com/en-us/windows/uwp/) (or UWP). To meet the requirements of the new Fabric renderer, the Windows implementation now uses the modern [Windows App SDK](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/). This evolution allowed us to utilize the upstream React Native cross-platform rendering logic while also enabling us to better implement the Windows-specific platform code.
+
+This change means that React Native for Windows New Architecture applications are now Win32, Windows App SDK applications. This aligns with the current recommendations for Windows application development, providing React Native for Windows developers with greater access to the latest Windows' frameworks. All React Native for Windows Old Architecture applications will continue to target UWP.
+
+### From UWP XAML to the Window App SDK Visual Layer
+
+On Windows, React Native host components (that is, React Native components that are directly backed by native UI) were implemented with [UWP XAML](https://learn.microsoft.com/en-us/windows/uwp/xaml-platform/xaml-overview) controls in the Old Architecture.
+
+For the New Architecture, rather than moving to [Windows App SDK's WinUI 3](https://learn.microsoft.com/en-us/windows/apps/winui/winui3/) (the direct successor to UWP XAML), we instead implemented host components using [Windows App SDK's Visual Layer](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/composition) (commonly known as "Composition" or the "Windows App SDK Scene Graph").
+
+This change makes it easier for React Native for Windows to implement expected behavior of React Native UI without having to work around how XAML behaves.
+
+## Choosing the React Native Architecture on Windows
+
+Developers choose the React Native Architecture (New or Old) for their Windows application when (re-)initializing Windows platform support for their project. This choice is determined by the `--template` argument when running the [init-windows command](init-windows-cli.md).
+
+Starting with `react-native-windows@0.80.0`, calling `init-windows` for the *first time* in an application project (as seen in the [Getting Started](getting-started.md) guide) will default to using the New Architecture template if none is specified. If you re-run `init-windows` on a project without specifying a template, the command will default to the previously used template. See [Default Options and Re-initializing Projects](init-windows-cli.md#default-options-and-re-initializing-projects) for more details.
+
+> **Note:** The choice described here only applies for your project's Windows build and is independent of the choice you make for other React Native platforms, i.e. your Android and iOS builds can target a different architecture than your Windows build.
+
+### Choosing the New Architecture for applications
+
+To (re-)initialize Windows with the New Architecture, you'll want to specify `--template cpp-app` when calling the [init-windows command](init-windows-cli.md) in your application project:
 
 ```bat
-yarn react-native init-windows --overwrite
+yarn react-native init-windows --template cpp-app
 ```
 
-To create a project with the New Architecture, use the same command but ensure you're specifying a New Architecture template, such as `cpp-app`:
+> **Note**: 
+
+### Choosing the Old Architecture for applications
+
+To (re-)initialize Windows with the Old Architecture, you'll want to specify `--template old/uwp-cpp-app`  when calling the [init-windows command](init-windows-cli.md) in your application project:
 
 ```bat
-yarn react-native init-windows --template cpp-app --overwrite
+yarn react-native init-windows --template old/uwp-cpp-app
 ```
 
-> **Note:** There are only two supported New Architecture templates available at this time: `cpp-app` and `cpp-lib`.
+> **Note:** If you want to use the old C# template, specify `old/uwp-cs-app` instead, but be sure to check out [.NET and C# Support](#net-and-c-support) in the FAQ below.
 
-## Development Status
+### Switching or migrating your application project to a different architecture
 
-### The Good Stuff
+At a high-level, switching your application project means re-initializing Windows support with the correct template.
 
-Starting with this New Architecture Preview, it is now possible to create a New Architecture application by following the steps above and using the new `cpp-app` template. Developers should expect that the vast majority of core components, APIs, and functionality in React Native (i.e. from the `react-native` package) are already available in React Native for Windows.
+> **Important:** Now's a good time to make sure you're using version control so you're able to abort the attempt and/or revert the changes.
 
-In terms of build developer experience, be sure to look out for drastically improved build speeds and reduced dev machine requirements as we default to using pre-built binaries for New Architecture projects.
+If you've made zero manual changes to the `windows` folder since you first added Windows support, this switch can be as "easy" as:
 
-### The Not-So-Good Stuff
+1. Deleting the `windows` folder in your project
+2. Re-running `init-windows` and specifying the correct template
+3. Running `run-windows` to build and launch the new native app
 
-However there are still some important gaps, especially with respect to community module support. First off, community modules that provide UI components by implementing new UI (i.e. via the Paper `IViewManager` interfaces) will not work with New Architecture apps. Those modules will need to implement new Fabric `ComponentView`s, and while technically possible, the experience is not quite ready for wide adoption.
+However, if you've made any changes to the `windows` folder (anything from changing native code to creating app icons, store assets, etc.) then you'll need to re-apply those changes.
 
-The story is better for non-UI community modules. Some purely non-UI community modules, built to target the existing Old Architecture apps, may still work "out-of-the-box" with your New Architecture apps. But due to the varied state of Windows support in community modules, you may find that even some of those non-UI modules will need updating.
+Even if you fix up your `windows` folder, the native libraries you depend on may or may not support the architecture you're switching to. This can produce build and/or runtime failures, which may require more troubleshooting on your part to successfully migrate.
 
-> **Note:** We do have a new library template, `cpp-lib`, which can be used to build non-UI community modules targeting the New Architecture. There are even accommodations within that template to continue to support Old Architecture apps simultaneously with one codebase. However, the template does not yet contain any examples for implementing custom UI for either architecture. The goal will be a single library template that supports both Old and New, UI and non-UI, with examples, but it isn't ready yet.
+## New Architecture Feature Parity
 
-### Remaining Work
+Developers should expect that the vast majority of core components, APIs, and functionality in React Native (i.e. from the `react-native` package) are already available in React Native for Windows in the New Architecture. However there are some gaps and we're not at 100% feature parity with the other platforms.
 
-Our work on React Native Windows' New Architecture follows a series of milestones designed to guide our development priorities. Currently, our focus is on enabling community modules alongside full API parity and improving accessibility features.
+### Library Support
 
-To track real-time progress and specific milestones, visit our [New Architecture for React Native for Windows Issue](https://github.com/microsoft/react-native-windows/issues/12042). This page is regularly updated with our latest development goals, roadmap items, and areas we’re actively working on. We encourage developers to check there for the latest on what’s available, what’s in progress, and what’s coming next.
+Unfortunately, the level of parity can be even lower when taking into consideration native library support, whether via local or community modules. If you're using a native library which supported Windows on the Old Architecture, and it does not provide any new native UI components, chances are the library can easily support Windows on the New Architecture, if it doesn't already.
 
-## React Native Component Parity
+However if a library exposed new native UI, then chances are the library will need to re-implement that native UI for Windows.
 
-The New Architecture introduces the most significant updates in how UI is rendered. By moving from UWP to the WinAppSDK, we gain the flexibility to implement components that weren't previously available while also reducing the parity gap for existing components.
+### Windows-Only Core Components
 
-Perhaps the most notable change is we're finally implementing React Native's [`Modal`](https://reactnative.dev/docs/modal), thereby removing the necessity of using the Windows-only[`Flyout`](https://microsoft.github.io/react-native-windows/docs/flyout-component) or [`Popup`](https://microsoft.github.io/react-native-windows/docs/popup-component) components.
+The following core components were created for and included in React Native for Windows Old Architecture and are not currently supported in the New Architecture:
 
-Below you'll find a list of components we plan to support in the New Architecture.
+- [Flyout](flyout-component-windows.md)
+- [Popup](popup-component-windows.md)
+- [Glyph](glyph-component-windows.md)
 
-### Supported Components
-
-The plan is to support all React Native core host components in React Native for Windows. Each component below links to the corresponding issue label in our GitHub repo that tracks the progress of its parity with the New Architecture:
-
-- [View](https://github.com/microsoft/react-native-windows/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Area%3A%20View%22%20%20label%3A%22Workstream%3A%20Component%20Parity%22%20label%3A%22Area%3A%20Fabric%22%20)
-- [Text](https://github.com/microsoft/react-native-windows/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Area%3A%20Text%22%20%20label%3A%22Workstream%3A%20Component%20Parity%22%20label%3A%22Area%3A%20Fabric%22%20)
-- [Image](https://github.com/microsoft/react-native-windows/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Area%3A%20Image%22%20%20label%3A%22Workstream%3A%20Component%20Parity%22%20label%3A%22Area%3A%20Fabric%22%20)
-- [TextInput](https://github.com/microsoft/react-native-windows/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Area%3A%20TextInput%22%20%20label%3A%22Workstream%3A%20Component%20Parity%22%20label%3A%22Area%3A%20Fabric%22%20)
-- [ScrollView](https://github.com/microsoft/react-native-windows/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Area%3A%20ScrollView%22%20%20label%3A%22Workstream%3A%20Component%20Parity%22%20label%3A%22Area%3A%20Fabric%22%20)
-- [Modal](https://github.com/microsoft/react-native-windows/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Area%3A%20Modal%22%20%20label%3A%22Workstream%3A%20Component%20Parity%22%20label%3A%22Area%3A%20Fabric%22&page=1)
-- [ActivityIndicator](https://github.com/microsoft/react-native-windows/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Area%3A%20ActivityIndicator%22%20%20label%3A%22Workstream%3A%20Component%20Parity%22%20label%3A%22Area%3A%20Fabric%22%20)
-- [Switch](https://github.com/microsoft/react-native-windows/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Area%3A%20Switch%22%20%20label%3A%22Workstream%3A%20Component%20Parity%22%20label%3A%22Area%3A%20Fabric%22%20)
-- [RefreshControl](https://github.com/microsoft/react-native-windows/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Area%3A%20RefreshControl%22%20%20label%3A%22Workstream%3A%20Component%20Parity%22%20label%3A%22Area%3A%20Fabric%22%20)
-
-### Unsupported Components
-
-The following components were created and included in React Native for Windows Old Architecture in order to tackle the unique compatibility problems posed by using UWP XAML. There is no plan to include built-in support for these Windows-specific components within React Native for Windows (though they may possibly be supported by future community modules).
-
-- [Flyout](https://github.com/microsoft/react-native-windows/issues/11921)
-- [Popup](https://github.com/microsoft/react-native-windows/issues/11921)
-- [Glyph](https://github.com/microsoft/react-native-windows/issues/11961)
+> **Note:** Flyout and Popup were designed to workaround the inability to properly implement the [Modal](https://reactnative.dev/docs/modal) core component in UWP XAML. Modal is now supported in the New Architecture on Windows, and developers are encouraged to migrate to it where possible.
 
 ## Send us your Feedback
 
-You're sure to encounter some bumps, challenges and rough edges with trying out the New Architecture. We've already logged many issues tracking properties and features that are on our to-do list, but if you come across significant concerns that aren't yet covered, please [open an issue](https://github.com/microsoft/react-native-windows/issues/new/choose) in the react-native-windows repo. You can also leave comments on [existing issues](https://github.com/microsoft/react-native-windows/issues) to help us prioritize what to tackle first!
+You're sure to encounter some bumps, challenges and rough edges with trying out the New Architecture. We've already logged many issues tracking properties and features that are on our to-do list, but if you come across significant concerns that aren't yet covered, please [open an issue](https://github.com/microsoft/react-native-windows/issues/new/choose) in the `react-native-windows` repo. You can also leave comments on [existing issues](https://github.com/microsoft/react-native-windows/issues) to help us prioritize what to tackle first!
 
 ## FAQ
 
-### Why the change from UWP to Windows App SDK?
+### Migrating from Old to New
+
+#### Can I keep using the Old Architecture?
+
+Yes, for now. The React Native for Windows Old Architecture templates are still available for both creating new and upgrading existing application projects.
+
+React Native for Windows won't automatically migrate Old Architecture Windows projects to use the New Architecture. Developers continuing to use the Old Architecture on Windows will eventually need to migrate manually by re-initializing their Windows native project.
+
+#### Can I still publish New Architecture applications to the Windows Store?
+
+Yes, the new `cpp-app` template uses a Windows Packaging project so you can still publish your application to the Windows Store.
+
+#### How do I migrate a library project to support the New Architecture?
+
+React Native for Windows library projects can support both New and Old Architecture applications with the latest supported template. See [Native Platform: Getting Started](native-platform-getting-started.md) for details.
+
+#### I've found something that doesn't work as expected in the New Architecture, what can I do?
+
+First, search [React Native for Windows Open Issues](https://github.com/microsoft/react-native-windows/issues) to see if the issue you're seeing has already been reported, and if has, give it a comment or up-vote, especially if it's blocking you migration.
+
+If you don't find an existing issue, please [Open a new issue](https://github.com/microsoft/react-native-windows/issues/new/choose) and let us know what you're seeing.
+
+### Migrating from UWP to Windows App SDK
+
+#### Why the change from UWP to Windows App SDK?
 
 For years, React Native for Windows has built Windows apps using the [Universal Windows Platform](https://learn.microsoft.com/en-us/windows/uwp/) and its [XAML](https://learn.microsoft.com/en-us/windows/uwp/xaml-platform/xaml-overview) technologies.
 
@@ -109,22 +151,34 @@ Furthermore, many requirements of the New Architecture, particularly the faster,
 
 Now, the current recommendation for new Windows apps is to build using the [Windows App SDK](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/). There are many benefits for Windows developers to migrate their apps off UWP and onto the Windows App SDK. Most importantly for React Native for Windows, the Windows App SDK gives us the tools to implement the New Architecture properly.
 
-### Why the change from XAML to Composition?
+#### Why the change from XAML to Composition?
 
-It is not always possible to adapt the XAML framework, let alone specific controls, to meet the API requirements and expectations of React Native. However, thanks to the Windows App SDK, we're now able to "drop down" and use the layer of UI primitives under XAML, aka Composition, or the [Windows App SDK Scene Graph](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/composition).
+It is not always possible to adapt the XAML framework, let alone specific controls, to meet the API requirements, behaviors and expectations of React Native. However, thanks to the Windows App SDK, we're now able to "drop down" and use the layer of UI primitives under XAML, the [Windows App SDK Visual Layer](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/composition) aka Composition.
 
-So now, instead of trying to implement React Native components with XAML controls (and perhaps fight their default behavior) we're now able to implement those components more directly in Composition, giving us the power to align with React Native's expectations rather than XAML's.
+So now, instead of trying to implement React Native components with fully-featured XAML controls (and perhaps fight their default behavior) we're now able to implement those components more directly in Composition, giving us the power to align with React Native's expectations rather than XAML's.
 
-### What if I still need/want XAML controls?
+#### What if I still need/want XAML controls?
 
-We understand that customers may still want to use XAML controls (whether it's any of the rich controls included with Windows App SDK's WinUI 3, or any of their own existing custom controls) within their React Native for Windows app's UI.
+We understand that customers may still want to use XAML controls (whether it's any of the rich controls included with Windows App SDK's WinUI 3, third-party libraries, or any of their own existing custom controls) within their React Native for Windows application's UI.
 
 We are actively working on enabling this, but it's not quite production ready yet. We fully expect to support that developers, especially community module developers, will be able to implement New Architecture `ComponentView`s by loading XAML controls, rather than requiring them to implement the controls "from scratch" using the base Composition APIs.
 
-### What about C# support?
+#### Will the New Architecture ever target UWP? Will the Old Architecture ever target Windows App SDK?
 
-We are actively working on adding support for C# app and module developers. The transition from UWP C# to modern .NET C# requires some more extensive project changes than was required for supporting C++.
+No. The New Architecture only targets Windows App SDK and the Old Architecture only targets UWP. Previous experimental features that enabled different scenarios are not supported.
 
-### Will the Old Architecture ever support targeting Windows App SDK?
+### .NET and C# Support
 
-No. Then plan is, Old Architecture targets UWP, New Architecture targets Windows App SDK.
+#### Does React Native for Windows support C# in the New Architecture?
+
+While Windows App SDK does support writing applications and libraries using C# and modern .NET, React Native for Windows doesn't yet. Most React Native for Windows applications and libraries, not to mention React Native for Windows itself, are written in C++ so the team prioritized C++ support first.
+
+While there are plans and some basic infrastructure set up to support C#, what exists is not nearly robust enough to support the React Native ecosystem.
+
+To see give feedback on our progress toward C# support, see [Issues tagged "Workstream: New Arch C# Support"](https://github.com/microsoft/react-native-windows/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Workstream%3A%20New%20Arch%20C%23%20Support%22).
+
+#### Can I migrate my Old Architecture C# application to New Architecture C++?
+
+Yes, in some cases. It depends on how much your application project depends upon actual C# code, either directly or indirectly. Without native C# support in the New Architecture, any functionality your project uses which is written in C# will need to be re-written (if possible) in C++ or removed / replaced. This includes any native libraries (local or community) your application uses.
+
+If you made no changes to your native Windows code (i.e. the code in your projects `windows` folder) and rely on no native libraries (local or community) that were written in C#, then there's a good chance you can simply re-initialize your project as a New Architecture project.


### PR DESCRIPTION
## Description

This PR updates the documentation to reflect the New Architecture default for new applications in 0.80, and also refreshes the documentation on the differences between the architectures for RNW.

### Why
We are switching the default for new projects in 0.80. We are also directing more folks to the "New vs. Old Architecture" page both within the docs and from outside.

Resolves #1046

## Screenshots
N/A

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/1051)