### PR TITLE
Fix version in Getting Started documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,16 +15,16 @@ For information around how to set up React Native, see the [React Native Getting
 
 Call the following from the place where you want your project directory to live:
 
-<!-- Note, make sure both `@react-native-community/cli@ABC` and `--version "XYZ"` are pointing to the correct NPM tags in the command below. -->
+<!-- Note, make sure both `@react-native-community/cli@ABC` and `--version XYZ` are pointing to the correct NPM tags in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "next" for the CLI and "nightly" for the RN version -->
-<!-- 2. For stable versions in versioned_docs use "latest" for the CLI and the semantic version, i.e. "^0.73.0" for the RN version -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `next` for the CLI and `nightly` for the RN version -->
+<!-- 2. For stable versions in versioned_docs use `latest` for the CLI and the semantic version, i.e. `^0.73.0` for the RN version -->
 
 <!-- See https://www.npmjs.com/package/@react-native-community/cli?activeTab=versions for the CLI version tags. -->
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx --yes @react-native-community/cli@next init <projectName> --version "nightly"
+npx --yes @react-native-community/cli@next init <projectName> --version nightly
 ```
 
 ### Navigate into this newly created directory
@@ -37,10 +37,10 @@ cd <projectName>
 
 ### Add React Native Windows to your project's dependencies
 
-<!-- Note, make sure "version" is pointing to the correct react-native-windows NPM tag in the command below. -->
+<!-- Note, make sure `version` is pointing to the correct react-native-windows NPM tag in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "canary" -->
-<!-- 2. For other versions in versioned_docs use the version in the format "^0.XY.0" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `canary` -->
+<!-- 2. For other versions in versioned_docs use the version in the format `^0.XY.0` -->
 
 Next you'll want to add `react-native-windows` as a dependency:
 

--- a/website/versioned_docs/version-0.75/getting-started.md
+++ b/website/versioned_docs/version-0.75/getting-started.md
@@ -14,17 +14,17 @@ For information around how to set up React Native, see the [React Native Getting
 
 Remember to call `@react-native-community/cli init` from the place you want your project directory to live.
 
-<!-- Note, make sure both `@react-native-community/cli@ABC` and `--version "XYZ"` are pointing to the correct NPM tags in the command below. -->
+<!-- Note, make sure both `@react-native-community/cli@ABC` and `--version XYZ` are pointing to the correct NPM tags in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "next" for the CLI and "nightly" for the RN version -->
-<!-- 2. For the latest stable version in versioned_docs use "latest" for both the CLI and RN version -->
-<!-- 3. For older stable versions you'll have to look up the CLI version, but for the RN version use the stable tag name, i.e. "0.73-stable" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `next` for the CLI and `nightly` for the RN version -->
+<!-- 2. For the latest stable version in versioned_docs use `latest` for both the CLI and RN version -->
+<!-- 3. For older stable versions you'll have to look up the CLI version, but for the RN version use the stable tag name, i.e. `0.73-stable` -->
 
 <!-- See https://www.npmjs.com/package/@react-native-community/cli?activeTab=versions for the CLI version tags. -->
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx --yes @react-native-community/cli@latest init <projectName> --version "0.75-stable"
+npx --yes @react-native-community/cli@latest init <projectName> --version 0.75-stable
 ```
 
 ### Navigate into this newly created directory
@@ -37,10 +37,10 @@ cd <projectName>
 
 ### Add React Native Windows to your project's dependencies
 
-<!-- Note, make sure "version" is pointing to the correct react-native-windows NPM tag in the command below. -->
+<!-- Note, make sure `version` is pointing to the correct react-native-windows NPM tag in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "canary" -->
-<!-- 2. For other versions in versioned_docs use the version in the format "^0.XY.0" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `canary` -->
+<!-- 2. For other versions in versioned_docs use the version in the format `^0.XY.0` -->
 
 <!--DOCUSAURUS_CODE_TABS-->
 

--- a/website/versioned_docs/version-0.76/getting-started.md
+++ b/website/versioned_docs/version-0.76/getting-started.md
@@ -16,17 +16,17 @@ For information around how to set up React Native, see the [React Native Getting
 
 Remember to call `@react-native-community/cli init` from the place you want your project directory to live.
 
-<!-- Note, make sure both `@react-native-community/cli@ABC` and `--version "XYZ"` are pointing to the correct NPM tags in the command below. -->
+<!-- Note, make sure both `@react-native-community/cli@ABC` and `--version XYZ` are pointing to the correct NPM tags in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "next" for the CLI and "nightly" for the RN version -->
-<!-- 2. For the latest stable version in versioned_docs use "latest" for both the CLI and RN version -->
-<!-- 3. For older stable versions you'll have to look up the CLI version, but for the RN version use the stable tag name, i.e. "0.73-stable" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `next` for the CLI and `nightly` for the RN version -->
+<!-- 2. For the latest stable version in versioned_docs use `latest` for both the CLI and RN version -->
+<!-- 3. For older stable versions you'll have to look up the CLI version, but for the RN version use the stable tag name, i.e. `0.73-stable` -->
 
 <!-- See https://www.npmjs.com/package/@react-native-community/cli?activeTab=versions for the CLI version tags. -->
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx --yes @react-native-community/cli@latest init <projectName> --version "0.76-stable"
+npx --yes @react-native-community/cli@latest init <projectName> --version 0.76-stable
 ```
 
 ### Navigate into this newly created directory
@@ -39,10 +39,10 @@ cd <projectName>
 
 ### Add React Native Windows to your project's dependencies
 
-<!-- Note, make sure "version" is pointing to the correct react-native-windows NPM tag in the command below. -->
+<!-- Note, make sure `version` is pointing to the correct react-native-windows NPM tag in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "canary" -->
-<!-- 2. For other versions in versioned_docs use the version in the format "^0.XY.0" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `canary` -->
+<!-- 2. For other versions in versioned_docs use the version in the format `^0.XY.0` -->
 
 <!--DOCUSAURUS_CODE_TABS-->
 

--- a/website/versioned_docs/version-0.77/getting-started.md
+++ b/website/versioned_docs/version-0.77/getting-started.md
@@ -16,17 +16,17 @@ For information around how to set up React Native, see the [React Native Getting
 
 Remember to call `@react-native-community/cli init` from the place you want your project directory to live.
 
-<!-- Note, make sure both `@react-native-community/cli@ABC` and `--version "XYZ"` are pointing to the correct NPM tags in the command below. -->
+<!-- Note, make sure both `@react-native-community/cli@ABC` and `--version XYZ` are pointing to the correct NPM tags in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "next" for the CLI and "nightly" for the RN version -->
-<!-- 2. For the latest stable version in versioned_docs use "latest" for both the CLI and RN version -->
-<!-- 3. For older stable versions you'll have to look up the CLI version, but for the RN version use the stable tag name, i.e. "0.73-stable" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `next` for the CLI and `nightly` for the RN version -->
+<!-- 2. For the latest stable version in versioned_docs use `latest` for both the CLI and RN version -->
+<!-- 3. For older stable versions you'll have to look up the CLI version, but for the RN version use the stable tag name, i.e. `0.73-stable` -->
 
 <!-- See https://www.npmjs.com/package/@react-native-community/cli?activeTab=versions for the CLI version tags. -->
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx --yes @react-native-community/cli@next init <projectName> --version "^0.77.0"
+npx --yes @react-native-community/cli@latest init <projectName> --version ^0.77.0
 ```
 
 ### Navigate into this newly created directory
@@ -39,10 +39,10 @@ cd <projectName>
 
 ### Add React Native Windows to your project's dependencies
 
-<!-- Note, make sure "version" is pointing to the correct react-native-windows NPM tag in the command below. -->
+<!-- Note, make sure `version` is pointing to the correct react-native-windows NPM tag in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "canary" -->
-<!-- 2. For other versions in versioned_docs use the version in the format "^0.XY.0" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `canary` -->
+<!-- 2. For other versions in versioned_docs use the version in the format `^0.XY.0` -->
 
 <!--DOCUSAURUS_CODE_TABS-->
 

--- a/website/versioned_docs/version-0.78/getting-started.md
+++ b/website/versioned_docs/version-0.78/getting-started.md
@@ -16,11 +16,11 @@ For information around how to set up React Native, see the [React Native Getting
 
 Remember to call `@react-native-community/cli init` from the place you want your project directory to live.
 
-<!-- Note, make sure both `@react-native-community/cli@ABC` and `--version "XYZ"` are pointing to the correct NPM tags in the command below. -->
+<!-- Note, make sure both `@react-native-community/cli@ABC` and `--version XYZ` are pointing to the correct NPM tags in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "next" for the CLI and "nightly" for the RN version -->
-<!-- 2. For the latest stable version in versioned_docs use "^0.xx.0" for both the CLI and RN version -->
-<!-- 3. For older stable versions you'll have to look up the CLI version, but for the RN version use the stable tag name, i.e. "0.73-stable" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `next` for the CLI and `nightly` for the RN version -->
+<!-- 2. For the latest stable version in versioned_docs use `^0.xx.0` for both the CLI and RN version --> -->
+<!-- 3. For older stable versions you'll have to look up the CLI version, but for the RN version use the stable tag name, i.e. `0.73-stable` -->
 
 <!-- See https://www.npmjs.com/package/@react-native-community/cli?activeTab=versions for the CLI version tags. -->
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
@@ -39,10 +39,10 @@ cd <projectName>
 
 ### Add React Native Windows to your project's dependencies
 
-<!-- Note, make sure "version" is pointing to the correct react-native-windows NPM tag in the command below. -->
+<!-- Note, make sure `version` is pointing to the correct react-native-windows NPM tag in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "canary" -->
-<!-- 2. For other versions in versioned_docs use the version in the format "^0.XY.0" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `canary` -->
+<!-- 2. For other versions in versioned_docs use the version in the format `^0.XY.0` -->
 
 <!--DOCUSAURUS_CODE_TABS-->
 

--- a/website/versioned_docs/version-0.79/getting-started.md
+++ b/website/versioned_docs/version-0.79/getting-started.md
@@ -18,16 +18,16 @@ For information around how to set up React Native, see the [React Native Getting
 
 Call the following from the place where you want your project directory to live:
 
-<!-- Note, make sure both `@react-native-community/cli@ABC` and `--version "XYZ"` are pointing to the correct NPM tags in the command below. -->
+<!-- Note, make sure both `@react-native-community/cli@ABC` and `--version XYZ` are pointing to the correct NPM tags in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "next" for the CLI and "nightly" for the RN version -->
-<!-- 2. For stable versions in versioned_docs use "latest" for the CLI and the semantic version, i.e. "^0.73.0" for the RN version -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `next` for the CLI and `nightly` for the RN version -->
+<!-- 2. For stable versions in versioned_docs use `latest` for the CLI and the semantic version, i.e. `^0.73.0` for the RN version -->
 
 <!-- See https://www.npmjs.com/package/@react-native-community/cli?activeTab=versions for the CLI version tags. -->
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx --yes @react-native-community/cli@latest init <projectName> --version "^0.79.0"
+npx --yes @react-native-community/cli@latest init <projectName> --version ^0.79.0
 ```
 
 ### Navigate into this newly created directory
@@ -40,10 +40,10 @@ cd <projectName>
 
 ### Add React Native Windows to your project's dependencies
 
-<!-- Note, make sure "version" is pointing to the correct react-native-windows NPM tag in the command below. -->
+<!-- Note, make sure `version` is pointing to the correct react-native-windows NPM tag in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "canary" -->
-<!-- 2. For other versions in versioned_docs use the version in the format "^0.XY.0" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `canary` -->
+<!-- 2. For other versions in versioned_docs use the version in the format `^0.XY.0` -->
 
 Next you'll want to add `react-native-windows` as a dependency:
 


### PR DESCRIPTION
## Description

Running the first command in React Native Windows' [Getting Started][1] documentation

    npx --yes @react-native-community/cli@latest init <projectName> --version "^0.79.0"

fails with

> error Cannot read properties of null (reading 'major').

[Upstream react-native-community/cli docs][2] refer to these versions without quoting them.

Dropping the quotes fixes this issue.

### Why

Documentation is incorrect, misleading and discouraging.

Resolves microsoft/react-native-windows#15081.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/1087)

## Screenshot

<img width="942" height="308" alt="image" src="https://github.com/user-attachments/assets/527cc89d-b3c2-473c-b44b-5d902a394afe" />

[1]: https://microsoft.github.io/react-native-windows/docs/getting-started
[2]: https://github.com/react-native-community/cli/blob/main/docs/commands.md