### PR TITLE
Fix cpp-lib example: dedupe react-native-windows in Metro config

### DIFF
--- a/samples/NativeModuleSample/cpp-lib/example/metro.config.js
+++ b/samples/NativeModuleSample/cpp-lib/example/metro.config.js
@@ -27,18 +27,23 @@ const config = {
   // We need to make sure that only one version is loaded for peerDependencies
   // So we block them at the root, and alias them to the versions in example's node_modules
   resolver: {
-    blacklistRE: 
-      modules.map(
-        (m) =>
-          new RegExp(`^${escape(path.join(root, 'node_modules', m))}\\/.*$`)
-      ).concat([
+    blockList:
+      modules.map((m) => {
+        // Normalize separators so the pattern matches metro's forward-slash
+        // normalized module paths on Windows (path.join yields backslashes).
+        const escaped = escape(path.join(root, 'node_modules', m)).replace(
+          /\\\\/g,
+          '[\\\\/]'
+        );
+        return new RegExp(`^${escaped}[\\\\/].*$`);
+      }).concat([
         // This stops "npx @react-native-community/cli run-windows" from causing the metro server to crash if its already running
         new RegExp(
           `${path.resolve(__dirname, 'windows').replace(/[/\\]/g, '/')}.*`,
         ),
         // This prevents "npx @react-native-community/cli run-windows" from hitting: EBUSY: resource busy or locked, open msbuild.ProjectImports.zip or other files produced by msbuild
-        new RegExp(`${rnwPath}/build/.*`),
-        new RegExp(`${rnwPath}/target/.*`),
+        new RegExp(`${rnwPath.replace(/\\/g, '/')}/build/.*`),
+        new RegExp(`${rnwPath.replace(/\\/g, '/')}/target/.*`),
         /.*\.ProjectImports\.zip/,
       ])
     ,
@@ -51,6 +56,44 @@ const config = {
       //
     }
     ),
+
+    // On the windows platform, redirect 'react-native' (and its deep imports)
+    // to 'react-native-windows' so a single renderer / view-config registry
+    // instance is used. Without this, custom native components (e.g. those
+    // created via codegenNativeComponent) can be registered against one module
+    // instance and looked up from another, causing "View config getter callback
+    // for component `X` must be a function (received `undefined`)" at runtime.
+    resolveRequest: (context, moduleName, platform) => {
+      if (platform === 'windows') {
+        if (moduleName === 'react-native') {
+          return context.resolveRequest(
+            { ...context, resolveRequest: undefined },
+            'react-native-windows',
+            platform
+          );
+        }
+        if (moduleName.startsWith('react-native/')) {
+          const redirected = moduleName.replace(
+            'react-native/',
+            'react-native-windows/'
+          );
+          try {
+            return context.resolveRequest(
+              { ...context, resolveRequest: undefined },
+              redirected,
+              platform
+            );
+          } catch (e) {
+            // fall through to default resolution below
+          }
+        }
+      }
+      return context.resolveRequest(
+        { ...context, resolveRequest: undefined },
+        moduleName,
+        platform
+      );
+    },
   },
 
   transformer: {


### PR DESCRIPTION
## Problem
The `NativeModuleSample/cpp-lib` example renders a **blank screen** at runtime. The
red box (with JS debugging / dev bundle) reveals:

> Render Error: View config getter callback for component `CircleMask` must be a
> function (received `undefined`).

This matches open issue microsoft/react-native-windows#15519 and reproduces on both 0.84 and 0.85.

## Root cause
The example's `metro.config.js` loads **two copies of `react-native-windows`** — one
from the library root's `node_modules` and one from `example/node_modules`. Each copy
has its own `ReactNativeViewConfigRegistry`. `codegenNativeComponent('CircleMask')`
registers the view config into one instance, while the renderer looks it up in the
other → `undefined` → React throws → the whole tree unmounts (blank window).

The existing dedupe logic was a no-op because it:
1. Used the **deprecated `blacklistRE`** key (Metro 0.84 / RN 0.85 uses `blockList`).
2. Built patterns with **Windows backslashes**, which never match Metro's
   forward-slash-normalized module paths.

## Fix
- Rename `blacklistRE` → `blockList` and normalize path separators so the root
  `node_modules` duplicate of `react-native-windows` is actually blocked.
- Add a `resolveRequest` hook redirecting `react-native` (and deep imports) to
  `react-native-windows` on the `windows` platform, ensuring a single renderer /
  view-config registry instance.

## Verification
- Dev bundle now contains a **single** `ReactNativeViewConfigRegistry`
  (bundle size **10.1 MB → 5.09 MB**).
- The example renders fully: all TurboModule outputs, both buttons, and the
  `CircleMask` native component (teal circle).

 After fix - cpp-lib example rendering (CircleMask native component visible)
<img width="500" height="673" alt="cpp-lib-pr-final" src="https://github.com/user-attachments/assets/100d1950-3ae8-4cb9-a13a-590705e8a7c3" />


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/1291)