### PR TITLE
Fix version quotes in documentation

### DIFF
--- a/docs/native-platform-getting-started.md
+++ b/docs/native-platform-getting-started.md
@@ -16,15 +16,15 @@ Before you get started, make sure you have installed all of the [development dep
 
 Call the following from the place where you want your project directory to live:
 
-<!-- Note, make sure `--react-native-version "XYZ"` are pointing to the correct NPM tags in the command below. -->
+<!-- Note, make sure `--react-native-version XYZ` are pointing to the correct NPM tags in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "nightly" for the RN version -->
-<!-- 2. For stable versions in versioned_docs use the semantic version, i.e. "^0.73.0" for the RN version -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `nightly` for the RN version -->
+<!-- 2. For stable versions in versioned_docs use the semantic version, i.e. `^0.73.0` for the RN version -->
 
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx --yes create-react-native-library@0.48.9 --react-native-version "nightly" <projectName>
+npx --yes create-react-native-library@0.48.9 --react-native-version nightly <projectName>
 ```
 
 > **Note:** Replace `<projectName>` with the name of your library. The rest of this guide will assume you named your project `testlib`.
@@ -49,10 +49,10 @@ cd <projectName>
 
 ### Add React Native for Windows to your project's node dependencies
 
-<!-- Note, make sure "version" is pointing to the correct react-native-windows NPM tag in the command below. -->
+<!-- Note, make sure `version` is pointing to the correct react-native-windows NPM tag in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "canary" -->
-<!-- 2. For other versions in versioned_docs use the version in the format "^0.XY.0" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `canary` -->
+<!-- 2. For other versions in versioned_docs use the version in the format `^0.XY.0` -->
 
 Next you'll want to add `react-native-windows` as a dependency:
 

--- a/website/versioned_docs/version-0.72/getting-started.md
+++ b/website/versioned_docs/version-0.72/getting-started.md
@@ -14,16 +14,16 @@ For information around how to set up React Native, see the [React Native Getting
 
 Remember to call `react-native init` from the place you want your project directory to live.
 
-<!-- Note, make sure "version" is pointing to the correct react-native NPM tag in the command below. -->
+<!-- Note, make sure `version` is pointing to the correct react-native NPM tag in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "nightly" -->
-<!-- 2. For the latest stable version in versioned_docs use "latest" -->
-<!-- 3. For older stable versions use the stable tag name, i.e. "0.72-stable" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `nightly` -->
+<!-- 2. For the latest stable version in versioned_docs use `latest` -->
+<!-- 3. For older stable versions use the stable tag name, i.e. `0.72-stable` -->
 
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx react-native@0.72-stable init <projectName> --version "0.72-stable"
+npx react-native@0.72-stable init <projectName> --version 0.72-stable
 ```
 
 ### Navigate into this newly created directory

--- a/website/versioned_docs/version-0.73/getting-started.md
+++ b/website/versioned_docs/version-0.73/getting-started.md
@@ -14,16 +14,16 @@ For information around how to set up React Native, see the [React Native Getting
 
 Remember to call `react-native init` from the place you want your project directory to live.
 
-<!-- Note, make sure "version" is pointing to the correct react-native NPM tag in the command below. -->
+<!-- Note, make sure `version` is pointing to the correct react-native NPM tag in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "nightly" -->
-<!-- 2. For the latest stable version in versioned_docs use "latest" -->
-<!-- 3. For older stable versions use the stable tag name, i.e. "0.73-stable" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `nightly` -->
+<!-- 2. For the latest stable version in versioned_docs use `latest` -->
+<!-- 3. For older stable versions use the stable tag name, i.e. `0.73-stable` -->
 
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx --yes react-native@0.73-stable init <projectName> --version "0.73-stable"
+npx --yes react-native@0.73-stable init <projectName> --version 0.73-stable
 ```
 
 ### Navigate into this newly created directory

--- a/website/versioned_docs/version-0.74/getting-started.md
+++ b/website/versioned_docs/version-0.74/getting-started.md
@@ -14,17 +14,17 @@ For information around how to set up React Native, see the [React Native Getting
 
 Remember to call `@react-native-community/cli init` from the place you want your project directory to live.
 
-<!-- Note, make sure both `@react-native-community/cli@ABC` and `--version "XYZ"` are pointing to the correct NPM tags in the command below. -->
+<!-- Note, make sure both `@react-native-community/cli@ABC` and `--version XYZ` are pointing to the correct NPM tags in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "next" for the CLI and "nightly" for the RN version -->
-<!-- 2. For the latest stable version in versioned_docs use "latest" for both the CLI and RN version -->
-<!-- 3. For older stable versions you'll have to look up the CLI version, but for the RN version use the stable tag name, i.e. "0.73-stable" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `next` for the CLI and `nightly` for the RN version -->
+<!-- 2. For the latest stable version in versioned_docs use `latest` for both the CLI and RN version -->
+<!-- 3. For older stable versions you'll have to look up the CLI version, but for the RN version use the stable tag name, i.e. `0.73-stable` -->
 
 <!-- See https://www.npmjs.com/package/@react-native-community/cli?activeTab=versions for the CLI version tags. -->
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx --yes @react-native-community/cli@latest init <projectName> --version "0.74-stable"
+npx --yes @react-native-community/cli@latest init <projectName> --version 0.74-stable
 ```
 
 ### Navigate into this newly created directory

--- a/website/versioned_docs/version-0.79/native-platform-getting-started.md
+++ b/website/versioned_docs/version-0.79/native-platform-getting-started.md
@@ -17,15 +17,15 @@ Before you get started, make sure you have installed all of the [development dep
 
 Call the following from the place where you want your project directory to live:
 
-<!-- Note, make sure `--react-native-version "XYZ"` are pointing to the correct NPM tags in the command below. -->
+<!-- Note, make sure `--react-native-version XYZ` are pointing to the correct NPM tags in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "nightly" for the RN version -->
-<!-- 2. For stable versions in versioned_docs use the semantic version, i.e. "^0.73.0" for the RN version -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `nightly` for the RN version -->
+<!-- 2. For stable versions in versioned_docs use the semantic version, i.e. `^0.73.0` for the RN version -->
 
 <!-- See https://www.npmjs.com/package/react-native?activeTab=versions for the RN version tags. -->
 
 ```bat
-npx --yes create-react-native-library@0.48.9 --react-native-version "^0.79.0" <projectName>
+npx --yes create-react-native-library@0.48.9 --react-native-version ^0.79.0 <projectName>
 ```
 
 > **Note:** Replace `<projectName>` with the name of your library. The rest of this guide will assume you named your project `testlib`.
@@ -50,10 +50,10 @@ cd <projectName>
 
 ### Add React Native for Windows to your project's node dependencies
 
-<!-- Note, make sure "version" is pointing to the correct react-native-windows NPM tag in the command below. -->
+<!-- Note, make sure `version` is pointing to the correct react-native-windows NPM tag in the command below. -->
 
-<!-- 1. For the next version (i.e. in docs/getting-started.md) use "canary" -->
-<!-- 2. For other versions in versioned_docs use the version in the format "^0.XY.0" -->
+<!-- 1. For the next version (i.e. in docs/getting-started.md) use `canary` -->
+<!-- 2. For other versions in versioned_docs use the version in the format `^0.XY.0` -->
 
 Next you'll want to add `react-native-windows` as a dependency:
 


### PR DESCRIPTION
Commit 14c9769135 fixed the _Getting Started_ page by dropping quotes around version strings as it meddles with some scripts creating the project from a template.  This fixes the public documentation under The Basics (Windows) -> Get Started with Windows.

However, Native Development (Windows) -> Getting Started is another public document illustrating how to create an RN library.  This was missed out by the above commit.

Resolves https://github.com/microsoft/react-native-windows/issues/15181.

# Screenshots

<img width="1085" height="459" alt="image" src="https://github.com/user-attachments/assets/66640cd8-3bad-4121-bd86-9f40a44f14f3" />
