### PR TITLE
docs: update CI Node.js version

### DIFF
--- a/docs/setup-ci.md
+++ b/docs/setup-ci.md
@@ -33,7 +33,7 @@ Next you need to create a YAML file for GitHub Actions, the basic steps are:
           - name: Setup Node.js
             uses: actions/setup-node@v1
             with:
-              node-version: '^18'
+              node-version: '22.22.0'
 
           - name: Setup MSBuild
             uses: microsoft/setup-msbuild@v2


### PR DESCRIPTION
## Summary

Updates the GitHub Actions setup example to use Node.js `22.22.0`, matching the current React Native Windows dependency script guidance.

Fixes #861.

## Validation

- Documentation-only change; no tests run.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/1253)