### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,12 @@ updates:
   commit-message:
     prefix: 📦
   open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  groups:
+    github-actions:
+      patterns: ["*"]
+  schedule:
+    interval: "weekly"
+  cooldown:
+    default-days: 7

--- a/.github/workflows/ci-upgrade.yml
+++ b/.github/workflows/ci-upgrade.yml
@@ -14,7 +14,7 @@ jobs:
     name: Setup Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
   call-upgradesample-calculator:
     name: Upgrade Calculator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Setup Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
   call-buildsample-calculator:
     name: Build Calculator

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,12 +21,12 @@ jobs:
       website: ${{ steps.filter.outputs.website }}
       workflows: ${{ steps.filter.outputs.workflows }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
     # This task is to calculate which projects/paths had file changes
     # Project builds can be skipped in PR if no files changed
     # Changes to the "workflow" files should make projects build
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
       id: filter
       with:
         filters: |
@@ -91,4 +91,4 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setupcheck, call-buildsample-calculator, call-buildsample-native-module-sample, call-buildwebsite]
     steps:
-     - uses: actions/checkout@v3
+     - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0

--- a/.github/workflows/template-buildsample.yml
+++ b/.github/workflows/template-buildsample.yml
@@ -44,7 +44,7 @@ jobs:
     name: "Check if build is required: ${{ !inputs.skipBuild }}"
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
   build-sample:
     name: Build ${{ inputs.sampleName }} ${{ inputs.configuration }} ${{ inputs.platform }}
@@ -52,10 +52,10 @@ jobs:
     if: ${{ !inputs.skipBuild }}
     runs-on: ${{ inputs.vmImage }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22.14.0'
 

--- a/.github/workflows/template-buildwebsite.yml
+++ b/.github/workflows/template-buildwebsite.yml
@@ -21,7 +21,7 @@ jobs:
     name: "Check if build is required: ${{ !inputs.skipBuild }}"
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
   build_website:
     name: Build Website
@@ -29,7 +29,7 @@ jobs:
     if: ${{ !inputs.skipBuild }}
     runs-on: ${{ inputs.vmImage }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
     - name: Spell-check docs
       run: npx markdown-spellcheck "docs/*.md" "!docs/*-api-windows.md" --en-us --ignore-acronyms --ignore-numbers --report --color

--- a/.github/workflows/template-upgradesample.yml
+++ b/.github/workflows/template-upgradesample.yml
@@ -55,7 +55,7 @@ jobs:
     name: "Check if upgrade is required: ${{ !inputs.skipUpgrade }}"
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
   upgrade-sample:
     name: Upgrade ${{ inputs.sampleName }} ${{ inputs.configuration }} ${{ inputs.platform }} to ${{ inputs.reactNativeWindowsVersion }}
@@ -63,10 +63,10 @@ jobs:
     if: ${{ !inputs.skipUpgrade }}
     runs-on: ${{ inputs.vmImage }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22.14.0'
 

--- a/.github/workflows/website-publish.yml
+++ b/.github/workflows/website-publish.yml
@@ -21,7 +21,7 @@ jobs:
         git config --global user.name "React-Native-Windows Bot"
         echo "machine github.com login 53619745+rnbot password ${{ secrets.RNBOT_GH_TOKEN }}" > ~/.netrc
     - name: Git Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: Yarn Install (Website)
       run: yarn install --frozen-lockfile
       working-directory: ./website


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). This groups Dependabot PRs for GitHub Actions and enforces a minimum 7-day cooldown between updates. If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows-samples/pull/1304)